### PR TITLE
fix: store the fallback provider's base URL separately from the primary's

### DIFF
--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/FudAIApp.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/FudAIApp.kt
@@ -57,7 +57,10 @@ class FudAIApp : Application() {
         container.notifications.createChannels()
         WidgetRefreshScheduler.onAppStarted(this)
         container.widgetSnapshotWriter.observe().launchIn(appScope)
-        appScope.launch { container.prefs.migrateLegacyGeminiModels() }
+        appScope.launch {
+            container.prefs.migrateLegacyGeminiModels()
+            container.prefs.migrateFallbackBaseUrls()
+        }
         // Older Android builds removed food rows without removing their JPEGs.
         // Prune only unreferenced files; logged foods, saved meals, and pending
         // analysis drafts remain untouched.

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/FudAIApp.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/FudAIApp.kt
@@ -69,6 +69,7 @@ class FudAIApp : Application() {
             container.prefs.reconcileLocalModelSelections()
             container.prefs.migrateAIModelSelections()
             container.prefs.migrateMatchingSpeechProviderIfNeeded()
+            container.prefs.migrateFallbackBaseUrls()
         }
         // Older Android builds removed food rows without removing their JPEGs.
         // Prune only unreferenced files; logged foods, saved meals, and pending

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/PreferencesStore.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/PreferencesStore.kt
@@ -453,12 +453,47 @@ class PreferencesStore(private val context: Context) : WorkoutStateStore {
         }
     }
 
