### PR TITLE
fix bottom nav overlapping Android system navigation bar

### DIFF
--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/navigation/BottomNavBar.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/navigation/BottomNavBar.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -124,6 +125,7 @@ fun FudAIBottomNavBar(
     Box(
         modifier = modifier
             .fillMaxWidth()
+            .navigationBarsPadding()
             .padding(horizontal = 14.dp, vertical = 10.dp)
     ) {
         BoxWithConstraints(


### PR DESCRIPTION
## Problem

Closes #28

The app calls `enableEdgeToEdge()` in `MainActivity`, which makes the app draw behind the Android system bars. However, the custom `FudAIBottomNavBar` had no inset handling, so the floating bar rendered partially behind the system navigation bar on devices using gesture or 3-button navigation.

## Fix

Added `navigationBarsPadding()` to the outer `Box` modifier in `FudAIBottomNavBar`:

```kotlin
Box(
    modifier = modifier
        .fillMaxWidth()
        .navigationBarsPadding()   // ← added
        .padding(horizontal = 14.dp, vertical = 10.dp)
)
```

`navigationBarsPadding()` adds bottom padding equal to the system navigation bar height, so the floating pill sits above it. Because `Scaffold` measures the `bottomBar` height to derive the content's bottom padding, the extra height is automatically propagated — screen content is never obscured either.

## Testing

- Gesture navigation (no visible nav bar) - bar position unchanged 
- 3-button navigation - bar floats above the buttons   
- 2-button navigation - bar floats above the handles   