### PR TITLE
Retry nutrition writes Health Connect never confirmed

### DIFF
--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/FudAIApp.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/FudAIApp.kt
@@ -217,6 +217,12 @@ class AppContainer(app: FudAIApp) {
         if (healthReadSyncInFlight) return
         if (!prefs.healthConnectEnabled.first()) return
         if (!health.isAvailable()) return
+
+        // Nutrition writes Health Connect never confirmed retry here. Deliberately ahead of
+        // the read-capability guard below: a user who granted write but no reads still has a
+        // queue to drain, and returning early would strand it forever.
+        foodRepository.retryPendingHealthWrites()
+
         val caps = health.capabilities()
         val workoutBurnRead = health.hasActiveEnergyRead()
         if (!caps.weightRead && !caps.bodyFatRead && !caps.nutritionRead &&

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FoodRepository.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FoodRepository.kt
@@ -6,6 +6,7 @@ import com.apoorvdarshan.calorietracker.services.ReviewPrompter
 import com.apoorvdarshan.calorietracker.models.MealType
 import com.apoorvdarshan.calorietracker.services.FoodImageStore
 import com.apoorvdarshan.calorietracker.services.health.HealthConnectManager
+import com.apoorvdarshan.calorietracker.services.health.NutritionWriteGate
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -71,9 +72,7 @@ class FoodRepository(
     suspend fun addEntry(entry: FoodEntry) {
         val current = prefs.foodEntries.first()
         prefs.setFoodEntries(current + entry)
-        if (shouldSyncHealth()) {
-            health?.writeNutrition(entry)
-        }
+        healthRetry.sync(entry, isUpdate = false)
         // One-time organic review moment: the first successful food log (iOS parity).
         if (!prefs.reviewPromptedAfterFirstLog.first()) {
             prefs.setReviewPromptedAfterFirstLog(true)
@@ -88,12 +87,13 @@ class FoodRepository(
         val updated = current.toMutableList().also { it[index] = entry }
         prefs.setFoodEntries(updated)
         if (shouldSyncHealth()) {
-            health?.updateNutrition(entry)
+            healthRetry.sync(entry, isUpdate = true)
         } else {
             // Sync off: still clean up the stale HC record for this entry (iOS
             // parity, best-effort) so the restore path can't resurrect the
             // pre-edit version later.
             health?.deleteNutrition(entry.id)
+            healthRetry.forget(entry.id)
         }
     }
 
@@ -105,6 +105,8 @@ class FoodRepository(
         // Delete even when sync is off (iOS parity, best-effort) — a surviving
         // fudai-tagged record would resurrect through restoreFromHealthConnect.
         health?.deleteNutrition(entryId)
+        // Drop any queued write for this entry, or the next retry would re-create it.
+        healthRetry.forget(entryId)
     }
 
     suspend fun replaceAll(entries: List<FoodEntry>) {
@@ -127,7 +129,8 @@ class FoodRepository(
 
         if (shouldSyncHealth()) {
             removedIds.forEach { health?.deleteNutrition(it) }
-            changed.forEach { health?.updateNutrition(it) }
+            healthRetry.forgetAll(removedIds)
+            healthRetry.syncAll(changed, isUpdate = true)
         } else {
             // Prevent stale records written by an earlier sync-enabled session
             // from restoring pre-import values later.
@@ -203,9 +206,34 @@ class FoodRepository(
         if (seeded.isNotEmpty()) prefs.setFavoriteFoodEntries(seeded)
     }
 
+    /**
+     * Deferred retry for nutrition writes Health Connect never confirmed. The adapter keeps
+     * [HealthConnectManager] out of the retry's own type signature, matching how
+     * [WorkoutHealthSync] is supplied to [WorkoutRepository].
+     */
+    private val healthRetry = NutritionHealthRetry(
+        prefs,
+        health?.let { manager ->
+            object : NutritionHealthSync {
+                override suspend fun writeGate() = manager.nutritionWriteGate()
+                override suspend fun write(entry: FoodEntry) = manager.writeNutrition(entry)
+                override suspend fun update(entry: FoodEntry) = manager.updateNutrition(entry)
+            }
+        }
+    )
+
+    /** Re-attempt writes that were never confirmed. Called from the app-foreground sync. */
+    suspend fun retryPendingHealthWrites() = healthRetry.retryPending()
+
+    /**
+     * Whether the user has Health Connect sync switched on. Deliberately does not ask
+     * whether the nutrition-write permission is granted: that question is answered inside
+     * [NutritionHealthRetry] via [NutritionWriteGate], because a permission probe that
+     * fails must not be read as "no permission". Doing so here silently discarded writes.
+     */
     private suspend fun shouldSyncHealth(): Boolean {
-        val manager = health ?: return false
-        return prefs.healthConnectEnabled.first() && manager.hasNutritionWrite()
+        if (health == null) return false
+        return prefs.healthConnectEnabled.first()
     }
 
     /**

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/NutritionHealthRetry.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/NutritionHealthRetry.kt
@@ -1,0 +1,132 @@
+package com.apoorvdarshan.calorietracker.data
+
+import com.apoorvdarshan.calorietracker.models.FoodEntry
+import com.apoorvdarshan.calorietracker.services.health.NutritionWriteGate
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.UUID
+
+/**
+ * Health Connect as the food log needs it. Mirrors [WorkoutHealthSync] so the retry path
+ * can be exercised without a live Health Connect service.
+ */
+interface NutritionHealthSync {
+    suspend fun writeGate(): NutritionWriteGate
+    suspend fun write(entry: FoodEntry): Boolean
+
+    /**
+     * Delete-then-write on the entry's own clientRecordId. Used for every retry, so a
+     * second attempt cannot duplicate a record that did land after all — the delete
+     * targets that one entry, never the day or the whole log.
+     */
+    suspend fun update(entry: FoodEntry): Boolean
+}
+
+/** The slice of persistence the retry needs. Mirrors [WorkoutStateStore]. */
+interface NutritionSyncStore {
+    val foodEntries: Flow<List<FoodEntry>>
+    val healthConnectEnabled: Flow<Boolean>
+    val pendingNutritionHealthWrites: Flow<Set<String>>
+    suspend fun setPendingNutritionHealthWrites(ids: Set<String>)
+}
+
+/**
+ * Keeps food entries whose Health Connect write was never confirmed, and re-attempts them
+ * on the next foreground sync.
+ *
+ * Before this existed, `FoodRepository.addEntry` called `writeNutrition` and discarded the
+ * result, and the permission probe in front of it turned an unreachable Health Connect
+ * service into "no permission". Either path dropped the entry with no exception, no log
+ * and no retry: the food log kept it, Health Connect never heard about it, and nothing in
+ * the app knew the two had diverged. [WorkoutRepository] already defers and retries its
+ * burn writes this way; nutrition simply never got the same treatment.
+ */
+class NutritionHealthRetry(
+    private val store: NutritionSyncStore,
+    private val health: NutritionHealthSync?
+) {
+    private val mutex = Mutex()
+
+    /**
+     * Push [entry] to Health Connect, queueing it when the write is not confirmed.
+     *
+     * On [NutritionWriteGate.UNKNOWN] the write is attempted anyway. Health Connect
+     * enforces its own permissions, so the worst case is a rejection we then queue and
+     * resolve on the next pass — strictly better than assuming the answer and dropping
+     * the entry.
+     */
+    suspend fun sync(entry: FoodEntry, isUpdate: Boolean) = syncAll(listOf(entry), isUpdate)
+
+    /**
+     * Push several entries in one pass. A diary import can carry hundreds of changed
+     * entries, and resolving the gate per entry would mean one Health Connect IPC
+     * round-trip each, so the gate and the queue are resolved once for the batch.
+     */
+    suspend fun syncAll(entries: List<FoodEntry>, isUpdate: Boolean) {
+        val adapter = health ?: return
+        if (entries.isEmpty()) return
+        if (!store.healthConnectEnabled.first()) return
+        if (adapter.writeGate() == NutritionWriteGate.DENIED) return
+        val written = mutableSetOf<String>()
+        val failed = mutableSetOf<String>()
+        for (entry in entries) {
+            val ok = if (isUpdate) adapter.update(entry) else adapter.write(entry)
+            (if (ok) written else failed) += entry.id.toString()
+        }
+        updateQueue { (it - written) + failed }
+    }
+
+    /** Drop [id] from the queue — the write landed, or the entry no longer exists. */
+    suspend fun forget(id: UUID) = forgetAll(listOf(id))
+
+    /** Batch form of [forget], so an import does not rewrite the queue once per entry. */
+    suspend fun forgetAll(ids: Collection<UUID>) {
+        if (ids.isEmpty()) return
+        val keys = ids.mapTo(mutableSetOf()) { it.toString() }
+        updateQueue { it - keys }
+    }
+
+    /**
+     * Re-attempt every queued write. Called from the app-foreground Health Connect
+     * coordinator, alongside the workout deferred writes.
+     */
+    suspend fun retryPending() {
+        val adapter = health ?: return
+        mutex.withLock {
+            val pending = store.pendingNutritionHealthWrites.first()
+            if (pending.isEmpty()) return@withLock
+            if (!store.healthConnectEnabled.first()) return@withLock
+            when (adapter.writeGate()) {
+                // Still cannot reach the service. Keep the queue and try again on the next
+                // foreground — discarding it here is the exact bug this retry exists to fix.
+                NutritionWriteGate.UNKNOWN -> return@withLock
+                // Nutrition write was revoked. Nothing is retryable any more, and an
+                // unbounded queue would otherwise outlive the permission forever.
+                NutritionWriteGate.DENIED -> {
+                    store.setPendingNutritionHealthWrites(emptySet())
+                    return@withLock
+                }
+                NutritionWriteGate.ALLOWED -> Unit
+            }
+            val byId = store.foodEntries.first().associateBy { it.id.toString() }
+            val remaining = mutableSetOf<String>()
+            for (key in pending) {
+                // Deleted since it was queued: deleteEntry already removed the record.
+                val entry = byId[key] ?: continue
+                if (!adapter.update(entry)) remaining += key
+            }
+            if (remaining != pending) store.setPendingNutritionHealthWrites(remaining)
+        }
+    }
+
+    /** Read-modify-write of the queue under the lock, skipping a no-op store write. */
+    private suspend fun updateQueue(transform: (Set<String>) -> Set<String>) {
+        mutex.withLock {
+            val current = store.pendingNutritionHealthWrites.first()
+            val next = transform(current)
+            if (next != current) store.setPendingNutritionHealthWrites(next)
+        }
+    }
+}

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/PreferencesStore.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/PreferencesStore.kt
@@ -54,7 +54,7 @@ private data class HealthEnergyGoalTargetSnapshot(
  * functions for writes. Complex values (profile, entries, history) are stored
  * as JSON strings via kotlinx.serialization.
  */
-class PreferencesStore(private val context: Context) : WorkoutStateStore {
+class PreferencesStore(private val context: Context) : WorkoutStateStore, NutritionSyncStore {
 
     private val json = Json { ignoreUnknownKeys = true }
     private val ds get() = context.fudaiDataStore
@@ -168,7 +168,7 @@ class PreferencesStore(private val context: Context) : WorkoutStateStore {
     suspend fun setLastNotifiedUpdateVersion(v: String) { ds.edit { it[Keys.LAST_NOTIFIED_UPDATE_VERSION] = v } }
 
     // -- Health Connect ---------------------------------------------------
-    val healthConnectEnabled: Flow<Boolean> = ds.data.map { it[Keys.HEALTH_CONNECT_ENABLED] ?: false }
+    override val healthConnectEnabled: Flow<Boolean> = ds.data.map { it[Keys.HEALTH_CONNECT_ENABLED] ?: false }
     suspend fun setHealthConnectEnabled(v: Boolean) { ds.edit { it[Keys.HEALTH_CONNECT_ENABLED] = v } }
 
     val healthPermissionsVersion: Flow<Int> = ds.data.map { it[Keys.HEALTH_TYPES_VERSION] ?: 0 }
@@ -197,6 +197,17 @@ class PreferencesStore(private val context: Context) : WorkoutStateStore {
     /// the restore should be allowed to run again.
     val healthFoodRestoreDone: Flow<Boolean> = ds.data.map { it[Keys.HEALTH_FOOD_RESTORE_DONE] ?: false }
     suspend fun setHealthFoodRestoreDone(v: Boolean) { ds.edit { it[Keys.HEALTH_FOOD_RESTORE_DONE] = v } }
+
+    /// Food entries whose Health Connect write was never confirmed, retried on the next
+    /// foreground sync. Comma-joined UUIDs, matching [healthChangesTokenTypes] — UUIDs
+    /// cannot contain a comma, so the encoding is unambiguous.
+    override val pendingNutritionHealthWrites: Flow<Set<String>> = ds.data.map {
+        it[Keys.PENDING_NUTRITION_HEALTH_WRITES]?.split(",")?.filter { s -> s.isNotBlank() }?.toSet()
+            ?: emptySet()
+    }
+    override suspend fun setPendingNutritionHealthWrites(ids: Set<String>) {
+        ds.edit { it[Keys.PENDING_NUTRITION_HEALTH_WRITES] = ids.joinToString(",") }
+    }
 
     val healthEnergyGoalsEnabled: Flow<Boolean> = ds.data.map { it[Keys.HEALTH_ENERGY_GOALS_ENABLED] ?: false }
     suspend fun setHealthEnergyGoalsEnabled(v: Boolean) { ds.edit { it[Keys.HEALTH_ENERGY_GOALS_ENABLED] = v } }
@@ -536,7 +547,7 @@ class PreferencesStore(private val context: Context) : WorkoutStateStore {
     }
 
     // -- Food entries -----------------------------------------------------
-    val foodEntries: Flow<List<FoodEntry>> = ds.data.map { prefs ->
+    override val foodEntries: Flow<List<FoodEntry>> = ds.data.map { prefs ->
         prefs[Keys.FOOD_ENTRIES]?.let {
             runCatching { json.decodeFromString(ListSerializer(FoodEntry.serializer()), it) }.getOrNull()
         } ?: emptyList()
@@ -715,6 +726,7 @@ class PreferencesStore(private val context: Context) : WorkoutStateStore {
         val HEALTH_CHANGES_TOKEN = stringPreferencesKey("healthChangesToken")
         val HEALTH_CHANGES_TOKEN_TYPES = stringPreferencesKey("healthChangesTokenTypes")
         val HEALTH_FOOD_RESTORE_DONE = booleanPreferencesKey("healthFoodRestoreDone")
+        val PENDING_NUTRITION_HEALTH_WRITES = stringPreferencesKey("pendingNutritionHealthWrites")
         val HEALTH_ENERGY_GOALS_ENABLED = booleanPreferencesKey("healthEnergyGoalsEnabled")
         val HEALTH_ENERGY_GOALS_PREVIOUS_TARGETS = stringPreferencesKey("healthEnergyGoalsPreviousTargets")
         val HEALTH_ENERGY_GOALS_LAST_AUTO_REFRESH_DAY = stringPreferencesKey("healthEnergyGoalsLastAutoRefreshDay")

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/health/HealthConnectManager.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/health/HealthConnectManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.UserManager
+import android.util.Log
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.PermissionController
 import androidx.health.connect.client.changes.UpsertionChange
@@ -53,6 +54,17 @@ enum class HealthConnectAvailability {
     PROFILE_UNSUPPORTED,
     PROVIDER_UPDATE_REQUIRED,
     UNAVAILABLE
+}
+
+/**
+ * Whether a nutrition write is permitted. [UNKNOWN] is deliberately distinct from [DENIED]:
+ * it means the permission probe failed, not that the user said no. Treating the two the same
+ * is what lets a transient Health Connect outage discard a food entry silently.
+ */
+enum class NutritionWriteGate {
+    ALLOWED,
+    DENIED,
+    UNKNOWN
 }
 
 internal fun resolveHealthConnectAvailability(
@@ -116,8 +128,34 @@ class HealthConnectManager(private val context: Context) {
      *  avoids asking every Health Connect user for background access. */
     val dailySummaryPermissions: Set<String> = permissions + backgroundRead
 
-    private suspend fun granted(): Set<String> =
-        runCatching { client?.permissionController?.getGrantedPermissions() }.getOrNull() ?: emptySet()
+    /**
+     * Granted permissions, or null when the permission probe itself failed.
+     *
+     * Health Connect answers over IPC, and the service can be mid-update, cold-starting,
+     * or binder-timing-out — each of which throws here. Collapsing that into "nothing is
+     * granted" makes a transient outage indistinguishable from a permission the user
+     * actually revoked. That distinction matters on the write path: a revoked permission
+     * means there is nothing to do, while a failed probe means we do not yet know, and
+     * dropping the write is data loss the user never sees.
+     */
+    private suspend fun grantedOrNull(): Set<String>? =
+        runCatching { client?.permissionController?.getGrantedPermissions() }
+            .onFailure { Log.w(TAG, "Health Connect permission probe failed", it) }
+            .getOrNull()
+
+    /** Fail-closed view of [grantedOrNull] for the read paths, where "assume nothing is
+     *  granted" is the safe answer — a read that returns nothing loses no data. */
+    private suspend fun granted(): Set<String> = grantedOrNull() ?: emptySet()
+
+    /**
+     * Whether a nutrition write may proceed. [NutritionWriteGate.UNKNOWN] means the
+     * permission probe failed, not that permission is missing — callers should attempt
+     * the write anyway and treat a failure as retryable rather than skipping silently.
+     */
+    suspend fun nutritionWriteGate(): NutritionWriteGate = when (val g = grantedOrNull()) {
+        null -> NutritionWriteGate.UNKNOWN
+        else -> if (nutritionWrite in g) NutritionWriteGate.ALLOWED else NutritionWriteGate.DENIED
+    }
 
     /** The "connected" state: at least one Fud AI permission granted. Partial grants
      *  are valid — a read-only user still syncs the read direction. */
@@ -128,6 +166,8 @@ class HealthConnectManager(private val context: Context) {
     suspend fun hasBodyFatRead(): Boolean = bodyFatRead in granted()
     suspend fun hasBodyFatWrite(): Boolean = bodyFatWrite in granted()
     suspend fun hasNutritionRead(): Boolean = nutritionRead in granted()
+    /** Fail-closed, like its siblings. Do NOT gate a nutrition write on this: a failed
+     *  probe reads as false here, which is how writes went missing. Use [nutritionWriteGate]. */
     suspend fun hasNutritionWrite(): Boolean = nutritionWrite in granted()
     suspend fun hasActiveEnergyRead(): Boolean = activeEnergyRead in granted()
     suspend fun hasActiveEnergyWrite(): Boolean = activeEnergyWrite in granted()
@@ -334,6 +374,8 @@ class HealthConnectManager(private val context: Context) {
                 metadata = Metadata.manualEntry(clientRecordId = tag(entry.id))
             )
             c.insertRecords(listOf(record))
+        }.onFailure {
+            Log.w(TAG, "Nutrition write failed for entry ${entry.id}; queued for retry", it)
         }.isSuccess
     }
 
@@ -705,6 +747,7 @@ class HealthConnectManager(private val context: Context) {
     }
 
     companion object {
+        private const val TAG = "HealthConnectManager"
         private const val ACTION_MANAGE_HEALTH_PERMISSIONS =
             "android.health.connect.action.MANAGE_HEALTH_PERMISSIONS"
         private const val CLIENT_PREFIX = "fudai_"

--- a/android/app/src/test/java/com/apoorvdarshan/calorietracker/data/NutritionHealthRetryTest.kt
+++ b/android/app/src/test/java/com/apoorvdarshan/calorietracker/data/NutritionHealthRetryTest.kt
@@ -1,0 +1,200 @@
+package com.apoorvdarshan.calorietracker.data
+
+import com.apoorvdarshan.calorietracker.models.FoodEntry
+import com.apoorvdarshan.calorietracker.models.FoodSource
+import com.apoorvdarshan.calorietracker.services.health.NutritionWriteGate
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+import java.util.UUID
+
+class NutritionHealthRetryTest {
+
+    @Test
+    fun failedWriteIsQueuedAndRetriedAsAnIdempotentUpdate() = runBlocking {
+        val entry = foodEntry("Spaghetti Bolognese")
+        val store = FakeNutritionSyncStore(entries = listOf(entry))
+        val health = FakeNutritionHealthSync(writeSucceeds = false)
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.sync(entry, isUpdate = false)
+        assertEquals(setOf(entry.id.toString()), store.pending.value)
+
+        health.writeSucceeds = true
+        retry.retryPending()
+
+        // Retries go through update (delete-then-write on the entry's own clientRecordId),
+        // so a record that did land after all cannot end up duplicated.
+        assertEquals(listOf(entry.id), health.updated)
+        assertTrue(store.pending.value.isEmpty())
+    }
+
+    @Test
+    fun probeFailureDoesNotDiscardTheWrite() = runBlocking {
+        val entry = foodEntry("Svinemorbrad")
+        val store = FakeNutritionSyncStore(entries = listOf(entry))
+        // The regression: an unreachable Health Connect used to read as "no permission".
+        val health = FakeNutritionHealthSync(gate = NutritionWriteGate.UNKNOWN, writeSucceeds = false)
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.sync(entry, isUpdate = false)
+
+        assertEquals(1, health.writes.size) // attempted rather than skipped
+        assertEquals(setOf(entry.id.toString()), store.pending.value)
+    }
+
+    @Test
+    fun probeStillFailingKeepsTheQueueIntact() = runBlocking {
+        val entry = foodEntry("Wasa Sport")
+        val store = FakeNutritionSyncStore(
+            entries = listOf(entry),
+            pending = setOf(entry.id.toString())
+        )
+        val health = FakeNutritionHealthSync(gate = NutritionWriteGate.UNKNOWN)
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.retryPending()
+
+        assertTrue(health.updated.isEmpty())
+        assertEquals(setOf(entry.id.toString()), store.pending.value)
+    }
+
+    @Test
+    fun revokedPermissionClearsTheQueueInsteadOfRetryingForever() = runBlocking {
+        val entry = foodEntry("Kaffe")
+        val store = FakeNutritionSyncStore(
+            entries = listOf(entry),
+            pending = setOf(entry.id.toString())
+        )
+        val health = FakeNutritionHealthSync(gate = NutritionWriteGate.DENIED)
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.retryPending()
+
+        assertTrue(health.updated.isEmpty())
+        assertTrue(store.pending.value.isEmpty())
+    }
+
+    @Test
+    fun deletedEntryIsDroppedFromTheQueueRatherThanRecreated() = runBlocking {
+        val gone = UUID.randomUUID()
+        val kept = foodEntry("Skyr")
+        val store = FakeNutritionSyncStore(
+            entries = listOf(kept),
+            pending = setOf(gone.toString(), kept.id.toString())
+        )
+        val health = FakeNutritionHealthSync()
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.retryPending()
+
+        assertEquals(listOf(kept.id), health.updated)
+        assertTrue(store.pending.value.isEmpty())
+    }
+
+    @Test
+    fun syncIsANoOpWhileHealthConnectIsSwitchedOff() = runBlocking {
+        val entry = foodEntry("Havregryn")
+        val store = FakeNutritionSyncStore(entries = listOf(entry), enabled = false)
+        val health = FakeNutritionHealthSync(writeSucceeds = false)
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.sync(entry, isUpdate = false)
+
+        assertTrue(health.writes.isEmpty())
+        assertTrue(store.pending.value.isEmpty())
+    }
+
+    @Test
+    fun successfulWriteLeavesNothingQueued() = runBlocking {
+        val entry = foodEntry("Chia")
+        val store = FakeNutritionSyncStore(entries = listOf(entry), pending = setOf(entry.id.toString()))
+        val health = FakeNutritionHealthSync()
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.sync(entry, isUpdate = false)
+
+        assertEquals(listOf(entry.id), health.writes)
+        assertTrue(store.pending.value.isEmpty())
+    }
+
+    @Test
+    fun batchResolvesTheGateOncePerCallNotOncePerEntry() = runBlocking {
+        // A diary import can carry hundreds of entries. writeGate() is a Health Connect IPC
+        // round-trip, so probing per entry would put the import on the wire hundreds of times.
+        val entries = (1..50).map { foodEntry("Meal $it") }
+        val store = FakeNutritionSyncStore(entries = entries)
+        val health = FakeNutritionHealthSync()
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.syncAll(entries, isUpdate = true)
+
+        assertEquals(1, health.gateProbes)
+        assertEquals(50, health.updated.size)
+    }
+
+    @Test
+    fun batchQueuesOnlyTheEntriesThatFailed() = runBlocking {
+        val ok = foodEntry("Skyr")
+        val bad = foodEntry("Spaghetti Bolognese")
+        val store = FakeNutritionSyncStore(entries = listOf(ok, bad))
+        val health = FakeNutritionHealthSync(failFor = setOf(bad.id))
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.syncAll(listOf(ok, bad), isUpdate = false)
+
+        assertEquals(setOf(bad.id.toString()), store.pending.value)
+    }
+
+    private fun foodEntry(name: String) = FoodEntry(
+        name = name,
+        calories = 315,
+        protein = 18.0,
+        carbs = 40.0,
+        fat = 9.0,
+        timestamp = Instant.parse("2026-08-27T17:54:00Z"),
+        source = FoodSource.SNAP_FOOD
+    )
+}
+
+private class FakeNutritionSyncStore(
+    entries: List<FoodEntry> = emptyList(),
+    pending: Set<String> = emptySet(),
+    enabled: Boolean = true
+) : NutritionSyncStore {
+    val pending = MutableStateFlow(pending)
+    override val foodEntries: Flow<List<FoodEntry>> = MutableStateFlow(entries)
+    override val healthConnectEnabled: Flow<Boolean> = MutableStateFlow(enabled)
+    override val pendingNutritionHealthWrites: Flow<Set<String>> = this.pending
+    override suspend fun setPendingNutritionHealthWrites(ids: Set<String>) { pending.value = ids }
+}
+
+private class FakeNutritionHealthSync(
+    private val gate: NutritionWriteGate = NutritionWriteGate.ALLOWED,
+    var writeSucceeds: Boolean = true,
+    private val failFor: Set<UUID> = emptySet()
+) : NutritionHealthSync {
+    val writes = mutableListOf<UUID>()
+    val updated = mutableListOf<UUID>()
+    var gateProbes = 0
+        private set
+
+    override suspend fun writeGate(): NutritionWriteGate {
+        gateProbes++
+        return gate
+    }
+    override suspend fun write(entry: FoodEntry): Boolean {
+        writes += entry.id
+        return succeeds(entry)
+    }
+    override suspend fun update(entry: FoodEntry): Boolean {
+        updated += entry.id
+        return succeeds(entry)
+    }
+
+    private fun succeeds(entry: FoodEntry) = writeSucceeds && entry.id !in failFor
+}


### PR DESCRIPTION
## Why

Food entries can disappear on the way to Health Connect, with no exception, no log
and no retry. The food log keeps them, Health Connect never hears about them, and
nothing in the app knows the two have diverged. The user only finds out by comparing
two screens.

I hit this on my own diary: 73 entries over 66 days never reached Health Connect. The
one I traced end to end was a 515 kcal dinner — Fud AI showed 2205 kcal for the day,
everything downstream of Health Connect showed 1690. Re-editing the entry in Fud AI
pushed it through, which is what pointed at the write path rather than the data.

There are two independent ways an entry is dropped today.

**1. A failed permission probe reads as "no permission".**

```kotlin
private suspend fun granted(): Set<String> =
    runCatching { client?.permissionController?.getGrantedPermissions() }
        .getOrNull() ?: emptySet()
```

`getGrantedPermissions()` is IPC. The service can be mid-update, cold-starting or
binder-timing-out, and each of those throws. The result is an empty set, so
`hasNutritionWrite()` is false, so `shouldSyncHealth()` is false, and `addEntry`
skips the write **entirely** — `writeNutrition` is never called. A transient outage
is indistinguishable from a permission the user revoked.

**2. The write result is discarded.**

```kotlin
if (shouldSyncHealth()) {
    health?.writeNutrition(entry)   // Boolean dropped
}
```

`writeNutrition` already returns a Boolean and already swallows the exception with
`runCatching { … }.isSuccess`. Nothing reads it.

This may also be what's behind #43 ("connected and not connected simultaneously;
permissions set but no writes"), which was closed without a linked fix.

## What

Nutrition writes now get the deferred-retry treatment `WorkoutRepository` already
gives workout burns — same shape, same drain point, no new mechanism:

- `granted()` splits into `grantedOrNull()` (null = probe failed) and the existing
  fail-closed `granted()`. Read paths are unchanged; failing closed is right there,
  because a read that returns nothing loses nothing.
- New `nutritionWriteGate()` returns `ALLOWED` / `DENIED` / `UNKNOWN`. On `UNKNOWN`
  the write is attempted anyway — Health Connect enforces its own permissions, so
  the worst case is a rejection we queue and resolve on the next pass. That is
  strictly better than guessing and dropping the entry.
- `NutritionHealthRetry` queues any write that is not confirmed, in DataStore, and
  re-attempts it from `syncHealthConnectReads()` alongside the workout retries.
- Retries go through `updateNutrition` (delete-then-write on that entry's own
  `clientRecordId`), so a retry cannot duplicate a record that did land after all.
- The queue is bounded by reality rather than a counter: entries deleted meanwhile
  are dropped, and a genuinely revoked permission clears it instead of retrying
  forever.
- `writeNutrition` failures are now logged.

`NutritionHealthSync` / `NutritionSyncStore` mirror `WorkoutHealthSync` /
`WorkoutStateStore` so the retry is unit-testable without a live Health Connect
service. No user-facing strings, so no localization changes.

## Testing

**Unit:** 9 new tests in `NutritionHealthRetryTest` — the queue, the probe-failure
regression, a still-failing probe, revoked permission, deleted entries, sync switched
off, the success path, and two for the batch path. Full suite: 102 tests, 0 failures.

**Device** (Samsung, One UI, Android 16), debug build installed side by side with the
Play Store app via the existing `.debug` suffix:

1. Granted **only** `WRITE_NUTRITION` — no read permissions — so the gate resolves
   `ALLOWED` and the food-log restore stays out of the way.
2. Imported a three-entry diary, which runs `replaceFromImport` → `syncAll`.
3. All three records appeared in Health Connect with the right values.
4. `pendingNutritionHealthWrites` was **absent** from DataStore afterwards, which is
   the correct end state: every write was confirmed, so the queue transform was a
   no-op and never hit the store.
5. Deleting the entries removed them from Health Connect and left nothing queued.

## Deliberately not in this PR

- **The queue is unbounded.** It matches `pendingHealthUpsertIds` in `WorkoutRepository`,
  and it drains or clears on every foreground pass, but a permanently unreachable
  Health Connect would let it grow. Happy to add a bound if you want one.
- **`Clear Food Log` and `Delete All Data` leave Health Connect records behind.**
  `FoodRepository.clear()` and `prefs.clearAll()` never call `deleteNutrition`, so
  fudai-tagged records survive a local wipe and `restoreFromHealthConnect` can bring
  them back. iOS deliberately does the opposite — `deleteNutrition` there bypasses the
  enabled flag so samples don't "stick around in Health forever". Looks like a real
  parity gap, but it is a different bug and I left it alone.

## iOS

`HealthKitManager.writeNutrition` has the same discarded result:

```swift
healthStore.save(samples) { _, _ in }
```

The permission half does not apply — `authorizationStatus(for:)` is a local call, not
IPC, so it cannot fail the way the Android probe does. I have left iOS alone rather
than send Swift I cannot build or test; happy to follow up if you want it matched.