+    /** Splits the fallback role's base URL off the shared per-provider key exactly once.
+     *  The fallback config historically read the same `customBaseURL_` entry as the primary,
+     *  so two configurations of the same provider type could never point at different servers.
+     *  Seeding the role-scoped key from the shared value keeps existing fallback setups
+     *  working after the split (Custom endpoints have no default URL to fall back to). */
+    suspend fun migrateFallbackBaseUrls() {
+        ds.edit { prefs ->
+            if ((prefs[Keys.FALLBACK_BASE_URL_MIGRATION_VERSION] ?: 0) >= 1) return@edit
+
+            AIProvider.values().forEach { provider ->
+                val fallbackKey = stringPreferencesKey(FALLBACK_BASE_URL_PREFIX + provider.name)
+                if (prefs[fallbackKey] == null) {
+                    prefs[stringPreferencesKey(CUSTOM_BASE_URL_PREFIX + provider.name)]
+                        ?.let { prefs[fallbackKey] = it }
+                }
+            }
+
+            prefs[Keys.FALLBACK_BASE_URL_MIGRATION_VERSION] = 1
+        }
+    }
+
     fun customBaseUrl(provider: AIProvider): Flow<String?> = ds.data.map {
         it[stringPreferencesKey(CUSTOM_BASE_URL_PREFIX + provider.name)]
     }
 
     suspend fun setCustomBaseUrl(provider: AIProvider, url: String?) {
         val key = stringPreferencesKey(CUSTOM_BASE_URL_PREFIX + provider.name)
+        ds.edit {
+            if (url.isNullOrEmpty()) it.remove(key) else it[key] = url
+        }
+    }
+
+    /** Base URL override used when the provider runs in the fallback role. Stored separately
+     *  from [customBaseUrl] so a primary and fallback of the same provider type can point at
+     *  different servers. */
+    fun fallbackCustomBaseUrl(provider: AIProvider): Flow<String?> = ds.data.map {
+        it[stringPreferencesKey(FALLBACK_BASE_URL_PREFIX + provider.name)]
+    }
+
+    suspend fun setFallbackCustomBaseUrl(provider: AIProvider, url: String?) {
+        val key = stringPreferencesKey(FALLBACK_BASE_URL_PREFIX + provider.name)
         ds.edit {
             if (url.isNullOrEmpty()) it.remove(key) else it[key] = url
         }
@@ -750,6 +785,7 @@ class PreferencesStore(private val context: Context) : WorkoutStateStore {
         val FALLBACK_ENABLED = booleanPreferencesKey("aiFallbackEnabled")
         val FALLBACK_PROVIDER = stringPreferencesKey("selectedFallbackAIProvider")
         val FALLBACK_MODEL = stringPreferencesKey("selectedFallbackAIModel")
+        val FALLBACK_BASE_URL_MIGRATION_VERSION = intPreferencesKey("fallbackBaseURLMigrationVersion")
         val SELECTED_SPEECH_PROVIDER = stringPreferencesKey("selectedSpeechProvider")
         fun selectedSpeechLanguage(provider: SpeechProvider) =
             stringPreferencesKey("selectedSpeechLanguage_${provider.name}")
@@ -766,5 +802,6 @@ class PreferencesStore(private val context: Context) : WorkoutStateStore {
 
     companion object {
         private const val CUSTOM_BASE_URL_PREFIX = "customBaseURL_"
+        private const val FALLBACK_BASE_URL_PREFIX = "fallbackCustomBaseURL_"
     }
 }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/PreferencesStore.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/PreferencesStore.kt
@@ -36,6 +36,8 @@ import com.apoorvdarshan.calorietracker.ui.theme.AppThemeColor
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.SetSerializer
@@ -94,6 +96,8 @@ class PreferencesStore(
 
     private val json = Json { ignoreUnknownKeys = true }
     private val ds get() = context.fudaiDataStore
+    private val fallbackBaseUrlMigrationMutex = Mutex()
+    @Volatile private var fallbackBaseUrlMigrationCompleted = false
 
     // -- User profile -----------------------------------------------------
     val userProfile: Flow<UserProfile?> = ds.data.map { prefs ->
@@ -746,12 +750,55 @@ class PreferencesStore(
     private fun storedSpeechProvider(rawValue: String?): SpeechProvider? =
         SpeechProvider.values().firstOrNull { it.name == rawValue }
 
+    /** Splits the fallback role's base URL off the shared per-provider key exactly once.
+     *  The fallback config historically read the same `customBaseURL_` entry as the primary,
+     *  so two configurations of the same provider type could never point at different servers.
+     *  Seeding the role-scoped key from the shared value keeps existing fallback setups
+     *  working after the split (Custom endpoints have no default URL to fall back to).
+     *  Idempotent and mutex-guarded so AI request paths can await completion before reading
+     *  fallback URLs on the first launch after upgrading. */
+    suspend fun migrateFallbackBaseUrls() {
+        if (fallbackBaseUrlMigrationCompleted) return
+        fallbackBaseUrlMigrationMutex.withLock {
+            if (fallbackBaseUrlMigrationCompleted) return
+            if ((ds.data.first()[Keys.FALLBACK_BASE_URL_MIGRATION_VERSION] ?: 0) >= 1) {
+                fallbackBaseUrlMigrationCompleted = true
+                return
+            }
+            ds.edit { prefs ->
+                AIProvider.values().forEach { provider ->
+                    val fallbackKey = stringPreferencesKey(FALLBACK_BASE_URL_PREFIX + provider.name)
+                    if (prefs[fallbackKey] == null) {
+                        prefs[stringPreferencesKey(CUSTOM_BASE_URL_PREFIX + provider.name)]
+                            ?.let { prefs[fallbackKey] = it }
+                    }
+                }
+                prefs[Keys.FALLBACK_BASE_URL_MIGRATION_VERSION] = 1
+            }
+            fallbackBaseUrlMigrationCompleted = true
+        }
+    }
+
     fun customBaseUrl(provider: AIProvider): Flow<String?> = ds.data.map {
         it[stringPreferencesKey(CUSTOM_BASE_URL_PREFIX + provider.name)]
     }
 
     suspend fun setCustomBaseUrl(provider: AIProvider, url: String?) {
         val key = stringPreferencesKey(CUSTOM_BASE_URL_PREFIX + provider.name)
+        ds.edit {
+            if (url.isNullOrEmpty()) it.remove(key) else it[key] = url
+        }
+    }
+
+    /** Base URL override used when the provider runs in the fallback role. Stored separately
+     *  from [customBaseUrl] so a primary and fallback of the same provider type can point at
+     *  different servers. */
+    fun fallbackCustomBaseUrl(provider: AIProvider): Flow<String?> = ds.data.map {
+        it[stringPreferencesKey(FALLBACK_BASE_URL_PREFIX + provider.name)]
+    }
+
+    suspend fun setFallbackCustomBaseUrl(provider: AIProvider, url: String?) {
+        val key = stringPreferencesKey(FALLBACK_BASE_URL_PREFIX + provider.name)
         ds.edit {
             if (url.isNullOrEmpty()) it.remove(key) else it[key] = url
         }
@@ -1177,6 +1224,7 @@ class PreferencesStore(
         val TEXT_FALLBACK_ENABLED = booleanPreferencesKey("textAIFallbackEnabled")
         val TEXT_FALLBACK_PROVIDER = stringPreferencesKey("selectedTextFallbackAIProvider")
         val TEXT_FALLBACK_MODEL = stringPreferencesKey("selectedTextFallbackAIModel")
+        val FALLBACK_BASE_URL_MIGRATION_VERSION = intPreferencesKey("fallbackBaseURLMigrationVersion")
         val SELECTED_SPEECH_PROVIDER = stringPreferencesKey("selectedSpeechProvider")
         val SPEECH_FALLBACK_ENABLED = booleanPreferencesKey("speechFallbackEnabled")
         val SPEECH_FALLBACK_PROVIDER = stringPreferencesKey("selectedSpeechFallbackProvider")
@@ -1197,6 +1245,7 @@ class PreferencesStore(
 
     companion object {
         private const val CUSTOM_BASE_URL_PREFIX = "customBaseURL_"
+        private const val FALLBACK_BASE_URL_PREFIX = "fallbackCustomBaseURL_"
         private const val MATCHING_SPEECH_PROVIDER_MIGRATION_VERSION = 1
     }
 }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/ChatService.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/ChatService.kt
@@ -120,7 +120,8 @@ class ChatService(
             val fallback = currentFallbackConfig(
                 hasImage = imageBytes != null,
                 primary = provider,
-                primaryModel = model
+                primaryModel = model,
+                primaryBaseUrl = baseUrl
             ) ?: throw primaryError
             runProvider(
                 fallback.provider, fallback.model, fallback.baseUrl, fallback.apiKey,
@@ -173,8 +174,10 @@ class ChatService(
     private suspend fun currentFallbackConfig(
         hasImage: Boolean,
         primary: AIProvider,
-        primaryModel: String
+        primaryModel: String,
+        primaryBaseUrl: String
     ): ChatFallbackConfig? {
+        prefs.migrateFallbackBaseUrls()
         val enabled = if (hasImage) prefs.fallbackEnabled.first() else prefs.textFallbackEnabled.first()
         if (!enabled) return null
         val provider = if (hasImage) {
@@ -187,10 +190,10 @@ class ChatService(
         } else {
             provider.supportedTextModelOrDefault(prefs.selectedTextFallbackModel.first())
         }
-        if (provider == primary && model == primaryModel) return null
+        val baseUrl = prefs.fallbackCustomBaseUrl(provider).first()?.takeIf { it.isNotEmpty() } ?: provider.baseUrl
+        if (provider == primary && model == primaryModel && baseUrl == primaryBaseUrl) return null
         val apiKey = keyStore.apiKey(provider)
         if (provider.requiresApiKey && apiKey.isNullOrEmpty()) return null
-        val baseUrl = prefs.customBaseUrl(provider).first()?.takeIf { it.isNotEmpty() } ?: provider.baseUrl
         if (provider != AIProvider.LOCAL_GEMMA && baseUrl.isEmpty()) return null
         return ChatFallbackConfig(provider, model, baseUrl, apiKey)
     }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/FoodAnalysisService.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/FoodAnalysisService.kt
@@ -480,7 +480,7 @@ class FoodAnalysisService(
         return try {
             dispatch(primary, primaryModel, primaryBaseUrl, primaryKey, finalPrompt, uploadImages, maxTokens, requestTimeoutSeconds)
         } catch (primaryError: Throwable) {
-            val fallback = currentFallbackConfig(primary, primaryModel) ?: throw primaryError
+            val fallback = currentFallbackConfig(primary, primaryModel, primaryBaseUrl) ?: throw primaryError
             dispatch(fallback.provider, fallback.model, fallback.baseUrl, fallback.apiKey, finalPrompt, uploadImages, maxTokens, requestTimeoutSeconds)
         }
     }
@@ -582,16 +582,18 @@ class FoodAnalysisService(
 
     private suspend fun currentFallbackConfig(
         primary: AIProvider,
-        primaryModel: String
+        primaryModel: String,
+        primaryBaseUrl: String
     ): FallbackConfig? {
         if (!prefs.fallbackEnabled.first()) return null
         val provider = prefs.selectedFallbackProvider.first()
         val model = provider.supportedModelOrDefault(prefs.selectedFallbackModel.first())
+        val baseUrl = prefs.fallbackCustomBaseUrl(provider).first()?.takeIf { it.isNotEmpty() } ?: provider.baseUrl
         // Fallback identical to primary would be a pointless retry of the same call.
-        if (provider == primary && model == primaryModel) return null
+        // The same provider and model on a *different* server is a legitimate config.
+        if (provider == primary && model == primaryModel && baseUrl == primaryBaseUrl) return null
         val key = keyStore.apiKey(provider)
         if (provider.requiresApiKey && key.isNullOrEmpty()) return null
-        val baseUrl = prefs.customBaseUrl(provider).first()?.takeIf { it.isNotEmpty() } ?: provider.baseUrl
         if (baseUrl.isEmpty()) return null
         return FallbackConfig(provider, model, baseUrl, key)
     }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/FoodAnalysisService.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/FoodAnalysisService.kt
@@ -525,9 +525,9 @@ class FoodAnalysisService(
         } catch (primaryError: Throwable) {
             if (primaryError is kotlinx.coroutines.CancellationException) throw primaryError
             val fallback = if (imageBytesList.isEmpty()) {
-                currentTextFallbackConfig(primary, primaryModel)
+                currentTextFallbackConfig(primary, primaryModel, primaryBaseUrl)
             } else {
-                currentImageFallbackConfig(primary, primaryModel)
+                currentImageFallbackConfig(primary, primaryModel, primaryBaseUrl)
             } ?: throw primaryError
             try {
                 dispatch(fallback.provider, fallback.model, fallback.baseUrl, fallback.apiKey, finalPrompt, uploadImages, maxTokens, requestTimeoutSeconds)
@@ -643,31 +643,36 @@ class FoodAnalysisService(
 
     private suspend fun currentImageFallbackConfig(
         primary: AIProvider,
-        primaryModel: String
+        primaryModel: String,
+        primaryBaseUrl: String
     ): FallbackConfig? {
+        prefs.migrateFallbackBaseUrls()
         if (!prefs.fallbackEnabled.first()) return null
         val provider = prefs.selectedFallbackProvider.first()
         val model = provider.supportedModelOrDefault(prefs.selectedFallbackModel.first())
+        val baseUrl = prefs.fallbackCustomBaseUrl(provider).first()?.takeIf { it.isNotEmpty() } ?: provider.baseUrl
         // Fallback identical to primary would be a pointless retry of the same call.
-        if (provider == primary && model == primaryModel) return null
+        // The same provider and model on a *different* server is a legitimate config.
+        if (provider == primary && model == primaryModel && baseUrl == primaryBaseUrl) return null
         val key = keyStore.apiKey(provider)
         if (provider.requiresApiKey && key.isNullOrEmpty()) return null
-        val baseUrl = prefs.customBaseUrl(provider).first()?.takeIf { it.isNotEmpty() } ?: provider.baseUrl
         if (provider != AIProvider.LOCAL_GEMMA && baseUrl.isEmpty()) return null
         return FallbackConfig(provider, model, baseUrl, key)
     }
 
     private suspend fun currentTextFallbackConfig(
         primary: AIProvider,
-        primaryModel: String
+        primaryModel: String,
+        primaryBaseUrl: String
     ): FallbackConfig? {
+        prefs.migrateFallbackBaseUrls()
         if (!prefs.textFallbackEnabled.first()) return null
         val provider = prefs.selectedTextFallbackProvider.first()
         val model = provider.supportedTextModelOrDefault(prefs.selectedTextFallbackModel.first())
-        if (provider == primary && model == primaryModel) return null
+        val baseUrl = prefs.fallbackCustomBaseUrl(provider).first()?.takeIf { it.isNotEmpty() } ?: provider.baseUrl
+        if (provider == primary && model == primaryModel && baseUrl == primaryBaseUrl) return null
         val key = keyStore.apiKey(provider)
         if (provider.requiresApiKey && key.isNullOrEmpty()) return null
-        val baseUrl = prefs.customBaseUrl(provider).first()?.takeIf { it.isNotEmpty() } ?: provider.baseUrl
         if (provider != AIProvider.LOCAL_GEMMA && baseUrl.isEmpty()) return null
         return FallbackConfig(provider, model, baseUrl, key)
     }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt
@@ -1912,12 +1912,12 @@ private fun SettingsSheets(
                     onSave = { vm.setFallbackApiKey(it); onDismiss() }
                 )
                 SettingsSheet.FALLBACK_BASE_URL -> {
-                    val existing = remember { runBlocking { vm.container.prefs.customBaseUrl(ui.fallbackProvider).first().orEmpty() } }
+                    val existing = remember { runBlocking { vm.container.prefs.fallbackCustomBaseUrl(ui.fallbackProvider).first().orEmpty() } }
                     TextFieldSheet(
                         title = stringResource(R.string.settings_custom_url_title),
                         initial = existing,
                         placeholder = stringResource(R.string.settings_custom_url_placeholder),
-                        onSave = { vm.setCustomBaseUrl(ui.fallbackProvider, it); onDismiss() }
+                        onSave = { vm.setFallbackCustomBaseUrl(ui.fallbackProvider, it); onDismiss() }
                     )
                 }
                 SettingsSheet.GENDER -> ListSheet(

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt
@@ -2759,12 +2759,12 @@ private fun SettingsSheets(
                     onSave = { vm.setFallbackApiKey(it); onDismiss() }
                 )
                 SettingsSheet.FALLBACK_BASE_URL -> {
-                    val existing = remember { runBlocking { vm.container.prefs.customBaseUrl(ui.fallbackProvider).first().orEmpty() } }
+                    val existing = remember { runBlocking { vm.container.prefs.fallbackCustomBaseUrl(ui.fallbackProvider).first().orEmpty() } }
                     TextFieldSheet(
                         title = stringResource(R.string.settings_custom_url_title),
                         initial = existing,
                         placeholder = stringResource(R.string.settings_custom_url_placeholder),
-                        onSave = { vm.setCustomBaseUrl(ui.fallbackProvider, it); onDismiss() }
+                        onSave = { vm.setFallbackCustomBaseUrl(ui.fallbackProvider, it); onDismiss() }
                     )
                 }
                 SettingsSheet.GENDER -> ListSheet(

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt
@@ -2591,7 +2591,22 @@ private fun SettingsSheets(
                 SettingsSheet.TEXT_FALLBACK_MODEL -> {
                     val primaryTextProvider = if (ui.separateTextProviderEnabled) ui.selectedTextAI else ui.selectedAI
                     val primaryTextModel = if (ui.separateTextProviderEnabled) ui.selectedTextModel else ui.selectedModel
-                    val options = if (ui.textFallbackProvider == primaryTextProvider) {
+                    val primaryBaseUrl = remember(primaryTextProvider) {
+                        runBlocking {
+                            vm.container.prefs.migrateFallbackBaseUrls()
+                            vm.container.prefs.customBaseUrl(primaryTextProvider).first()
+                                ?.takeIf { it.isNotEmpty() } ?: primaryTextProvider.baseUrl
+                        }
+                    }
+                    val fallbackBaseUrl = remember(ui.textFallbackProvider) {
+                        runBlocking {
+                            vm.container.prefs.migrateFallbackBaseUrls()
+                            vm.container.prefs.fallbackCustomBaseUrl(ui.textFallbackProvider).first()
+                                ?.takeIf { it.isNotEmpty() } ?: ui.textFallbackProvider.baseUrl
+                        }
+                    }
+                    val sameServer = ui.textFallbackProvider == primaryTextProvider && primaryBaseUrl == fallbackBaseUrl
+                    val options = if (sameServer) {
                         ui.textFallbackProvider.textModels.filter { it != primaryTextModel }
                     } else {
                         ui.textFallbackProvider.textModels
@@ -2614,12 +2629,17 @@ private fun SettingsSheets(
                     onSave = { vm.setTextFallbackApiKey(it); onDismiss() }
                 )
                 SettingsSheet.TEXT_FALLBACK_BASE_URL -> {
-                    val existing = remember { runBlocking { vm.container.prefs.customBaseUrl(ui.textFallbackProvider).first().orEmpty() } }
+                    val existing = remember(ui.textFallbackProvider) {
+                        runBlocking {
+                            vm.container.prefs.migrateFallbackBaseUrls()
+                            vm.container.prefs.fallbackCustomBaseUrl(ui.textFallbackProvider).first().orEmpty()
+                        }
+                    }
                     TextFieldSheet(
                         title = stringResource(R.string.settings_custom_url_title),
                         initial = existing,
                         placeholder = stringResource(R.string.settings_custom_url_placeholder),
-                        onSave = { vm.setCustomBaseUrl(ui.textFallbackProvider, it); onDismiss() }
+                        onSave = { vm.setFallbackCustomBaseUrl(ui.textFallbackProvider, it); onDismiss() }
                     )
                 }
                 SettingsSheet.REASONING_EFFORT -> ListSheet(
@@ -2740,12 +2760,14 @@ private fun SettingsSheets(
                     // can't be a literal duplicate config. Different servers may share a model.
                     val primaryBaseUrl = remember(ui.selectedAI) {
                         runBlocking {
+                            vm.container.prefs.migrateFallbackBaseUrls()
                             vm.container.prefs.customBaseUrl(ui.selectedAI).first()
                                 ?.takeIf { it.isNotEmpty() } ?: ui.selectedAI.baseUrl
                         }
                     }
                     val fallbackBaseUrl = remember(ui.fallbackProvider) {
                         runBlocking {
+                            vm.container.prefs.migrateFallbackBaseUrls()
                             vm.container.prefs.fallbackCustomBaseUrl(ui.fallbackProvider).first()
                                 ?.takeIf { it.isNotEmpty() } ?: ui.fallbackProvider.baseUrl
                         }
@@ -2772,7 +2794,12 @@ private fun SettingsSheets(
                     onSave = { vm.setFallbackApiKey(it); onDismiss() }
                 )
                 SettingsSheet.FALLBACK_BASE_URL -> {
-                    val existing = remember { runBlocking { vm.container.prefs.fallbackCustomBaseUrl(ui.fallbackProvider).first().orEmpty() } }
+                    val existing = remember(ui.fallbackProvider) {
+                        runBlocking {
+                            vm.container.prefs.migrateFallbackBaseUrls()
+                            vm.container.prefs.fallbackCustomBaseUrl(ui.fallbackProvider).first().orEmpty()
+                        }
+                    }
                     TextFieldSheet(
                         title = stringResource(R.string.settings_custom_url_title),
                         initial = existing,

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt
@@ -2736,9 +2736,22 @@ private fun SettingsSheets(
                     leadingContent = { AIProviderBrandIcon(it, Modifier.size(20.dp)) }
                 )
                 SettingsSheet.FALLBACK_MODEL -> {
-                    // Same provider as primary → exclude primary's selected model so
-                    // fallback can't be a literal duplicate config.
-                    val opts = if (ui.fallbackProvider == ui.selectedAI)
+                    // Same provider + same server → exclude primary's model so fallback
+                    // can't be a literal duplicate config. Different servers may share a model.
+                    val primaryBaseUrl = remember(ui.selectedAI) {
+                        runBlocking {
+                            vm.container.prefs.customBaseUrl(ui.selectedAI).first()
+                                ?.takeIf { it.isNotEmpty() } ?: ui.selectedAI.baseUrl
+                        }
+                    }
+                    val fallbackBaseUrl = remember(ui.fallbackProvider) {
+                        runBlocking {
+                            vm.container.prefs.fallbackCustomBaseUrl(ui.fallbackProvider).first()
+                                ?.takeIf { it.isNotEmpty() } ?: ui.fallbackProvider.baseUrl
+                        }
+                    }
+                    val sameServer = ui.fallbackProvider == ui.selectedAI && primaryBaseUrl == fallbackBaseUrl
+                    val opts = if (sameServer)
                         ui.fallbackProvider.models.filter { it != ui.selectedModel }
                     else ui.fallbackProvider.models
                     ListSheet(

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModel.kt
@@ -1020,6 +1020,12 @@ class SettingsViewModel(val container: AppContainer) : ViewModel() {
         }
     }
 
+    fun setFallbackCustomBaseUrl(provider: AIProvider, url: String) {
+        viewModelScope.launch {
+            container.prefs.setFallbackCustomBaseUrl(provider, url.takeIf { it.isNotBlank() })
+        }
+    }
+
     private fun maskKey(key: String?): String =
         if (key.isNullOrBlank()) "" else key.take(4) + "..." + key.takeLast(4)
 

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModel.kt
@@ -438,8 +438,15 @@ class SettingsViewModel(val container: AppContainer) : ViewModel() {
         viewModelScope.launch {
             container.prefs.setSelectedFallbackProvider(p)
             // Reset model to provider default if old model isn't in the new provider's list.
-            val current = _ui.value.fallbackModel
-            val newModel = p.supportedModelOrDefault(current)
+            var newModel = p.supportedModelOrDefault(_ui.value.fallbackModel)
+            val primary = _ui.value.selectedAI
+            val primaryUrl = container.prefs.customBaseUrl(primary).first()?.takeIf { it.isNotEmpty() }
+                ?: primary.baseUrl
+            val fallbackUrl = container.prefs.fallbackCustomBaseUrl(p).first()?.takeIf { it.isNotEmpty() }
+                ?: p.baseUrl
+            if (p == primary && newModel == _ui.value.selectedModel && primaryUrl == fallbackUrl) {
+                newModel = p.models.firstOrNull { it != _ui.value.selectedModel } ?: newModel
+            }
             container.prefs.setSelectedFallbackModel(newModel)
             val masked = maskKey(container.keyStore.apiKey(p))
             _ui.value = _ui.value.copy(fallbackProvider = p, fallbackModel = newModel, fallbackApiKeyMasked = masked)
@@ -479,7 +486,20 @@ class SettingsViewModel(val container: AppContainer) : ViewModel() {
         if (provider !in _ui.value.availableTextProviders) return
         viewModelScope.launch {
             container.prefs.setSelectedTextFallbackProvider(provider)
-            val model = provider.supportedTextModelOrDefault(_ui.value.textFallbackModel)
+            var model = provider.supportedTextModelOrDefault(_ui.value.textFallbackModel)
+            val primary = if (_ui.value.separateTextProviderEnabled) _ui.value.selectedTextAI else _ui.value.selectedAI
+            val primaryModel = if (_ui.value.separateTextProviderEnabled) {
+                _ui.value.selectedTextModel
+            } else {
+                _ui.value.selectedModel
+            }
+            val primaryUrl = container.prefs.customBaseUrl(primary).first()?.takeIf { it.isNotEmpty() }
+                ?: primary.baseUrl
+            val fallbackUrl = container.prefs.fallbackCustomBaseUrl(provider).first()?.takeIf { it.isNotEmpty() }
+                ?: provider.baseUrl
+            if (provider == primary && model == primaryModel && primaryUrl == fallbackUrl) {
+                model = provider.textModels.firstOrNull { it != primaryModel } ?: model
+            }
             container.prefs.setSelectedTextFallbackModel(model)
             _ui.value = _ui.value.copy(
                 textFallbackProvider = provider,
@@ -1452,13 +1472,52 @@ class SettingsViewModel(val container: AppContainer) : ViewModel() {
     fun setCustomBaseUrl(provider: AIProvider, url: String) {
         viewModelScope.launch {
             container.prefs.setCustomBaseUrl(provider, url.takeIf { it.isNotBlank() })
+            reconcileImageFallbackAfterUrlChange()
+            reconcileTextFallbackAfterUrlChange()
         }
     }
 
     fun setFallbackCustomBaseUrl(provider: AIProvider, url: String) {
         viewModelScope.launch {
             container.prefs.setFallbackCustomBaseUrl(provider, url.takeIf { it.isNotBlank() })
+            reconcileImageFallbackAfterUrlChange()
+            reconcileTextFallbackAfterUrlChange()
         }
+    }
+
+    private suspend fun reconcileImageFallbackAfterUrlChange() {
+        if (!_ui.value.fallbackEnabled) return
+        val primary = _ui.value.selectedAI
+        val fallback = _ui.value.fallbackProvider
+        if (fallback != primary || _ui.value.fallbackModel != _ui.value.selectedModel) return
+        val primaryUrl = container.prefs.customBaseUrl(primary).first()?.takeIf { it.isNotEmpty() }
+            ?: primary.baseUrl
+        val fallbackUrl = container.prefs.fallbackCustomBaseUrl(fallback).first()?.takeIf { it.isNotEmpty() }
+            ?: fallback.baseUrl
+        if (primaryUrl != fallbackUrl) return
+        val alternate = fallback.models.firstOrNull { it != _ui.value.selectedModel } ?: return
+        container.prefs.setSelectedFallbackModel(alternate)
+        _ui.value = _ui.value.copy(fallbackModel = alternate)
+    }
+
+    private suspend fun reconcileTextFallbackAfterUrlChange() {
+        if (!_ui.value.textFallbackEnabled) return
+        val primary = if (_ui.value.separateTextProviderEnabled) _ui.value.selectedTextAI else _ui.value.selectedAI
+        val primaryModel = if (_ui.value.separateTextProviderEnabled) {
+            _ui.value.selectedTextModel
+        } else {
+            _ui.value.selectedModel
+        }
+        val fallback = _ui.value.textFallbackProvider
+        if (fallback != primary || _ui.value.textFallbackModel != primaryModel) return
+        val primaryUrl = container.prefs.customBaseUrl(primary).first()?.takeIf { it.isNotEmpty() }
+            ?: primary.baseUrl
+        val fallbackUrl = container.prefs.fallbackCustomBaseUrl(fallback).first()?.takeIf { it.isNotEmpty() }
+            ?: fallback.baseUrl
+        if (primaryUrl != fallbackUrl) return
+        val alternate = fallback.textModels.firstOrNull { it != primaryModel } ?: return
+        container.prefs.setSelectedTextFallbackModel(alternate)
+        _ui.value = _ui.value.copy(textFallbackModel = alternate)
     }
 
     private fun maskKey(key: String?): String =

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModel.kt
@@ -1455,6 +1455,12 @@ class SettingsViewModel(val container: AppContainer) : ViewModel() {
         }
     }
 
+    fun setFallbackCustomBaseUrl(provider: AIProvider, url: String) {
+        viewModelScope.launch {
+            container.prefs.setFallbackCustomBaseUrl(provider, url.takeIf { it.isNotBlank() })
+        }
+    }
+
     private fun maskKey(key: String?): String =
         if (key.isNullOrBlank()) "" else key.take(4) + "..." + key.takeLast(4)
 

--- a/ios/calorietracker/ContentView.swift
+++ b/ios/calorietracker/ContentView.swift
@@ -3405,7 +3405,7 @@ struct ProfileView: View {
     @State private var selectedFallbackProvider: AIProvider = AIProviderSettings.selectedFallbackProvider
     @State private var selectedFallbackModel: String = AIProviderSettings.selectedFallbackModel
     @State private var fallbackApiKeyText: String = AIProviderSettings.apiKey(for: AIProviderSettings.selectedFallbackProvider) ?? ""
-    @State private var fallbackBaseURL: String = AIProviderSettings.customBaseURL(for: AIProviderSettings.selectedFallbackProvider) ?? ""
+    @State private var fallbackBaseURL: String = AIProviderSettings.fallbackCustomBaseURL(for: AIProviderSettings.selectedFallbackProvider) ?? ""
     @State private var showFallbackAPIKey = false
     @State private var selectedSpeechProvider: SpeechProvider = SpeechSettings.selectedProvider
     @State private var selectedSpeechLanguage: SpeechLanguage = SpeechSettings.selectedLanguage(for: SpeechSettings.selectedProvider)
@@ -4357,7 +4357,8 @@ struct ProfileView: View {
                                     .textInputAutocapitalization(.never)
                                     .keyboardType(.URL)
                                     .onChange(of: fallbackBaseURL) { _, newValue in
-                                        AIProviderSettings.setCustomBaseURL(newValue.isEmpty ? nil : newValue, for: selectedFallbackProvider)
+                                        let t = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                                        AIProviderSettings.setFallbackCustomBaseURL(t.isEmpty ? nil : t, for: selectedFallbackProvider)
                                     }
                                 }
 
@@ -4890,7 +4891,7 @@ struct ProfileView: View {
             AIProviderSettings.selectedFallbackModel = alternateModel
         }
         fallbackApiKeyText = AIProviderSettings.apiKey(for: newProvider) ?? ""
-        fallbackBaseURL = AIProviderSettings.customBaseURL(for: newProvider) ?? ""
+        fallbackBaseURL = AIProviderSettings.fallbackCustomBaseURL(for: newProvider) ?? ""
     }
 
     private static let lastRecalcGoalSignatureKey = "lastRecalcGoalSignature"

--- a/ios/calorietracker/ContentView.swift
+++ b/ios/calorietracker/ContentView.swift
@@ -4150,7 +4150,7 @@ struct ProfileView: View {
     @State private var selectedTextFallbackProvider: AIProvider = AIProviderSettings.selectedTextFallbackProvider
     @State private var selectedTextFallbackModel: String = AIProviderSettings.selectedTextFallbackModel
     @State private var textFallbackApiKeyText: String = AIProviderSettings.apiKey(for: AIProviderSettings.selectedTextFallbackProvider) ?? ""
-    @State private var textFallbackBaseURL: String = AIProviderSettings.customBaseURL(for: AIProviderSettings.selectedTextFallbackProvider) ?? ""
+    @State private var textFallbackBaseURL: String = AIProviderSettings.fallbackCustomBaseURL(for: AIProviderSettings.selectedTextFallbackProvider) ?? ""
     @State private var showTextFallbackAPIKey = false
     @State private var localModelAvailabilityRevision = 0
     @State private var selectedSpeechProvider: SpeechProvider = SpeechSettings.selectedProvider
@@ -5007,6 +5007,8 @@ struct ProfileView: View {
                                     .onChange(of: customBaseURL) { _, newValue in
                                         let t = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
                                         AIProviderSettings.setCustomBaseURL(t.isEmpty ? nil : t, for: selectedProvider)
+                                        reconcileImageFallbackModelIfDuplicate()
+                                        reconcileTextFallbackModelIfDuplicate()
                                     }
                             }
 
@@ -5233,6 +5235,7 @@ struct ProfileView: View {
                                 .onChange(of: textBaseURL) { _, newValue in
                                     let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
                                     AIProviderSettings.setCustomBaseURL(trimmed.isEmpty ? nil : trimmed, for: selectedTextProvider)
+                                    reconcileTextFallbackModelIfDuplicate()
                                 }
                             }
 
@@ -5432,6 +5435,7 @@ struct ProfileView: View {
                                     .onChange(of: fallbackBaseURL) { _, newValue in
                                         let t = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
                                         AIProviderSettings.setFallbackCustomBaseURL(t.isEmpty ? nil : t, for: selectedFallbackProvider)
+                                        reconcileImageFallbackModelIfDuplicate()
                                     }
                                 }
 
@@ -6104,7 +6108,9 @@ struct ProfileView: View {
                     .textInputAutocapitalization(.never)
                     .keyboardType(.URL)
                     .onChange(of: textFallbackBaseURL) { _, newValue in
-                        AIProviderSettings.setCustomBaseURL(newValue.isEmpty ? nil : newValue, for: selectedTextFallbackProvider)
+                        let t = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                        AIProviderSettings.setFallbackCustomBaseURL(t.isEmpty ? nil : t, for: selectedTextFallbackProvider)
+                        reconcileTextFallbackModelIfDuplicate()
                     }
                 }
             }
@@ -6269,12 +6275,29 @@ struct ProfileView: View {
         return selectedFallbackProvider.models.filter { $0 != selectedModel }
     }
 
-    private var textFallbackModelPresetOptions: [String] {
+    private var resolvedTextPrimaryBaseURL: String {
+        let provider = separateTextProviderEnabled ? selectedTextProvider : selectedProvider
+        let url = separateTextProviderEnabled ? textBaseURL : customBaseURL
+        let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? provider.baseURL : trimmed
+    }
+
+    private var resolvedTextFallbackBaseURL: String {
+        let trimmed = textFallbackBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? selectedTextFallbackProvider.baseURL : trimmed
+    }
+
+    private var textFallbackSharesPrimaryServer: Bool {
         let primaryProvider = separateTextProviderEnabled ? selectedTextProvider : selectedProvider
-        let primaryModel = separateTextProviderEnabled ? selectedTextModel : selectedModel
-        guard selectedTextFallbackProvider == primaryProvider else {
+        return selectedTextFallbackProvider == primaryProvider &&
+            resolvedTextPrimaryBaseURL == resolvedTextFallbackBaseURL
+    }
+
+    private var textFallbackModelPresetOptions: [String] {
+        guard textFallbackSharesPrimaryServer else {
             return selectedTextFallbackProvider.textModels
         }
+        let primaryModel = separateTextProviderEnabled ? selectedTextModel : selectedModel
         return selectedTextFallbackProvider.textModels.filter { $0 != primaryModel }
     }
 
@@ -6341,14 +6364,39 @@ struct ProfileView: View {
         }
         let primaryProvider = separateTextProviderEnabled ? selectedTextProvider : selectedProvider
         let primaryModel = separateTextProviderEnabled ? selectedTextModel : selectedModel
-        if newProvider == primaryProvider,
+        let sharesServer = newProvider == primaryProvider &&
+            (AIProviderSettings.fallbackCustomBaseURL(for: newProvider) ?? newProvider.baseURL) ==
+            (AIProviderSettings.customBaseURL(for: primaryProvider) ?? primaryProvider.baseURL)
+        if sharesServer,
            selectedTextFallbackModel == primaryModel,
            let alternate = options.first(where: { $0 != primaryModel }) {
             selectedTextFallbackModel = alternate
             AIProviderSettings.selectedTextFallbackModel = alternate
         }
         textFallbackApiKeyText = AIProviderSettings.apiKey(for: newProvider) ?? ""
-        textFallbackBaseURL = AIProviderSettings.customBaseURL(for: newProvider) ?? ""
+        textFallbackBaseURL = AIProviderSettings.fallbackCustomBaseURL(for: newProvider) ?? ""
+    }
+
+    private func reconcileImageFallbackModelIfDuplicate() {
+        guard fallbackEnabled else { return }
+        guard selectedFallbackProvider == selectedProvider,
+              selectedFallbackModel == selectedModel,
+              resolvedPrimaryBaseURL == resolvedFallbackBaseURL else { return }
+        guard let alternate = selectedFallbackProvider.models.first(where: { $0 != selectedModel }) else { return }
+        selectedFallbackModel = alternate
+        AIProviderSettings.selectedFallbackModel = alternate
+    }
+
+    private func reconcileTextFallbackModelIfDuplicate() {
+        guard textFallbackEnabled else { return }
+        let primaryProvider = separateTextProviderEnabled ? selectedTextProvider : selectedProvider
+        let primaryModel = separateTextProviderEnabled ? selectedTextModel : selectedModel
+        guard selectedTextFallbackProvider == primaryProvider,
+              selectedTextFallbackModel == primaryModel,
+              resolvedTextPrimaryBaseURL == resolvedTextFallbackBaseURL else { return }
+        guard let alternate = selectedTextFallbackProvider.textModels.first(where: { $0 != primaryModel }) else { return }
+        selectedTextFallbackModel = alternate
+        AIProviderSettings.selectedTextFallbackModel = alternate
     }
 
     private func selectSpeechFallbackProvider(_ newProvider: SpeechProvider) {

--- a/ios/calorietracker/ContentView.swift
+++ b/ios/calorietracker/ContentView.swift
@@ -5339,10 +5339,10 @@ struct ProfileView: View {
                                     }
                                 }
                             } else {
-                                // Same provider as primary → exclude the primary's model from the picker so
+                                // Same provider + same server → exclude the primary's model so
                                 // user can't accidentally pick an identical config.
                                 let modelOptions: [String] = {
-                                    if selectedFallbackProvider == selectedProvider {
+                                    if fallbackSharesPrimaryServer {
                                         return selectedFallbackProvider.models.filter { $0 != selectedModel }
                                     }
                                     return selectedFallbackProvider.models
@@ -6247,8 +6247,23 @@ struct ProfileView: View {
             }
     }
 
+    private var resolvedPrimaryBaseURL: String {
+        let trimmed = customBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? selectedProvider.baseURL : trimmed
+    }
+
+    private var resolvedFallbackBaseURL: String {
+        let trimmed = fallbackBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? selectedFallbackProvider.baseURL : trimmed
+    }
+
+    /// True when fallback would hit the same provider, model, and server as primary.
+    private var fallbackSharesPrimaryServer: Bool {
+        selectedFallbackProvider == selectedProvider && resolvedPrimaryBaseURL == resolvedFallbackBaseURL
+    }
+
     private var fallbackModelPresetOptions: [String] {
-        guard selectedFallbackProvider == selectedProvider else {
+        guard fallbackSharesPrimaryServer else {
             return selectedFallbackProvider.models
         }
         return selectedFallbackProvider.models.filter { $0 != selectedModel }
@@ -6302,9 +6317,11 @@ struct ProfileView: View {
             selectedFallbackModel = newProvider.defaultModel
             AIProviderSettings.selectedFallbackModel = selectedFallbackModel
         }
-        // If switching fallback to the primary provider with the same model, select the first
-        // alternate model so the two configurations still provide capacity diversity.
-        if newProvider == selectedProvider,
+        // Same provider + same server + same model would be a pointless retry — pick an alternate.
+        let sharesServer = newProvider == selectedProvider &&
+            (AIProviderSettings.fallbackCustomBaseURL(for: newProvider) ?? newProvider.baseURL) ==
+            (AIProviderSettings.customBaseURL(for: selectedProvider) ?? selectedProvider.baseURL)
+        if sharesServer,
            selectedFallbackModel == selectedModel,
            let alternateModel = newProvider.models.first(where: { $0 != selectedModel }) {
             selectedFallbackModel = alternateModel

--- a/ios/calorietracker/ContentView.swift
+++ b/ios/calorietracker/ContentView.swift
@@ -4144,7 +4144,7 @@ struct ProfileView: View {
     @State private var selectedFallbackProvider: AIProvider = AIProviderSettings.selectedFallbackProvider
     @State private var selectedFallbackModel: String = AIProviderSettings.selectedFallbackModel
     @State private var fallbackApiKeyText: String = AIProviderSettings.apiKey(for: AIProviderSettings.selectedFallbackProvider) ?? ""
-    @State private var fallbackBaseURL: String = AIProviderSettings.customBaseURL(for: AIProviderSettings.selectedFallbackProvider) ?? ""
+    @State private var fallbackBaseURL: String = AIProviderSettings.fallbackCustomBaseURL(for: AIProviderSettings.selectedFallbackProvider) ?? ""
     @State private var showFallbackAPIKey = false
     @State private var textFallbackEnabled: Bool = AIProviderSettings.textFallbackEnabled
     @State private var selectedTextFallbackProvider: AIProvider = AIProviderSettings.selectedTextFallbackProvider
@@ -5430,7 +5430,8 @@ struct ProfileView: View {
                                     .textInputAutocapitalization(.never)
                                     .keyboardType(.URL)
                                     .onChange(of: fallbackBaseURL) { _, newValue in
-                                        AIProviderSettings.setCustomBaseURL(newValue.isEmpty ? nil : newValue, for: selectedFallbackProvider)
+                                        let t = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                                        AIProviderSettings.setFallbackCustomBaseURL(t.isEmpty ? nil : t, for: selectedFallbackProvider)
                                     }
                                 }
 
@@ -6310,7 +6311,7 @@ struct ProfileView: View {
             AIProviderSettings.selectedFallbackModel = alternateModel
         }
         fallbackApiKeyText = AIProviderSettings.apiKey(for: newProvider) ?? ""
-        fallbackBaseURL = AIProviderSettings.customBaseURL(for: newProvider) ?? ""
+        fallbackBaseURL = AIProviderSettings.fallbackCustomBaseURL(for: newProvider) ?? ""
     }
 
     private func selectTextFallbackProvider(_ newProvider: AIProvider) {

--- a/ios/calorietracker/Models/AIProvider.swift
+++ b/ios/calorietracker/Models/AIProvider.swift
@@ -261,6 +261,8 @@ struct AIProviderSettings {
     private static let fallbackEnabledKey = "aiFallbackEnabled"
     private static let fallbackProviderKey = "selectedFallbackAIProvider"
     private static let fallbackModelKey = "selectedFallbackAIModel"
+    private static let fallbackBaseURLKey = "fallbackCustomBaseURL_"
+    private static let fallbackBaseURLMigrationVersionKey = "fallbackBaseURLMigrationVersion"
     private static let geminiModelMigrationVersionKey = "geminiModelMigrationVersion"
     private static let maxResponseTokensKey = "aiMaxResponseTokens"
     private static let requestTimeoutSecondsKey = "aiRequestTimeoutSeconds"
@@ -323,6 +325,25 @@ struct AIProviderSettings {
         defaults.set(1, forKey: geminiModelMigrationVersionKey)
     }
 
+    /// Splits the fallback role's base URL off the shared per-provider key exactly once.
+    /// The fallback config historically read the same `customBaseURL_` entry as the
+    /// primary, so two configurations of the same provider type could never point at
+    /// different servers. Seeding the role-scoped key from the shared value keeps
+    /// existing fallback setups working after the split (Custom endpoints have no
+    /// default URL to fall back to).
+    static func migrateFallbackBaseURLsIfNeeded() {
+        let defaults = UserDefaults.standard
+        guard defaults.integer(forKey: fallbackBaseURLMigrationVersionKey) < 1 else { return }
+
+        for provider in AIProvider.allCases where fallbackCustomBaseURL(for: provider) == nil {
+            if let shared = customBaseURL(for: provider) {
+                defaults.set(shared, forKey: fallbackBaseURLKey + provider.rawValue)
+            }
+        }
+
+        defaults.set(1, forKey: fallbackBaseURLMigrationVersionKey)
+    }
+
     static var selectedModel: String {
         get {
             let saved = UserDefaults.standard.string(forKey: modelKey)
@@ -361,6 +382,21 @@ struct AIProviderSettings {
             UserDefaults.standard.set(url, forKey: baseURLKey + provider.rawValue)
         } else {
             UserDefaults.standard.removeObject(forKey: baseURLKey + provider.rawValue)
+        }
+    }
+
+    /// Base URL override used when the provider runs in the fallback role. Stored
+    /// separately from `customBaseURL(for:)` so a primary and fallback of the same
+    /// provider type can point at different servers.
+    static func fallbackCustomBaseURL(for provider: AIProvider) -> String? {
+        UserDefaults.standard.string(forKey: fallbackBaseURLKey + provider.rawValue)
+    }
+
+    static func setFallbackCustomBaseURL(_ url: String?, for provider: AIProvider) {
+        if let url, !url.isEmpty {
+            UserDefaults.standard.set(url, forKey: fallbackBaseURLKey + provider.rawValue)
+        } else {
+            UserDefaults.standard.removeObject(forKey: fallbackBaseURLKey + provider.rawValue)
         }
     }
 
@@ -444,19 +480,22 @@ struct AIProviderSettings {
 
     /// Returns the resolved fallback config when (a) fallback is enabled, (b) the fallback
     /// provider has a usable key (or doesn't require one), and (c) the fallback config
-    /// isn't byte-for-byte identical to the primary (same provider + model = pointless retry).
-    /// Same provider with a *different* model IS allowed — common pattern is e.g. Gemini Pro
-    /// primary with Gemini Flash fallback for capacity-pool diversity within one provider.
+    /// isn't byte-for-byte identical to the primary (same provider + model + server =
+    /// pointless retry). Same provider with a *different* model IS allowed — common pattern
+    /// is e.g. Gemini Pro primary with Gemini Flash fallback for capacity-pool diversity
+    /// within one provider — and so is the same model on a *different* server.
     static func currentFallbackConfig(excludingPrimary primary: AIProvider) -> FallbackConfig? {
         guard fallbackEnabled else { return nil }
         let provider = selectedFallbackProvider
         let model = selectedFallbackModel
-        if provider == primary, model == selectedModel { return nil }
+        let baseURL = fallbackCustomBaseURL(for: provider) ?? provider.baseURL
+        if provider == primary, model == selectedModel,
+           baseURL == (customBaseURL(for: primary) ?? primary.baseURL) { return nil }
         if provider.requiresAPIKey, apiKey(for: provider) == nil { return nil }
         return FallbackConfig(
             provider: provider,
             model: model,
-            baseURL: customBaseURL(for: provider) ?? provider.baseURL,
+            baseURL: baseURL,
             apiKey: apiKey(for: provider)
         )
     }
@@ -465,6 +504,7 @@ struct AIProviderSettings {
         for provider in AIProvider.allCases {
             setAPIKey(nil, for: provider)
             setCustomBaseURL(nil, for: provider)
+            setFallbackCustomBaseURL(nil, for: provider)
         }
         UserDefaults.standard.removeObject(forKey: providerKey)
         UserDefaults.standard.removeObject(forKey: modelKey)

--- a/ios/calorietracker/Models/AIProvider.swift
+++ b/ios/calorietracker/Models/AIProvider.swift
@@ -457,6 +457,8 @@ struct AIProviderSettings {
     private static let textFallbackEnabledKey = "textAIFallbackEnabled"
     private static let textFallbackProviderKey = "selectedTextFallbackAIProvider"
     private static let textFallbackModelKey = "selectedTextFallbackAIModel"
+    private static let fallbackBaseURLKey = "fallbackCustomBaseURL_"
+    private static let fallbackBaseURLMigrationVersionKey = "fallbackBaseURLMigrationVersion"
     private static let geminiModelMigrationVersionKey = "geminiModelMigrationVersion"
     private static let modelRegistryMigrationVersionKey = "aiModelRegistryMigrationVersion"
     private static let currentModelRegistryMigrationVersion = 2
@@ -604,6 +606,25 @@ struct AIProviderSettings {
         return provider
     }
 
+    /// Splits the fallback role's base URL off the shared per-provider key exactly once.
+    /// The fallback config historically read the same `customBaseURL_` entry as the
+    /// primary, so two configurations of the same provider type could never point at
+    /// different servers. Seeding the role-scoped key from the shared value keeps
+    /// existing fallback setups working after the split (Custom endpoints have no
+    /// default URL to fall back to).
+    static func migrateFallbackBaseURLsIfNeeded() {
+        let defaults = UserDefaults.standard
+        guard defaults.integer(forKey: fallbackBaseURLMigrationVersionKey) < 1 else { return }
+
+        for provider in AIProvider.allCases where fallbackCustomBaseURL(for: provider) == nil {
+            if let shared = customBaseURL(for: provider) {
+                defaults.set(shared, forKey: fallbackBaseURLKey + provider.rawValue)
+            }
+        }
+
+        defaults.set(1, forKey: fallbackBaseURLMigrationVersionKey)
+    }
+
     static var selectedModel: String {
         get {
             let saved = UserDefaults.standard.string(forKey: modelKey)
@@ -642,6 +663,21 @@ struct AIProviderSettings {
             UserDefaults.standard.set(url, forKey: baseURLKey + provider.rawValue)
         } else {
             UserDefaults.standard.removeObject(forKey: baseURLKey + provider.rawValue)
+        }
+    }
+
+    /// Base URL override used when the provider runs in the fallback role. Stored
+    /// separately from `customBaseURL(for:)` so a primary and fallback of the same
+    /// provider type can point at different servers.
+    static func fallbackCustomBaseURL(for provider: AIProvider) -> String? {
+        UserDefaults.standard.string(forKey: fallbackBaseURLKey + provider.rawValue)
+    }
+
+    static func setFallbackCustomBaseURL(_ url: String?, for provider: AIProvider) {
+        if let url, !url.isEmpty {
+            UserDefaults.standard.set(url, forKey: fallbackBaseURLKey + provider.rawValue)
+        } else {
+            UserDefaults.standard.removeObject(forKey: fallbackBaseURLKey + provider.rawValue)
         }
     }
 
@@ -796,19 +832,22 @@ struct AIProviderSettings {
 
     /// Returns the resolved fallback config when (a) fallback is enabled, (b) the fallback
     /// provider has a usable key (or doesn't require one), and (c) the fallback config
-    /// isn't byte-for-byte identical to the primary (same provider + model = pointless retry).
-    /// Same provider with a *different* model IS allowed — common pattern is e.g. Gemini Pro
-    /// primary with Gemini Flash fallback for capacity-pool diversity within one provider.
+    /// isn't byte-for-byte identical to the primary (same provider + model + server =
+    /// pointless retry). Same provider with a *different* model IS allowed — common pattern
+    /// is e.g. Gemini Pro primary with Gemini Flash fallback for capacity-pool diversity
+    /// within one provider — and so is the same model on a *different* server.
     static func currentImageFallbackConfig(excludingPrimary primary: AIProvider, model primaryModel: String) -> FallbackConfig? {
         guard fallbackEnabled else { return nil }
         let provider = selectedFallbackProvider
         let model = selectedFallbackModel
-        if provider == primary, model == primaryModel { return nil }
+        let baseURL = fallbackCustomBaseURL(for: provider) ?? provider.baseURL
+        if provider == primary, model == primaryModel,
+           baseURL == (customBaseURL(for: primary) ?? primary.baseURL) { return nil }
         if provider.requiresAPIKey, apiKey(for: provider) == nil { return nil }
         return FallbackConfig(
             provider: provider,
             model: model,
-            baseURL: customBaseURL(for: provider) ?? provider.baseURL,
+            baseURL: baseURL,
             apiKey: apiKey(for: provider)
         )
     }
@@ -817,12 +856,14 @@ struct AIProviderSettings {
         guard textFallbackEnabled else { return nil }
         let provider = selectedTextFallbackProvider
         let model = selectedTextFallbackModel
-        if provider == primary, model == primaryModel { return nil }
+        let baseURL = fallbackCustomBaseURL(for: provider) ?? provider.baseURL
+        if provider == primary, model == primaryModel,
+           baseURL == (customBaseURL(for: primary) ?? primary.baseURL) { return nil }
         if provider.requiresAPIKey, apiKey(for: provider) == nil { return nil }
         return FallbackConfig(
             provider: provider,
             model: model,
-            baseURL: customBaseURL(for: provider) ?? provider.baseURL,
+            baseURL: baseURL,
             apiKey: apiKey(for: provider)
         )
     }
@@ -831,6 +872,7 @@ struct AIProviderSettings {
         for provider in AIProvider.allCases {
             setAPIKey(nil, for: provider)
             setCustomBaseURL(nil, for: provider)
+            setFallbackCustomBaseURL(nil, for: provider)
         }
         UserDefaults.standard.removeObject(forKey: providerKey)
         UserDefaults.standard.removeObject(forKey: modelKey)

--- a/ios/calorietracker/Models/AIProvider.swift
+++ b/ios/calorietracker/Models/AIProvider.swift
@@ -886,6 +886,7 @@ struct AIProviderSettings {
         UserDefaults.standard.removeObject(forKey: textFallbackEnabledKey)
         UserDefaults.standard.removeObject(forKey: textFallbackProviderKey)
         UserDefaults.standard.removeObject(forKey: textFallbackModelKey)
+        UserDefaults.standard.removeObject(forKey: fallbackBaseURLMigrationVersionKey)
         UserDefaults.standard.removeObject(forKey: requestTimeoutSecondsKey)
     }
 

--- a/ios/calorietracker/calorietrackerApp.swift
+++ b/ios/calorietracker/calorietrackerApp.swift
@@ -47,6 +47,7 @@ struct calorietrackerApp: App {
         // before any view reads them.
         UnitPreferenceMigration.runIfNeeded()
         AIProviderSettings.migrateLegacyGeminiModelsIfNeeded()
+        AIProviderSettings.migrateFallbackBaseURLsIfNeeded()
         if CommandLine.arguments.contains("--reset-onboarding") {
             UserDefaults.standard.removeObject(forKey: "hasCompletedOnboarding")
             UserDefaults.standard.removeObject(forKey: "userProfile")

--- a/ios/calorietracker/calorietrackerApp.swift
+++ b/ios/calorietracker/calorietrackerApp.swift
@@ -51,6 +51,7 @@ struct calorietrackerApp: App {
         UnitPreferenceMigration.runIfNeeded()
         AIProviderSettings.migrateLegacyGeminiModelsIfNeeded()
         SpeechSettings.migrateMatchingPrimaryProviderIfNeeded()
+        AIProviderSettings.migrateFallbackBaseURLsIfNeeded()
         if CommandLine.arguments.contains("--reset-onboarding") {
             UserDefaults.standard.removeObject(forKey: "hasCompletedOnboarding")
             UserDefaults.standard.removeObject(forKey: "userProfile")

--- a/ios/calorietrackerTests/AIRequestConfigurationTests.swift
+++ b/ios/calorietrackerTests/AIRequestConfigurationTests.swift
@@ -2,6 +2,8 @@ import Testing
 import UIKit
 @testable import calorietracker
 
+// Serialized: several tests save/mutate/restore shared UserDefaults-backed settings.
+@Suite(.serialized)
 struct AIRequestConfigurationTests {
     @Test func geminiUsesCurrentModelsAndFallsBackFromRetiredChoices() {
         #expect(AIProvider.gemini.defaultModel == "gemini-3.5-flash-lite")
@@ -27,6 +29,74 @@ struct AIRequestConfigurationTests {
         #expect(AIProviderSettings.requestTimeout(for: .ollama) == 600)
         #expect(AIProviderSettings.requestTimeout(for: .customOpenAI) == 600)
         #expect(AIProviderSettings.requestTimeout(for: .gemini) == nil)
+    }
+
+    @Test func fallbackBaseURLIsStoredSeparatelyFromPrimary() {
+        let provider = AIProvider.ollama
+        let defaults = UserDefaults.standard
+        let originalShared = AIProviderSettings.customBaseURL(for: provider)
+        let originalFallback = AIProviderSettings.fallbackCustomBaseURL(for: provider)
+        let originalEnabled = AIProviderSettings.fallbackEnabled
+        let originalFallbackProvider = defaults.string(forKey: "selectedFallbackAIProvider")
+        let originalFallbackModel = defaults.string(forKey: "selectedFallbackAIModel")
+        defer {
+            AIProviderSettings.setCustomBaseURL(originalShared, for: provider)
+            AIProviderSettings.setFallbackCustomBaseURL(originalFallback, for: provider)
+            AIProviderSettings.fallbackEnabled = originalEnabled
+            if let originalFallbackProvider {
+                defaults.set(originalFallbackProvider, forKey: "selectedFallbackAIProvider")
+            } else {
+                defaults.removeObject(forKey: "selectedFallbackAIProvider")
+            }
+            if let originalFallbackModel {
+                defaults.set(originalFallbackModel, forKey: "selectedFallbackAIModel")
+            } else {
+                defaults.removeObject(forKey: "selectedFallbackAIModel")
+            }
+        }
+
+        AIProviderSettings.setCustomBaseURL("http://primary.local:8080/v1", for: provider)
+        AIProviderSettings.setFallbackCustomBaseURL("http://fallback.local:9090/v1", for: provider)
+        #expect(AIProviderSettings.customBaseURL(for: provider) == "http://primary.local:8080/v1")
+        #expect(AIProviderSettings.fallbackCustomBaseURL(for: provider) == "http://fallback.local:9090/v1")
+
+        // The resolved fallback config must use the fallback-scoped URL, not the primary's.
+        AIProviderSettings.fallbackEnabled = true
+        AIProviderSettings.selectedFallbackProvider = provider
+        AIProviderSettings.selectedFallbackModel = "llava"
+        let config = AIProviderSettings.currentFallbackConfig(excludingPrimary: .gemini)
+        #expect(config?.baseURL == "http://fallback.local:9090/v1")
+    }
+
+    @Test func fallbackBaseURLMigrationSeedsSharedValueExactlyOnce() {
+        let provider = AIProvider.customOpenAI
+        let defaults = UserDefaults.standard
+        let markerKey = "fallbackBaseURLMigrationVersion"
+        let originalShared = AIProviderSettings.customBaseURL(for: provider)
+        let originalFallback = AIProviderSettings.fallbackCustomBaseURL(for: provider)
+        let originalMarker = defaults.object(forKey: markerKey)
+        defer {
+            AIProviderSettings.setCustomBaseURL(originalShared, for: provider)
+            AIProviderSettings.setFallbackCustomBaseURL(originalFallback, for: provider)
+            if let originalMarker {
+                defaults.set(originalMarker, forKey: markerKey)
+            } else {
+                defaults.removeObject(forKey: markerKey)
+            }
+        }
+
+        defaults.removeObject(forKey: markerKey)
+        AIProviderSettings.setFallbackCustomBaseURL(nil, for: provider)
+        AIProviderSettings.setCustomBaseURL("http://shared.local:1234/v1", for: provider)
+
+        AIProviderSettings.migrateFallbackBaseURLsIfNeeded()
+        #expect(AIProviderSettings.fallbackCustomBaseURL(for: provider) == "http://shared.local:1234/v1")
+
+        // A deliberate clear after migration must survive the next launch: the marker
+        // prevents the shared value from being re-seeded.
+        AIProviderSettings.setFallbackCustomBaseURL(nil, for: provider)
+        AIProviderSettings.migrateFallbackBaseURLsIfNeeded()
+        #expect(AIProviderSettings.fallbackCustomBaseURL(for: provider) == nil)
     }
 
     @Test func foodPhotosAreDownscaledWithoutUpscaling() throws {

--- a/ios/calorietrackerTests/AIRequestConfigurationTests.swift
+++ b/ios/calorietrackerTests/AIRequestConfigurationTests.swift
@@ -2,6 +2,7 @@ import Testing
 import UIKit
 @testable import calorietracker
 
+// Serialized: several tests save/mutate/restore shared UserDefaults-backed settings.
 @Suite(.serialized)
 struct AIRequestConfigurationTests {
     @Test func settingsHubKeepsEveryFocusedCategory() {
@@ -221,6 +222,77 @@ struct AIRequestConfigurationTests {
 
         SpeechSettings.setInitialProvider(matching: .openrouter, defaults: defaults)
         #expect(defaults.string(forKey: "selectedSpeechProvider") == SpeechProvider.nativeIOS.rawValue)
+    }
+
+    @Test func fallbackBaseURLIsStoredSeparatelyFromPrimary() {
+        let provider = AIProvider.ollama
+        let defaults = UserDefaults.standard
+        let originalShared = AIProviderSettings.customBaseURL(for: provider)
+        let originalFallback = AIProviderSettings.fallbackCustomBaseURL(for: provider)
+        let originalEnabled = AIProviderSettings.fallbackEnabled
+        let originalFallbackProvider = defaults.string(forKey: "selectedFallbackAIProvider")
+        let originalFallbackModel = defaults.string(forKey: "selectedFallbackAIModel")
+        defer {
+            AIProviderSettings.setCustomBaseURL(originalShared, for: provider)
+            AIProviderSettings.setFallbackCustomBaseURL(originalFallback, for: provider)
+            AIProviderSettings.fallbackEnabled = originalEnabled
+            if let originalFallbackProvider {
+                defaults.set(originalFallbackProvider, forKey: "selectedFallbackAIProvider")
+            } else {
+                defaults.removeObject(forKey: "selectedFallbackAIProvider")
+            }
+            if let originalFallbackModel {
+                defaults.set(originalFallbackModel, forKey: "selectedFallbackAIModel")
+            } else {
+                defaults.removeObject(forKey: "selectedFallbackAIModel")
+            }
+        }
+
+        AIProviderSettings.setCustomBaseURL("http://primary.local:8080/v1", for: provider)
+        AIProviderSettings.setFallbackCustomBaseURL("http://fallback.local:9090/v1", for: provider)
+        #expect(AIProviderSettings.customBaseURL(for: provider) == "http://primary.local:8080/v1")
+        #expect(AIProviderSettings.fallbackCustomBaseURL(for: provider) == "http://fallback.local:9090/v1")
+
+        // The resolved fallback config must use the fallback-scoped URL, not the primary's.
+        AIProviderSettings.fallbackEnabled = true
+        AIProviderSettings.selectedFallbackProvider = provider
+        AIProviderSettings.selectedFallbackModel = "llava"
+        let config = AIProviderSettings.currentImageFallbackConfig(
+            excludingPrimary: .gemini,
+            model: AIProviderSettings.selectedModel
+        )
+        #expect(config?.baseURL == "http://fallback.local:9090/v1")
+    }
+
+    @Test func fallbackBaseURLMigrationSeedsSharedValueExactlyOnce() {
+        let provider = AIProvider.customOpenAI
+        let defaults = UserDefaults.standard
+        let markerKey = "fallbackBaseURLMigrationVersion"
+        let originalShared = AIProviderSettings.customBaseURL(for: provider)
+        let originalFallback = AIProviderSettings.fallbackCustomBaseURL(for: provider)
+        let originalMarker = defaults.object(forKey: markerKey)
+        defer {
+            AIProviderSettings.setCustomBaseURL(originalShared, for: provider)
+            AIProviderSettings.setFallbackCustomBaseURL(originalFallback, for: provider)
+            if let originalMarker {
+                defaults.set(originalMarker, forKey: markerKey)
+            } else {
+                defaults.removeObject(forKey: markerKey)
+            }
+        }
+
+        defaults.removeObject(forKey: markerKey)
+        AIProviderSettings.setFallbackCustomBaseURL(nil, for: provider)
+        AIProviderSettings.setCustomBaseURL("http://shared.local:1234/v1", for: provider)
+
+        AIProviderSettings.migrateFallbackBaseURLsIfNeeded()
+        #expect(AIProviderSettings.fallbackCustomBaseURL(for: provider) == "http://shared.local:1234/v1")
+
+        // A deliberate clear after migration must survive the next launch: the marker
+        // prevents the shared value from being re-seeded.
+        AIProviderSettings.setFallbackCustomBaseURL(nil, for: provider)
+        AIProviderSettings.migrateFallbackBaseURLsIfNeeded()
+        #expect(AIProviderSettings.fallbackCustomBaseURL(for: provider) == nil)
     }
 
     @Test func foodPhotosAreDownscaledWithoutUpscaling() throws {


### PR DESCRIPTION
Fixes #183

## Problem

The custom base URL is stored under a single per-provider key (`customBaseURL_<provider>`), shared by the primary and fallback configurations. When both roles use the same provider type (e.g. two different OpenAI-compatible servers), whichever URL was saved last silently wins for both on the next app start — the setup from #183 (a LAN endpoint as primary + a localhost proxy as fallback) cannot survive a relaunch.

## Fix

- The fallback role now stores its base URL under its own per-provider key (`fallbackCustomBaseURL_<provider>`): the fallback Settings editor reads/writes it, and the fallback request config resolves it (Android `FoodAnalysisService.currentFallbackConfig`, iOS `AIProviderSettings.currentFallbackConfig`).
- A one-time migration seeds the new key from the previously shared value, so existing fallback setups keep their URL after the update. Without it, a fallback on a Custom (OpenAI-compatible) endpoint would silently stop firing — that provider has no default URL to fall back to.
- The "fallback identical to primary" dedupe check now also compares base URLs: the same provider and model on a *different* server is a legitimate fallback config (exactly the two-servers scenario from the issue).
- iOS `deleteAllData()` clears the new keys as well.
- The iOS fallback Base URL field now trims whitespace the same way the primary field does (a pasted trailing space would otherwise break requests and defeat the identical-config check).

Same change on both platforms, mirrored storage key and marker names (`fallbackCustomBaseURL_`, `fallbackBaseURLMigrationVersion`).

## Tests

- iOS: two new tests in `AIRequestConfigurationTests` — role separation including `currentFallbackConfig` resolution, and the seed-once migration (a deliberate clear survives the next launch).
- Android: `:app:testDebugUnitTest` and `:app:assembleDebug` pass locally. The repo has no test seam for `PreferencesStore` (no Robolectric/DataStore fixture), so the migration logic is covered by the mirrored iOS test.

## Manual verification (performed on an Android emulator, debug build)

1. Primary = Custom (OpenAI-compatible) with Base URL `http://server-a.test:1234/v1`; fallback enabled = Custom (OpenAI-compatible) with Base URL `http://server-b.test:5678/v1`.
2. The fallback Base URL editor opens empty after the primary URL is set — pre-fix it pre-filled the shared per-provider value.
3. After force-stop + relaunch, the primary editor shows `server-a` and the fallback editor shows `server-b` — pre-fix both loaded whichever was saved last (the exact #183 symptom).
4. A DataStore dump confirms two distinct entries (`customBaseURL_CUSTOM_OPENAI` = server-a, `fallbackCustomBaseURL_CUSTOM_OPENAI` = server-b) and the `fallbackBaseURLMigrationVersion` marker written on the first launch of the new build.

## Checklist

- [x] Android built, unit-tested, and smoke-tested on an emulator (see Manual verification)
- [ ] iOS build + simulator pass — needs a macOS machine (I develop on Windows); the logic is mirrored 1:1 from the Android change and covered by the new unit tests

## Note (out of scope)

API keys have the same per-provider-type aliasing (`apikey_<provider>` keychain entries / Android KeyStore): a primary and fallback of the same provider type share one key entry. Left out to keep this PR focused — happy to follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Fallback AI providers can use custom server URLs independently from primary provider settings on Android and iOS.
  - The same provider and model can be used for primary and fallback roles when connected to different servers.
  - Fallback model selection now accounts for whether primary and fallback configurations share the same server.

- **Bug Fixes**
  - Existing fallback endpoint settings migrate automatically during app startup.
  - Clearing fallback URLs is preserved correctly, including after migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR separates primary and fallback custom base URLs on Android and iOS, migrates legacy values, resolves fallback requests using the role-specific endpoint, and permits the same provider/model combination when it targets a different server.
- Adds role-scoped fallback URL persistence and one-time migrations on both platforms.
- Updates image, text, and chat fallback resolution and duplicate detection.
- Updates settings editors and model filtering to account for server identity.
- Adds iOS regression coverage for role separation and seed-once migration behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with one non-blocking Android settings responsiveness issue.

The fallback request paths now await migration, and both platforms allow identical provider/model choices when their resolved servers differ. The earlier settings-race finding is only partly fixed: model and Base URL sheets await migration, but Android provider-selection and URL-reconciliation actions can still read an unseeded fallback key before the asynchronous startup migration completes. The earlier Android request-path migration thread was manually resolved without explanation. The newly introduced synchronous DataStore work may stall settings composition but does not make the change unsafe to merge.

**Files Needing Attention:** android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/src/main/java/com/apoorvdarshan/calorietracker/data/PreferencesStore.kt | Adds mutex-protected fallback URL migration and role-specific DataStore accessors. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt | Uses role-specific fallback URLs for editing and filtering, but synchronously blocks composition on DataStore work. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModel.kt | Reconciles duplicate fallback models after provider and endpoint changes. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/FoodAnalysisService.kt | Awaits migration and includes the resolved endpoint when detecting duplicate fallback configurations. |
| ios/calorietracker/Models/AIProvider.swift | Adds role-specific fallback URL persistence, migration, cleanup, and request resolution. |
| ios/calorietracker/ContentView.swift | Updates fallback URL editors and model filtering to distinguish different servers. |
| ios/calorietrackerTests/AIRequestConfigurationTests.swift | Covers independent URL storage and one-time migration semantics. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Legacy customBaseURL_provider] --> M[One-time migration]
    M --> P[Primary customBaseURL_provider]
    M --> F[Fallback fallbackCustomBaseURL_provider]
    P --> D{Same provider, model, and URL?}
    F --> D
    D -->|Yes| X[Suppress duplicate fallback]
    D -->|No| R[Allow fallback request]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20apoorvdarshan%2Ffud-ai%20PR%20%23186%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=186&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fsettings%2FSettingsScreen.kt%3A2594-2607%0A**Settings%20Reads%20Block%20UI**%0A%0AOpening%20a%20fallback%20model%20or%20Base%20URL%20sheet%20now%20runs%20%60migrateFallbackBaseUrls%28%29%60%20and%20disk-backed%20DataStore%20%60first%28%29%60%20reads%20inside%20%60runBlocking%60%20during%20Compose%20rendering.%20On%20first%20launch%2C%20or%20while%20another%20migration%20holds%20the%20mutex%2C%20this%20blocks%20the%20main%20thread%20and%20can%20visibly%20freeze%20the%20settings%20UI.%20Load%20these%20values%20asynchronously%20or%20expose%20them%20through%20reactive%20ViewModel%20state%20instead.%20The%20same%20pattern%20also%20appears%20in%20the%20text%20fallback%20Base%20URL%2C%20image%20fallback%20model%2C%20and%20image%20fallback%20Base%20URL%20sheets.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=186&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22apoorvdarshan%2Ffud-ai%22%20on%20the%20existing%20branch%20%22fix%2Ffallback-base-url%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ffallback-base-url%22.%0A%0A%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fsettings%2FSettingsScreen.kt%3A2594-2607%0A**Settings%20Reads%20Block%20UI**%0A%0AOpening%20a%20fallback%20model%20or%20Base%20URL%20sheet%20now%20runs%20%60migrateFallbackBaseUrls%28%29%60%20and%20disk-backed%20DataStore%20%60first%28%29%60%20reads%20inside%20%60runBlocking%60%20during%20Compose%20rendering.%20On%20first%20launch%2C%20or%20while%20another%20migration%20holds%20the%20mutex%2C%20this%20blocks%20the%20main%20thread%20and%20can%20visibly%20freeze%20the%20settings%20UI.%20Load%20these%20values%20asynchronously%20or%20expose%20them%20through%20reactive%20ViewModel%20state%20instead.%20The%20same%20pattern%20also%20appears%20in%20the%20text%20fallback%20Base%20URL%2C%20image%20fallback%20model%2C%20and%20image%20fallback%20Base%20URL%20sheets.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=186&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fsettings%2FSettingsScreen.kt%3A2594-2607%0A**Settings%20Reads%20Block%20UI**%0A%0AOpening%20a%20fallback%20model%20or%20Base%20URL%20sheet%20now%20runs%20%60migrateFallbackBaseUrls%28%29%60%20and%20disk-backed%20DataStore%20%60first%28%29%60%20reads%20inside%20%60runBlocking%60%20during%20Compose%20rendering.%20On%20first%20launch%2C%20or%20while%20another%20migration%20holds%20the%20mutex%2C%20this%20blocks%20the%20main%20thread%20and%20can%20visibly%20freeze%20the%20settings%20UI.%20Load%20these%20values%20asynchronously%20or%20expose%20them%20through%20reactive%20ViewModel%20state%20instead.%20The%20same%20pattern%20also%20appears%20in%20the%20text%20fallback%20Base%20URL%2C%20image%20fallback%20model%2C%20and%20image%20fallback%20Base%20URL%20sheets.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=186&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt:2594-2607
**Settings Reads Block UI**

Opening a fallback model or Base URL sheet now runs `migrateFallbackBaseUrls()` and disk-backed DataStore `first()` reads inside `runBlocking` during Compose rendering. On first launch, or while another migration holds the mutex, this blocks the main thread and can visibly freeze the settings UI. Load these values asynchronously or expose them through reactive ViewModel state instead. The same pattern also appears in the text fallback Base URL, image fallback model, and image fallback Base URL sheets.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: rebase onto main and harden fallbac..."](https://github.com/apoorvdarshan/fud-ai/commit/e5d4e866fed1db81315b5373cd03d6d4943f4028) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62405136)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->