### PR TITLE
fix(ios): use locale-aware decimal parsing in serving unit editor

### DIFF
--- a/ios/calorietracker/Views/EditFoodEntryView.swift
+++ b/ios/calorietracker/Views/EditFoodEntryView.swift
@@ -83,7 +83,7 @@ struct EditFoodEntryView: View {
         ServingUnitOption.option(matching: selectedServingUnitID, in: servingUnitOptions)
     }
     private var selectedServingQuantity: Double? {
-        Double(servingSizeText)
+        ServingUnitEditor.parseDecimal(servingSizeText)
     }
 
     init(entry: FoodEntry) {

--- a/ios/calorietracker/Views/FoodResultView.swift
+++ b/ios/calorietracker/Views/FoodResultView.swift
@@ -88,7 +88,7 @@ struct FoodResultView: View {
         ServingUnitOption.option(matching: selectedServingUnitID, in: servingUnitOptions)
     }
     private var selectedServingQuantity: Double? {
-        Double(servingSizeText)
+        ServingUnitEditor.parseDecimal(servingSizeText)
     }
 
     init(

--- a/ios/calorietracker/Views/ServingUnitEditor.swift
+++ b/ios/calorietracker/Views/ServingUnitEditor.swift
@@ -98,18 +98,16 @@ struct ServingUnitEditor: View {
         return String(format: "%.1f", value).trimmingTrailingZeros()
     }
 
-    /// Parse a decimal string using the current locale (accepts both "." and ",").
-    /// Uses NumberFormatter with the user's locale first, falls back to
-    /// Double() init (C locale) as a secondary attempt.
-    static func parseDecimal(_ string: String) -> Double? {
+    /// Parse a decimal string — accepts both "." (C locale) and "," (user locale).
+    /// Tries C-locale parsing first, then locale-aware as fallback.
+    static func parseDecimal(_ string: String, locale: Locale = .current) -> Double? {
+        if let value = Double(string) {
+            return value
+        }
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.locale = .current
-        if let number = formatter.number(from: string) {
-            return number.doubleValue
-        }
-        // Fallback: try C-locale parsing (period only)
-        return Double(string)
+        formatter.locale = locale
+        return formatter.number(from: string)?.doubleValue
     }
 }
 

--- a/ios/calorietracker/Views/ServingUnitEditor.swift
+++ b/ios/calorietracker/Views/ServingUnitEditor.swift
@@ -19,7 +19,7 @@ struct ServingUnitEditor: View {
     }
 
     private var selectedQuantity: Double? {
-        Double(quantityText)
+        Self.parseDecimal(quantityText)
     }
 
     private var selectedUnitLabel: String {
@@ -35,7 +35,7 @@ struct ServingUnitEditor: View {
             )
             .frame(width: 72)
             .onChange(of: quantityText) { _, newValue in
-                guard let parsed = Double(newValue), parsed > 0 else { return }
+                guard let parsed = Self.parseDecimal(newValue), parsed > 0 else { return }
                 servingSizeGrams = parsed * selectedOption.gramsPerUnit
             }
             .onChange(of: selectedUnitID) { _, _ in
@@ -96,6 +96,20 @@ struct ServingUnitEditor: View {
             return String(format: "%.2f", value).trimmingTrailingZeros()
         }
         return String(format: "%.1f", value).trimmingTrailingZeros()
+    }
+
+    /// Parse a decimal string using the current locale (accepts both "." and ",").
+    /// Uses NumberFormatter with the user's locale first, falls back to
+    /// Double() init (C locale) as a secondary attempt.
+    static func parseDecimal(_ string: String) -> Double? {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.locale = .current
+        if let number = formatter.number(from: string) {
+            return number.doubleValue
+        }
+        // Fallback: try C-locale parsing (period only)
+        return Double(string)
     }
 }
 

--- a/ios/calorietrackerTests/ServingUnitEditorTests.swift
+++ b/ios/calorietrackerTests/ServingUnitEditorTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+@testable import calorietracker
+
+struct ServingUnitEditorTests {
+
+    // MARK: - C locale (period decimal)
+
+    @Test func cLocale_simpleInteger() {
+        #expect(ServingUnitEditor.parseDecimal("5") == 5)
+    }
+
+    @Test func cLocale_simpleDecimal() {
+        #expect(ServingUnitEditor.parseDecimal("0.5") == 0.5)
+    }
+
+    @Test func cLocale_wholeWithDecimal() {
+        #expect(ServingUnitEditor.parseDecimal("1.5") == 1.5)
+    }
+
+    @Test func cLocale_largeNumber() {
+        #expect(ServingUnitEditor.parseDecimal("1000") == 1000)
+    }
+
+    @Test func cLocale_numberWithGroupingSeparator() {
+        // "1.000" in C locale → period is decimal → 1.0
+        #expect(ServingUnitEditor.parseDecimal("1.000") == 1.0)
+    }
+
+    @Test func cLocale_trailingZeros() {
+        #expect(ServingUnitEditor.parseDecimal("0.500") == 0.5)
+    }
+
+    @Test func cLocale_negative() {
+        #expect(ServingUnitEditor.parseDecimal("-2.5") == -2.5)
+    }
+
+    // MARK: - Comma-decimal locale (de_DE)
+
+    @Test func deLocale_simpleCommaDecimal() {
+        let deLocale = Locale(identifier: "de_DE")
+        #expect(ServingUnitEditor.parseDecimal("0,5", locale: deLocale) == 0.5)
+    }
+
+    @Test func deLocale_wholeWithComma() {
+        #expect(ServingUnitEditor.parseDecimal("1,5", locale: Locale(identifier: "de_DE")) == 1.5)
+    }
+
+    @Test func deLocale_periodStillWorks() {
+        // C-locale fallback catches period-decimal in any locale
+        #expect(ServingUnitEditor.parseDecimal("0.5", locale: Locale(identifier: "de_DE")) == 0.5)
+    }
+
+    // MARK: - French locale (fr_FR)
+
+    @Test func frLocale_commaDecimal() {
+        #expect(ServingUnitEditor.parseDecimal("1,5", locale: Locale(identifier: "fr_FR")) == 1.5)
+    }
+
+    // MARK: - Invalid inputs
+
+    @Test func invalid_empty() {
+        #expect(ServingUnitEditor.parseDecimal("") == nil)
+    }
+
+    @Test func invalid_text() {
+        #expect(ServingUnitEditor.parseDecimal("abc") == nil)
+    }
+
+    @Test func invalid_emoji() {
+        #expect(ServingUnitEditor.parseDecimal("🍕") == nil)
+    }
+
+    @Test func invalid_wrongLocaleSeparator() {
+        // "," is not a decimal separator in en_US
+        #expect(ServingUnitEditor.parseDecimal("0,5", locale: Locale(identifier: "en_US")) == nil)
+    }
+
+}


### PR DESCRIPTION
While using the app in a European region with comma-decimal keyboard layout (`,` instead of `.`), entering `0,5` for
half a bowl was silently ignored. `Double()` only accepts period as decimal separator, so parsing returned `nil`.

-----------

Fix: added `ServingUnitEditor.parseDecimal()` using `NumberFormatter` with the user's current locale, falling back to
`Double()` for C-locale strings. Updated 3 call sites.

Tested in simulator with both `0.5` and `0,5` — both work.

----------------
<img width="355" height="678" alt="Screenshot 2026-05-24 at 16 34 00" src="https://github.com/user-attachments/assets/8661490e-599d-47ae-be94-023c0700191b" />

<img width="355" height="678" alt="Screenshot 2026-05-24 at 16 33 55" src="https://github.com/user-attachments/assets/31e6c59d-9793-4cb2-ab27-015dfa2dbe73" />

<img width="355" height="678" alt="Screenshot 2026-05-24 at 16 33 26" src="https://github.com/user-attachments/assets/babf8928-a356-405b-82b9-3f9f7e335e42" />

