### PR TITLE
Show a clear invalid-API-key message for the AI coach on HTTP 400

### DIFF
--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/AiError.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/AiError.kt
@@ -9,9 +9,19 @@ sealed class AiError(message: String) : Exception(message) {
     class InvalidUrl(val url: String) : AiError("Invalid API URL. Check your provider settings.")
 }
 
-internal fun friendlyMessage(status: Int, raw: String): String = when (status) {
-    503, 529 -> "The AI provider is overloaded right now. We retried a few times — please try again in a minute, or switch to a different provider/model in Settings → AI Provider."
-    429 -> "Rate limit hit on your API key. Wait a minute, or switch to another provider in Settings → AI Provider."
-    401, 403 -> "Your API key was rejected. Open Settings → AI Provider and re-paste a valid key."
-    else -> raw
+internal fun friendlyMessage(status: Int, raw: String): String {
+    val keyRejected = "Your API key was rejected. Open Settings → AI Provider and re-paste a valid key."
+    val hasKeyInvalidMarker =
+        raw.contains("api key not valid", ignoreCase = true) ||
+            raw.contains("api_key_invalid", ignoreCase = true) ||
+            raw.contains("api key expired", ignoreCase = true) ||
+            raw.contains("api_key_expired", ignoreCase = true)
+
+    return when (status) {
+        503, 529 -> "The AI provider is overloaded right now. We retried a few times — please try again in a minute, or switch to a different provider/model in Settings → AI Provider."
+        429 -> "Rate limit hit on your API key. Wait a minute, or switch to another provider in Settings → AI Provider."
+        400 -> if (hasKeyInvalidMarker) keyRejected else raw
+        401, 403 -> keyRejected
+        else -> raw
+    }
 }

--- a/android/app/src/test/java/com/apoorvdarshan/calorietracker/services/ai/AiErrorTest.kt
+++ b/android/app/src/test/java/com/apoorvdarshan/calorietracker/services/ai/AiErrorTest.kt
@@ -1,0 +1,59 @@
+package com.apoorvdarshan.calorietracker.services.ai
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AiErrorTest {
+    private val keyRejected = "Your API key was rejected. Open Settings → AI Provider and re-paste a valid key."
+
+    @Test
+    fun badApiKeyOn400ReturnsKeyRejectedGuidance() {
+        assertEquals(
+            keyRejected,
+            friendlyMessage(400, "API key not valid. Please pass a valid API key.")
+        )
+    }
+
+    @Test
+    fun keyInvalidMarkersOn400AreCaseInsensitive() {
+        assertEquals(keyRejected, friendlyMessage(400, "api KEY not VALID. Please pass a valid API key."))
+        assertEquals(keyRejected, friendlyMessage(400, "reason: API_KEY_INVALID"))
+        assertEquals(keyRejected, friendlyMessage(400, "API key expired"))
+        assertEquals(keyRejected, friendlyMessage(400, "reason: API_KEY_EXPIRED"))
+    }
+
+    @Test
+    fun unauthorizedAndForbiddenReturnKeyRejectedGuidance() {
+        assertEquals(keyRejected, friendlyMessage(401, "Unauthorized"))
+        assertEquals(keyRejected, friendlyMessage(403, "Forbidden"))
+    }
+
+    @Test
+    fun rateLimitReturnsRateLimitMessage() {
+        assertEquals(
+            "Rate limit hit on your API key. Wait a minute, or switch to another provider in Settings → AI Provider.",
+            friendlyMessage(429, "Too many requests")
+        )
+    }
+
+    @Test
+    fun overloadedStatusesReturnOverloadedMessage() {
+        val overloaded = "The AI provider is overloaded right now. We retried a few times — please try again in a minute, or switch to a different provider/model in Settings → AI Provider."
+
+        assertEquals(overloaded, friendlyMessage(503, "Service unavailable"))
+        assertEquals(overloaded, friendlyMessage(529, "Overloaded"))
+    }
+
+    @Test
+    fun nonKeyBadRequestReturnsRawMessage() {
+        assertEquals(
+            "Invalid JSON payload received.",
+            friendlyMessage(400, "Invalid JSON payload received.")
+        )
+    }
+
+    @Test
+    fun unmappedStatusReturnsRawMessage() {
+        assertEquals("Internal error", friendlyMessage(500, "Internal error"))
+    }
+}

--- a/ios/calorietracker/Services/ChatService.swift
+++ b/ios/calorietracker/Services/ChatService.swift
@@ -564,13 +564,22 @@ struct ChatService {
     }
 
     private static func friendlyMessage(for status: Int, raw: String) -> String {
+        let keyRejected = "Your API key was rejected. Open Settings → AI Provider and re-paste a valid key."
+        // A bad/expired Gemini key comes back as HTTP 400 (INVALID_ARGUMENT), not 401/403, so
+        // match the key-invalid markers in the provider message (mirrors Android #99/#113).
+        let hasKeyInvalidMarker = raw.range(of: "api key not valid", options: .caseInsensitive) != nil
+            || raw.range(of: "api_key_invalid", options: .caseInsensitive) != nil
+            || raw.range(of: "api key expired", options: .caseInsensitive) != nil
+            || raw.range(of: "api_key_expired", options: .caseInsensitive) != nil
         switch status {
         case 503, 529:
             return "The AI provider is overloaded right now. We retried a few times — please try again in a minute, or switch to a different provider/model in Settings → AI Provider."
         case 429:
             return "Rate limit hit on your API key. Wait a minute, or switch to another provider in Settings → AI Provider."
+        case 400 where hasKeyInvalidMarker:
+            return keyRejected
         case 401, 403:
-            return "Your API key was rejected. Open Settings → AI Provider and re-paste a valid key."
+            return keyRejected
         default:
             return raw
         }

--- a/ios/calorietracker/Services/GeminiService.swift
+++ b/ios/calorietracker/Services/GeminiService.swift
@@ -919,13 +919,22 @@ struct GeminiService {
     }
 
     private static func friendlyMessage(for status: Int, raw: String) -> String {
+        let keyRejected = "Your API key was rejected. Open Settings → AI Provider and re-paste a valid key."
+        // A bad/expired Gemini key comes back as HTTP 400 (INVALID_ARGUMENT), not 401/403, so
+        // match the key-invalid markers in the provider message (mirrors Android #99/#113).
+        let hasKeyInvalidMarker = raw.range(of: "api key not valid", options: .caseInsensitive) != nil
+            || raw.range(of: "api_key_invalid", options: .caseInsensitive) != nil
+            || raw.range(of: "api key expired", options: .caseInsensitive) != nil
+            || raw.range(of: "api_key_expired", options: .caseInsensitive) != nil
         switch status {
         case 503, 529:
             return "The AI provider is overloaded right now. We retried a few times — please try again in a minute, or switch to a different provider/model in Settings → AI Provider."
         case 429:
             return "Rate limit hit on your API key. Wait a minute, or switch to another provider in Settings → AI Provider."
+        case 400 where hasKeyInvalidMarker:
+            return keyRejected
         case 401, 403:
-            return "Your API key was rejected. Open Settings → AI Provider and re-paste a valid key."
+            return keyRejected
         default:
             return raw
         }


### PR DESCRIPTION
## Why

A user reported the Coach chat "just yields network error" even with a valid-looking Gemini key configured, and rotating the key resolved it (#99). The root cause is in how the AI error path classifies HTTP status codes.

When a Gemini API key is bad or expired, the generativelanguage API does not return 401/403. It returns **HTTP 400** with `status: INVALID_ARGUMENT` and a message like `API key not valid. Please pass a valid API key.`, or a 400 whose reason is `API_KEY_INVALID` / `API_KEY_EXPIRED`. `friendlyMessage()` only mapped 401/403 to the actionable "re-paste your key" guidance, so these 400s fell through to the raw provider message and the user saw a confusing error with no hint that the key was the problem.

## What

- In `friendlyMessage(status, raw)`, a **400** whose provider message contains a key-invalid marker (`api key not valid`, `api_key_invalid`, `api key expired`, or `api_key_expired`, matched case-insensitively) now returns the same "Your API key was rejected. Open Settings → AI Provider and re-paste a valid key." guidance already used for 401/403.
- Every other 400 (a genuinely malformed request) keeps returning the raw provider message unchanged, so unrelated errors are not mislabeled as key problems.
- The 401/403 branch is untouched in behavior; both branches now share a single local so the message can never drift.

`RetryPolicy.execute` already routes provider errors through `friendlyMessage(code, raw)`, so the fix flows through to the coach UI with no wiring changes.

## Tests

Added `AiErrorTest` covering the new 400 key-invalid handling (including case-insensitive variants and the `API_KEY_INVALID` / `API_KEY_EXPIRED` reasons), the unchanged 401/403, 429, and 503/529 mappings, a non-key 400 (`Invalid JSON payload received.`) still returning the raw message, and an unmapped status falling through to the raw message.

Fixes #99
