### PR TITLE
Fix onboarding API key state in Android settings

### DIFF
--- a/android/app/src/androidTest/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModelInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModelInstrumentedTest.kt
@@ -1,0 +1,92 @@
+package com.apoorvdarshan.calorietracker.ui.settings
+
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.apoorvdarshan.calorietracker.FudAIApp
+import com.apoorvdarshan.calorietracker.models.AIProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SettingsViewModelInstrumentedTest {
+
+    @Test
+    fun refreshAiConfigurationReflectsValuesSavedAfterViewModelCreation() = runBlocking {
+        val app = InstrumentationRegistry.getInstrumentation()
+            .targetContext.applicationContext as FudAIApp
+        val container = app.container
+        val baselineProvider = AIProvider.ANTHROPIC
+        val refreshedProvider = AIProvider.OPENAI
+        val refreshedModel = refreshedProvider.models.last()
+        val testKey = "issue170-test-key-1234567890"
+
+        val originalProvider = container.prefs.selectedAIProvider.first()
+        val originalModel = originalProvider.supportedModelOrDefault(
+            container.prefs.selectedAIModel.first()
+        )
+        val originalKeys = listOf(baselineProvider, refreshedProvider)
+            .associateWith(container.keyStore::apiKey)
+        val viewModelStore = ViewModelStore()
+
+        try {
+            container.prefs.setSelectedAIProvider(baselineProvider)
+            container.prefs.setSelectedAIModel(baselineProvider.defaultModel)
+            container.keyStore.setApiKey(baselineProvider, null)
+
+            val viewModel = ViewModelProvider(
+                viewModelStore,
+                SettingsViewModel.Factory(container)
+            )[SettingsViewModel::class.java]
+
+            withTimeout(10_000) {
+                viewModel.ui.first {
+                    it.selectedAI == baselineProvider &&
+                        it.selectedModel == baselineProvider.defaultModel &&
+                        it.apiKeyMasked.isEmpty()
+                }
+            }
+
+            // Mirror onboarding writing a new provider/model/key after Settings was warmed.
+            container.prefs.setSelectedAIProvider(refreshedProvider)
+            container.prefs.setSelectedAIModel(refreshedModel)
+            container.keyStore.setApiKey(refreshedProvider, testKey)
+            assertEquals(baselineProvider, viewModel.ui.value.selectedAI)
+
+            viewModel.refreshAiConfiguration()
+
+            val refreshed = withTimeout(10_000) {
+                viewModel.ui.first {
+                    it.selectedAI == refreshedProvider &&
+                        it.selectedModel == refreshedModel &&
+                        it.apiKeyMasked == "issu...7890"
+                }
+            }
+            assertEquals(refreshedProvider, refreshed.selectedAI)
+            assertEquals(refreshedModel, refreshed.selectedModel)
+            assertEquals("issu...7890", refreshed.apiKeyMasked)
+
+            container.keyStore.setApiKey(refreshedProvider, null)
+            viewModel.refreshAiConfiguration()
+            val cleared = withTimeout(10_000) {
+                viewModel.ui.first {
+                    it.selectedAI == refreshedProvider && it.apiKeyMasked.isEmpty()
+                }
+            }
+            assertTrue(cleared.apiKeyMasked.isEmpty())
+        } finally {
+            container.prefs.setSelectedAIProvider(originalProvider)
+            container.prefs.setSelectedAIModel(originalModel)
+            originalKeys.forEach { (provider, key) ->
+                container.keyStore.setApiKey(provider, key)
+            }
+            viewModelStore.clear()
+        }
+    }
+}

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/navigation/FudAINavHost.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/navigation/FudAINavHost.kt
@@ -90,6 +90,16 @@ fun FudAINavHost(
     val currentVersion = remember(context) { AndroidUpdateChecker.currentVersion(context) }
     var updateAvailable by remember { mutableStateOf(false) }
 
+    // Settings is intentionally warmed before onboarding finishes. Reload the values that
+    // onboarding can change outside Settings so the first visit never shows the pre-onboarding
+    // provider/model/API-key snapshot (issue #170). Re-running this on later visits also keeps
+    // the app-scoped ViewModel honest if another flow updates the stored AI configuration.
+    LaunchedEffect(currentRoute) {
+        if (currentRoute == FudAIRoutes.SETTINGS) {
+            settingsViewModel.refreshAiConfiguration()
+        }
+    }
+
     LaunchedEffect(container.workoutRepository, workoutModeV2Initialized) {
         if (!workoutModeV2Initialized) {
             container.workoutRepository.setMode(WorkoutTabMode.LOG)
@@ -167,6 +177,7 @@ fun FudAINavHost(
             ) {
                 composable(FudAIRoutes.ONBOARDING) {
                     OnboardingScreen(container = container, onComplete = {
+                        settingsViewModel.refreshAiConfiguration()
                         nav.navigate(FudAIRoutes.HOME) {
                             popUpTo(FudAIRoutes.ONBOARDING) { inclusive = true }
                             launchSingleTop = true

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModel.kt
@@ -235,6 +235,26 @@ class SettingsViewModel(val container: AppContainer) : ViewModel() {
         }
     }
 
+    /**
+     * Reloads the AI configuration that may be written outside Settings.
+     *
+     * The app-scoped Settings ViewModel is warmed while onboarding is still visible. Onboarding
+     * then persists the selected provider, model, and API key independently, so the one-shot
+     * values loaded in [init] can otherwise remain stale until the process restarts (issue #170).
+     */
+    fun refreshAiConfiguration() {
+        viewModelScope.launch {
+            val provider = container.prefs.selectedAIProvider.first()
+            val model = provider.supportedModelOrDefault(container.prefs.selectedAIModel.first())
+            val maskedKey = maskKey(container.keyStore.apiKey(provider))
+            _ui.value = _ui.value.copy(
+                selectedAI = provider,
+                selectedModel = model,
+                apiKeyMasked = maskedKey
+            )
+        }
+    }
+
     fun selectWorkoutSplit(split: WorkoutSplit) {
         viewModelScope.launch {
             container.workoutRepository.updatePreferences { it.copy(split = split) }


### PR DESCRIPTION
## Summary

- reload the stored AI provider, model, and masked API key after onboarding completes
- refresh the same configuration whenever Android Settings opens
- add an on-device regression test for the pre-warmed Settings ViewModel lifecycle

## Root cause

Android creates the app-scoped `SettingsViewModel` before onboarding. Its one-time provider/model/key snapshot therefore stayed stale after onboarding persisted the real values, even though the API key itself was stored correctly.

Closes #170

## Validation

- `./gradlew :app:testDebugUnitTest :app:assembleDebug`
- focused `SettingsViewModelInstrumentedTest` on the Wi-Fi-connected I2302 (Android 16)
- installed and launched `com.apoorvdarshan.calorietracker.debug` on I2302
- `:app:lintDebug` was also checked; it remains blocked by the pre-existing `UnusedMaterial3ScaffoldPaddingParameter` error in `FudAINavHost.kt`, which is present on `main`