### PR TITLE
Combine diary items into a meal

### DIFF
--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FoodRepository.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FoodRepository.kt
@@ -2,6 +2,7 @@ package com.apoorvdarshan.calorietracker.data
 
 import com.apoorvdarshan.calorietracker.models.FoodEntry
 import com.apoorvdarshan.calorietracker.models.FoodSource
+import com.apoorvdarshan.calorietracker.models.combineFoodEntries
 import com.apoorvdarshan.calorietracker.services.ReviewPrompter
 import com.apoorvdarshan.calorietracker.models.MealType
 import com.apoorvdarshan.calorietracker.services.FoodImageStore
@@ -107,6 +108,29 @@ class FoodRepository(
         // Delete even when sync is off (iOS parity, best-effort) — a surviving
         // fudai-tagged record would resurrect through restoreFromHealthConnect.
         health?.deleteNutrition(entryId)
+    }
+
+    /**
+     * Merge selected diary foods into one combined meal entry and remove the
+     * originals so macros are not double-counted.
+     */
+    suspend fun combineIntoMeal(entryIds: Collection<UUID>): FoodEntry? {
+        if (prefs.fastingSessions.first().any { it.isActive }) return null
+        ensureFavoritesMigrated()
+        val idSet = entryIds.toSet()
+        if (idSet.size < 2) return null
+        val current = prefs.foodEntries.first()
+        val selected = current.filter { it.id in idSet }
+        if (selected.size < 2) return null
+        val combined = combineFoodEntries(selected)
+        val remaining = current.filter { it.id !in idSet }
+        prefs.setFoodEntries(remaining + combined)
+        pruneOrphanedImages()
+        selected.forEach { health?.deleteNutrition(it.id) }
+        if (shouldSyncHealth()) {
+            health?.writeNutrition(combined)
+        }
+        return combined
     }
 
     suspend fun replaceAll(entries: List<FoodEntry>) {

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/models/CombinedMeal.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/models/CombinedMeal.kt
@@ -1,0 +1,71 @@
+package com.apoorvdarshan.calorietracker.models
+
+import com.apoorvdarshan.calorietracker.services.ai.FoodAnalysis
+import java.util.UUID
+
+/** Map a diary food to one ingredient line (nested ingredients stay collapsed). */
+fun FoodEntry.toMealIngredient(): MealIngredient = MealIngredient(
+    name = name,
+    grams = servingSizeGrams?.takeIf { it.isFinite() && it > 0.0 } ?: 0.0,
+    calories = calories,
+    protein = protein,
+    carbs = carbs,
+    fat = fat
+)
+
+/** Map an analysis result to one ingredient line (nested ingredients stay collapsed). */
+fun FoodAnalysis.toMealIngredient(): MealIngredient = MealIngredient(
+    name = name,
+    grams = servingSizeGrams.takeIf { it.isFinite() && it > 0.0 } ?: 0.0,
+    calories = calories,
+    protein = protein,
+    carbs = carbs,
+    fat = fat
+)
+
+/** Recompute parent macros from an ingredient list. */
+fun FoodEntry.withIngredients(ingredients: List<MealIngredient>): FoodEntry {
+    val totals = ingredients.totals()
+    return copy(
+        calories = totals.calories,
+        protein = totals.protein,
+        carbs = totals.carbs,
+        fat = totals.fat,
+        servingSizeGrams = totals.grams.takeIf { it > 0 } ?: servingSizeGrams,
+        servingUnitOptions = emptyList(),
+        selectedServingUnit = null,
+        selectedServingQuantity = null,
+        ingredients = ingredients
+    )
+}
+
+object CombinedMeal {
+    fun combinedName(entries: List<FoodEntry>): String {
+        val names = entries.map { it.name.trim() }.filter { it.isNotEmpty() }
+        if (names.isEmpty()) return "Combined meal"
+        if (names.size <= 3) return names.joinToString(" + ")
+        return names.take(2).joinToString(" + ") + " + ${names.size - 2} more"
+    }
+
+    fun combineFoodEntries(entries: List<FoodEntry>): FoodEntry {
+        require(entries.size >= 2) { "Combine requires at least two food entries" }
+        val ingredients = entries.map { it.toMealIngredient() }
+        val totals = ingredients.totals()
+        val latest = entries.maxByOrNull { it.timestamp } ?: entries.first()
+        return FoodEntry(
+            id = UUID.randomUUID(),
+            name = combinedName(entries),
+            calories = totals.calories,
+            protein = totals.protein,
+            carbs = totals.carbs,
+            fat = totals.fat,
+            timestamp = latest.timestamp,
+            source = FoodSource.MANUAL,
+            mealType = latest.mealType,
+            servingSizeGrams = totals.grams.takeIf { it > 0 },
+            ingredients = ingredients
+        )
+    }
+}
+
+fun combineFoodEntries(entries: List<FoodEntry>): FoodEntry = CombinedMeal.combineFoodEntries(entries)

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/EditFoodEntrySheet.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/EditFoodEntrySheet.kt
@@ -100,6 +100,10 @@ fun EditFoodEntrySheet(
     entry: FoodEntry,
     preferGramsByDefault: Boolean = false,
     isFavorite: Boolean,
+    container: com.apoorvdarshan.calorietracker.AppContainer,
+    analyzeIngredientText: suspend (String) -> FoodAnalysis,
+    lookupIngredientBarcode: suspend (String) -> FoodAnalysis,
+    analyzeIngredientImage: suspend (ByteArray) -> FoodAnalysis,
     onReprocess: suspend (updatedNote: String) -> FoodAnalysis,
     onSave: (FoodEntry) -> Unit,
     onToggleFavorite: () -> Unit,
@@ -496,10 +500,21 @@ fun EditFoodEntrySheet(
                     onEdit = { index ->
                         ingredientEditor = IngredientEditorTarget(index, scaledIngredients()[index])
                     },
-                    onAdd = {
-                        ingredientEditor = IngredientEditorTarget(
-                            null,
-                            MealIngredient("", 100.0, 0, 0.0, 0.0, 0.0)
+                    addMenu = {
+                        IngredientIntakeSection(
+                            container = container,
+                            analyzeText = analyzeIngredientText,
+                            lookupBarcode = lookupIngredientBarcode,
+                            analyzeImage = analyzeIngredientImage,
+                            onIngredient = { ingredient ->
+                                applyIngredientChanges(scaledIngredients() + ingredient)
+                            },
+                            onManual = {
+                                ingredientEditor = IngredientEditorTarget(
+                                    null,
+                                    MealIngredient("", 100.0, 0, 0.0, 0.0, 0.0)
+                                )
+                            }
                         )
                     }
                 )

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodResultSheet.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodResultSheet.kt
@@ -88,6 +88,10 @@ fun FoodResultSheet(
     dayEntries: List<FoodEntry> = emptyList(),
     source: FoodSource = FoodSource.TEXT_INPUT,
     isSubmitting: Boolean = false,
+    container: com.apoorvdarshan.calorietracker.AppContainer,
+    analyzeIngredientText: suspend (String) -> FoodAnalysis,
+    lookupIngredientBarcode: suspend (String) -> FoodAnalysis,
+    analyzeIngredientImage: suspend (ByteArray) -> FoodAnalysis,
     onWhatIfSuggestion: (suspend (FoodEntry) -> String)? = null,
     onSave: (
         name: String,
@@ -500,10 +504,21 @@ fun FoodResultSheet(
                     onEdit = { index ->
                         ingredientEditor = IngredientEditorTarget(index, scaledIngredients()[index])
                     },
-                    onAdd = {
-                        ingredientEditor = IngredientEditorTarget(
-                            null,
-                            MealIngredient("", 100.0, 0, 0.0, 0.0, 0.0)
+                    addMenu = {
+                        IngredientIntakeSection(
+                            container = container,
+                            analyzeText = analyzeIngredientText,
+                            lookupBarcode = lookupIngredientBarcode,
+                            analyzeImage = analyzeIngredientImage,
+                            onIngredient = { ingredient ->
+                                applyIngredientChanges(scaledIngredients() + ingredient)
+                            },
+                            onManual = {
+                                ingredientEditor = IngredientEditorTarget(
+                                    null,
+                                    MealIngredient("", 100.0, 0, 0.0, 0.0, 0.0)
+                                )
+                            }
                         )
                     }
                 )

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
@@ -18,8 +18,15 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.activity.compose.BackHandler
 import androidx.compose.material.icons.filled.IosShare
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.outlined.Circle
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import java.util.UUID
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -208,6 +215,8 @@ fun HomeScreen(
     var addMenuGroup by remember { mutableStateOf<AddMenuGroup?>(null) }
     var showSortMenu by remember { mutableStateOf(false) }
     var editingEntry by remember { mutableStateOf<FoodEntry?>(null) }
+    var selectedFoodIds by remember { mutableStateOf<Set<UUID>>(emptySet()) }
+    val selectionMode = selectedFoodIds.isNotEmpty()
     var showNutritionDetail by remember { mutableStateOf(false) }
     var showCustomWaterLog by remember { mutableStateOf(false) }
     var showFastingStart by remember { mutableStateOf(false) }
@@ -329,6 +338,10 @@ fun HomeScreen(
             }
         }
         onQuickActionHandled(request.id)
+    }
+
+    BackHandler(enabled = selectionMode) {
+        selectedFoodIds = emptySet()
     }
 
     val today = LocalDate.now()
@@ -495,13 +508,30 @@ fun HomeScreen(
                                 is HomeDiaryItem.Food -> {
                                     val entry = item.entry
                                     // Tap row -> open EditFoodEntrySheet (matches iOS .onTapGesture).
-                                    // Swipe trailing edge -> delete; swipe leading edge -> toggle favorite.
+                                    // Long-press -> multi-select combine. Swipe trailing -> delete;
+                                    // swipe leading -> toggle favorite (disabled while selecting).
                                     val isFav = ui.isFavorite(entry)
+                                    val isSelected = entry.id in selectedFoodIds
                                     SwipeableFoodRow(
                                         entry = entry,
                                         isFavorite = isFav,
                                         rowShape = rowShape,
-                                        onTap = { editingEntry = entry },
+                                        selectionMode = selectionMode,
+                                        selected = isSelected,
+                                        onTap = {
+                                            if (selectionMode) {
+                                                selectedFoodIds = if (isSelected) {
+                                                    selectedFoodIds - entry.id
+                                                } else {
+                                                    selectedFoodIds + entry.id
+                                                }
+                                            } else {
+                                                editingEntry = entry
+                                            }
+                                        },
+                                        onLongPress = {
+                                            selectedFoodIds = selectedFoodIds + entry.id
+                                        },
                                         onDelete = { vm.deleteEntry(entry.id) },
                                         onToggleFavorite = { vm.toggleFavorite(entry) }
                                     )
@@ -534,6 +564,52 @@ fun HomeScreen(
         // bottom nav bar. The parent Scaffold renders content full-screen behind the
         // bar, so the Scaffold FAB slot would sit hidden underneath it. Mirrors the iOS
         // ContentView FAB: .overlay(alignment: .bottomTrailing) + .padding(.bottom).
+        if (selectionMode) {
+            Row(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .navigationBarsPadding()
+                    .padding(start = 16.dp, end = 16.dp, bottom = 100.dp)
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(18.dp))
+                    .background(MaterialTheme.colorScheme.surface)
+                    .border(1.dp, MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f), RoundedCornerShape(18.dp))
+                    .padding(horizontal = 14.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Icon(
+                    Icons.Filled.Close,
+                    contentDescription = stringResource(R.string.action_cancel),
+                    modifier = Modifier
+                        .size(28.dp)
+                        .clickable { selectedFoodIds = emptySet() },
+                    tint = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    stringResource(R.string.combine_selected_count, selectedFoodIds.size),
+                    modifier = Modifier.weight(1f),
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 16.sp
+                )
+                Text(
+                    stringResource(R.string.combine_into_meal),
+                    color = if (selectedFoodIds.size >= 2) AppColors.Calorie
+                    else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f),
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 16.sp,
+                    modifier = Modifier.clickable(enabled = selectedFoodIds.size >= 2) {
+                        val ids = selectedFoodIds
+                        vm.combineIntoMeal(ids) { combined ->
+                            selectedFoodIds = emptySet()
+                            if (combined != null) {
+                                editingEntry = combined
+                            }
+                        }
+                    }
+                )
+            }
+        } else {
         Box(
             modifier = Modifier
                 .align(Alignment.BottomEnd)
@@ -641,6 +717,7 @@ fun HomeScreen(
                     }
                 }
             }
+        }
         }
         }
     }
@@ -795,6 +872,10 @@ fun HomeScreen(
             entry = entry,
             preferGramsByDefault = ui.preferGramsByDefault,
             isFavorite = ui.isFavorite(entry),
+            container = container,
+            analyzeIngredientText = vm::analyzeIngredientText,
+            lookupIngredientBarcode = vm::lookupIngredientBarcode,
+            analyzeIngredientImage = vm::analyzeIngredientImage,
             onReprocess = { updatedNote ->
                 vm.reprocessFoodEntry(entry, updatedNote)
             },
@@ -835,6 +916,10 @@ fun HomeScreen(
             profile = ui.profile,
             dayEntries = ui.todayEntries,
             isSubmitting = ui.foodSaveInProgress,
+            container = container,
+            analyzeIngredientText = vm::analyzeIngredientText,
+            lookupIngredientBarcode = vm::lookupIngredientBarcode,
+            analyzeIngredientImage = vm::analyzeIngredientImage,
             source = ui.pendingReviewSource?.source
                 ?: ui.pendingFoodSource
                 ?: if (ui.pendingImageBytes != null) FoodSource.SNAP_FOOD else FoodSource.TEXT_INPUT,
@@ -1820,12 +1905,16 @@ private fun Divider() {
  * The dismiss state is reset on a no-confirm swing-back so partial swipes don't
  * leave the row stuck mid-flight when the user releases short of the threshold.
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun SwipeableFoodRow(
     entry: FoodEntry,
     isFavorite: Boolean,
     rowShape: RoundedCornerShape,
+    selectionMode: Boolean = false,
+    selected: Boolean = false,
     onTap: () -> Unit,
+    onLongPress: () -> Unit = {},
     onDelete: () -> Unit,
     onToggleFavorite: () -> Unit
 ) {
@@ -1839,36 +1928,55 @@ private fun SwipeableFoodRow(
     ) {
         val maxSwipePx = with(density) { maxWidth.toPx() * 0.72f }
         Box(Modifier.fillMaxWidth()) {
-            SwipeBackground(offsetPx = offsetPx, isFavorite = isFavorite)
+            if (!selectionMode) {
+                SwipeBackground(offsetPx = offsetPx, isFavorite = isFavorite)
+            }
             Box(
                 modifier = Modifier
-                    .offset { IntOffset(offsetPx.roundToInt(), 0) }
-                    .pointerInput(entry.id, maxSwipePx) {
-                        detectHorizontalDragGestures(
-                            onHorizontalDrag = { change, dragAmount ->
-                                change.consume()
-                                offsetPx = (offsetPx + dragAmount).coerceIn(-maxSwipePx, maxSwipePx)
-                            },
-                            onDragEnd = {
-                                val finalOffset = offsetPx
-                                offsetPx = 0f
-                                when {
-                                    finalOffset <= -deleteTriggerPx -> onDelete()
-                                    finalOffset >= favoriteTriggerPx -> onToggleFavorite()
+                    .offset { IntOffset(if (selectionMode) 0 else offsetPx.roundToInt(), 0) }
+                    .then(
+                        if (selectionMode) {
+                            Modifier.clickable(onClick = onTap)
+                        } else {
+                            Modifier
+                                .pointerInput(entry.id, maxSwipePx) {
+                                    detectHorizontalDragGestures(
+                                        onHorizontalDrag = { change, dragAmount ->
+                                            change.consume()
+                                            offsetPx = (offsetPx + dragAmount).coerceIn(-maxSwipePx, maxSwipePx)
+                                        },
+                                        onDragEnd = {
+                                            val finalOffset = offsetPx
+                                            offsetPx = 0f
+                                            when {
+                                                finalOffset <= -deleteTriggerPx -> onDelete()
+                                                finalOffset >= favoriteTriggerPx -> onToggleFavorite()
+                                            }
+                                        },
+                                        onDragCancel = {
+                                            offsetPx = 0f
+                                        }
+                                    )
                                 }
-                            },
-                            onDragCancel = {
-                                offsetPx = 0f
-                            }
-                        )
-                    }
-                    .clickable(onClick = onTap)
+                                .combinedClickable(
+                                    onClick = onTap,
+                                    onLongClick = onLongPress
+                                )
+                        }
+                    )
             ) {
-                FoodRow(entry = entry, isFavorite = isFavorite, rowShape = rowShape)
+                FoodRow(
+                    entry = entry,
+                    isFavorite = isFavorite,
+                    rowShape = rowShape,
+                    selectionMode = selectionMode,
+                    selected = selected
+                )
             }
         }
     }
 }
+
 
 @Composable
 private fun SwipeableWaterRow(
@@ -2069,7 +2177,9 @@ private data class Quad<A, B, C, D>(val a: A, val b: B, val c: C, val d: D)
 private fun FoodRow(
     entry: FoodEntry,
     isFavorite: Boolean = false,
-    rowShape: RoundedCornerShape = RoundedCornerShape(22.dp)
+    rowShape: RoundedCornerShape = RoundedCornerShape(22.dp),
+    selectionMode: Boolean = false,
+    selected: Boolean = false
 ) {
     val ctx = LocalContext.current
     val timeFmt = DateTimeFormatter.ofPattern(clockTimePattern(ctx), Locale.US).withZone(ZoneId.systemDefault())
@@ -2084,7 +2194,10 @@ private fun FoodRow(
             .fillMaxWidth()
             .clip(rowShape)
             .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.86f))
-            .background(AppColors.Calorie.copy(alpha = 0.025f))
+            .background(
+                if (selected) AppColors.Calorie.copy(alpha = 0.12f)
+                else AppColors.Calorie.copy(alpha = 0.025f)
+            )
             .border(
                 0.7.dp,
                 Brush.linearGradient(
@@ -2100,6 +2213,16 @@ private fun FoodRow(
         verticalAlignment = Alignment.Top,
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {
+        if (selectionMode) {
+            Icon(
+                imageVector = if (selected) Icons.Filled.CheckCircle else Icons.Outlined.Circle,
+                contentDescription = null,
+                tint = if (selected) AppColors.Calorie else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f),
+                modifier = Modifier
+                    .padding(top = 28.dp)
+                    .size(26.dp)
+            )
+        }
         Box(
             Modifier
                 .size(76.dp)

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt
@@ -652,6 +652,29 @@ class HomeViewModel(private val container: AppContainer) : ViewModel() {
         }
     }
 
+    suspend fun analyzeIngredientText(description: String): FoodAnalysis =
+        container.foodAnalysis.analyzeText(description)
+
+    suspend fun analyzeIngredientImage(bytes: ByteArray): FoodAnalysis =
+        container.foodAnalysis.analyzeAuto(bytes)
+
+    suspend fun lookupIngredientBarcode(barcode: String): FoodAnalysis =
+        OpenFoodFactsService.lookupWithImage(barcode).analysis
+
+    fun combineIntoMeal(ids: Set<UUID>, onDone: (FoodEntry?) -> Unit = {}) {
+        if (ids.size < 2) {
+            onDone(null)
+            return
+        }
+        viewModelScope.launch {
+            val combined = container.foodRepository.combineIntoMeal(ids)
+            if (combined == null) {
+                reportFoodBlockedByFast()
+            }
+            onDone(combined)
+        }
+    }
+
     fun toggleFavorite(entry: FoodEntry) {
         viewModelScope.launch {
             container.foodRepository.toggleFavorite(entry)

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/IngredientIntakeHost.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/IngredientIntakeHost.kt
@@ -1,0 +1,304 @@
+package com.apoorvdarshan.calorietracker.ui.home
+
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.DriveFileRenameOutline
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.PhotoLibrary
+import androidx.compose.material.icons.filled.QrCodeScanner
+import androidx.compose.material.icons.filled.Repeat
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import com.apoorvdarshan.calorietracker.AppContainer
+import com.apoorvdarshan.calorietracker.R
+import com.apoorvdarshan.calorietracker.models.MealIngredient
+import com.apoorvdarshan.calorietracker.models.toMealIngredient
+import com.apoorvdarshan.calorietracker.services.ai.FoodAnalysis
+import com.apoorvdarshan.calorietracker.ui.components.FudGlassDialog
+import com.apoorvdarshan.calorietracker.ui.components.FudGlassPrimaryButton
+import com.apoorvdarshan.calorietracker.ui.components.FudGlassTextField
+import com.apoorvdarshan.calorietracker.ui.components.InAppCameraCaptureDialog
+import com.apoorvdarshan.calorietracker.ui.theme.AppColors
+import kotlinx.coroutines.launch
+
+/**
+ * Add-ingredient plus menu for review/edit sheets. Analysis and saved-meal
+ * picks append a [MealIngredient] to the open draft — they do not create a
+ * second diary row.
+ */
+@Composable
+internal fun IngredientIntakeSection(
+    container: AppContainer,
+    analyzeText: suspend (String) -> FoodAnalysis,
+    lookupBarcode: suspend (String) -> FoodAnalysis,
+    analyzeImage: suspend (ByteArray) -> FoodAnalysis,
+    onIngredient: (MealIngredient) -> Unit,
+    onManual: () -> Unit
+) {
+    val ctx = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var menuExpanded by remember { mutableStateOf(false) }
+    var showText by remember { mutableStateOf(false) }
+    var showVoice by remember { mutableStateOf(false) }
+    var showBarcode by remember { mutableStateOf(false) }
+    var showCamera by remember { mutableStateOf(false) }
+    var savedTab by remember { mutableStateOf<SavedTab?>(null) }
+    var busy by remember { mutableStateOf(false) }
+    var errorText by remember { mutableStateOf<String?>(null) }
+
+    fun runAnalysis(block: suspend () -> FoodAnalysis) {
+        if (busy) return
+        busy = true
+        errorText = null
+        scope.launch {
+            try {
+                onIngredient(block().toMealIngredient())
+            } catch (e: Exception) {
+                errorText = e.message?.takeIf { it.isNotBlank() }
+                    ?: ctx.getString(R.string.error_analysis_failed)
+            } finally {
+                busy = false
+            }
+        }
+    }
+
+    val photoPicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickVisualMedia()
+    ) { uri ->
+        if (uri == null) return@rememberLauncherForActivityResult
+        val bytes = runCatching {
+            ctx.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+        }.getOrNull()
+        if (bytes != null) runAnalysis { analyzeImage(bytes) }
+    }
+
+    val cameraPermission = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) showCamera = true
+    }
+
+    val barcodePermission = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) showBarcode = true
+    }
+
+    fun openCamera() {
+        if (ContextCompat.checkSelfPermission(ctx, Manifest.permission.CAMERA) ==
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            showCamera = true
+        } else {
+            cameraPermission.launch(Manifest.permission.CAMERA)
+        }
+    }
+
+    fun openBarcode() {
+        if (ContextCompat.checkSelfPermission(ctx, Manifest.permission.CAMERA) ==
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            showBarcode = true
+        } else {
+            barcodePermission.launch(Manifest.permission.CAMERA)
+        }
+    }
+
+    Box(Modifier.fillMaxWidth()) {
+        MealIngredientsAddRow(onClick = { menuExpanded = true })
+        SheetGlassDropdownMenu(
+            expanded = menuExpanded,
+            onDismissRequest = { menuExpanded = false },
+            menuWidth = 238.dp
+        ) {
+            SheetGlassDropdownMenuItem(
+                label = stringResource(R.string.home_menu_camera),
+                leadingIcon = Icons.Filled.CameraAlt
+            ) {
+                menuExpanded = false
+                openCamera()
+            }
+            SheetGlassDropdownMenuItem(
+                label = stringResource(R.string.home_menu_from_photos),
+                leadingIcon = Icons.Filled.PhotoLibrary
+            ) {
+                menuExpanded = false
+                photoPicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+            }
+            SheetGlassDropdownMenuItem(
+                label = stringResource(R.string.home_menu_barcode),
+                leadingIcon = Icons.Filled.QrCodeScanner
+            ) {
+                menuExpanded = false
+                openBarcode()
+            }
+            SheetGlassDropdownMenuItem(
+                label = stringResource(R.string.home_menu_text_input),
+                leadingIcon = Icons.Filled.Edit
+            ) {
+                menuExpanded = false
+                showText = true
+            }
+            SheetGlassDropdownMenuItem(
+                label = stringResource(R.string.home_menu_voice),
+                leadingIcon = Icons.Filled.Mic
+            ) {
+                menuExpanded = false
+                showVoice = true
+            }
+            SheetGlassDropdownMenuItem(
+                label = stringResource(R.string.home_menu_manual_entry),
+                leadingIcon = Icons.Filled.DriveFileRenameOutline
+            ) {
+                menuExpanded = false
+                onManual()
+            }
+            SheetGlassDropdownMenuItem(
+                label = stringResource(R.string.saved_meals_tab_favorites),
+                leadingIcon = Icons.Filled.Favorite
+            ) {
+                menuExpanded = false
+                savedTab = SavedTab.FAVORITES
+            }
+            SheetGlassDropdownMenuItem(
+                label = stringResource(R.string.saved_meals_tab_frequent),
+                leadingIcon = Icons.Filled.Repeat
+            ) {
+                menuExpanded = false
+                savedTab = SavedTab.FREQUENT
+            }
+            SheetGlassDropdownMenuItem(
+                label = stringResource(R.string.saved_meals_tab_recents),
+                leadingIcon = Icons.Filled.History
+            ) {
+                menuExpanded = false
+                savedTab = SavedTab.RECENTS
+            }
+        }
+    }
+
+    if (busy) {
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator(color = AppColors.Calorie)
+        }
+    }
+
+    errorText?.let { message ->
+        FudGlassDialog(onDismissRequest = { errorText = null }) {
+            Text(message, color = MaterialTheme.colorScheme.onSurface)
+            TextButton(onClick = { errorText = null }, modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(R.string.action_ok))
+            }
+        }
+    }
+
+    if (showText) {
+        IngredientTextDialog(
+            onDismiss = { showText = false },
+            onSubmit = { text ->
+                showText = false
+                runAnalysis { analyzeText(text) }
+            }
+        )
+    }
+
+    if (showVoice) {
+        VoiceInputSheet(
+            container = container,
+            onDismiss = { showVoice = false },
+            onSubmit = { text ->
+                showVoice = false
+                runAnalysis { analyzeText(text) }
+            }
+        )
+    }
+
+    if (showBarcode) {
+        BarcodeScannerSheet(
+            onBarcode = { code ->
+                showBarcode = false
+                runAnalysis { lookupBarcode(code) }
+            },
+            onDismiss = { showBarcode = false }
+        )
+    }
+
+    if (showCamera) {
+        InAppCameraCaptureDialog(
+            onCapture = { bytes ->
+                showCamera = false
+                runAnalysis { analyzeImage(bytes) }
+            },
+            onDismiss = { showCamera = false }
+        )
+    }
+
+    savedTab?.let { tab ->
+        SavedMealsSheet(
+            container = container,
+            tab = tab,
+            onDismiss = { savedTab = null },
+            onRelogEntry = { entry ->
+                savedTab = null
+                onIngredient(entry.toMealIngredient())
+            }
+        )
+    }
+}
+
+@Composable
+private fun IngredientTextDialog(onDismiss: () -> Unit, onSubmit: (String) -> Unit) {
+    var input by remember { mutableStateOf("") }
+    FudGlassDialog(onDismissRequest = onDismiss) {
+        FudGlassTextField(
+            value = input,
+            onValueChange = { input = it },
+            placeholder = stringResource(R.string.text_input_placeholder_1),
+            singleLine = false,
+            minLines = 3,
+            maxLines = 5,
+            modifier = Modifier.fillMaxWidth()
+        )
+        FudGlassPrimaryButton(
+            text = stringResource(R.string.action_analyze),
+            onClick = { if (input.isNotBlank()) onSubmit(input.trim()) },
+            enabled = input.isNotBlank()
+        )
+        TextButton(onClick = onDismiss, modifier = Modifier.fillMaxWidth()) {
+            Text(
+                stringResource(R.string.action_cancel),
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/MealIngredientsUi.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/MealIngredientsUi.kt
@@ -46,7 +46,8 @@ internal data class IngredientEditorTarget(
 internal fun MealIngredientsCard(
     ingredients: List<MealIngredient>,
     onEdit: (Int) -> Unit,
-    onAdd: () -> Unit
+    onAdd: () -> Unit = {},
+    addMenu: (@Composable () -> Unit)? = null
 ) {
     SheetPillCard {
         if (ingredients.isEmpty()) {
@@ -94,21 +95,30 @@ internal fun MealIngredientsCard(
             }
         }
         SheetHairline()
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable(onClick = onAdd)
-                .padding(horizontal = 18.dp, vertical = 13.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Icon(Icons.Filled.AddCircle, contentDescription = null, tint = AppColors.Calorie)
-            Spacer(Modifier.width(10.dp))
-            Text(
-                stringResource(R.string.ingredients_add),
-                color = AppColors.Calorie,
-                fontWeight = FontWeight.SemiBold
-            )
+        if (addMenu != null) {
+            addMenu()
+        } else {
+            MealIngredientsAddRow(onClick = onAdd)
         }
+    }
+}
+
+@Composable
+internal fun MealIngredientsAddRow(onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 18.dp, vertical = 13.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(Icons.Filled.AddCircle, contentDescription = null, tint = AppColors.Calorie)
+        Spacer(Modifier.width(10.dp))
+        Text(
+            stringResource(R.string.ingredients_add),
+            color = AppColors.Calorie,
+            fontWeight = FontWeight.SemiBold
+        )
     }
 }
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1215,6 +1215,9 @@
     <string name="ingredients_remove">Remove</string>
     <string name="ingredients_weight">Weight</string>
     <string name="ingredients_footer">Ingredient changes update the meal’s calorie and macro totals automatically.</string>
+    <string name="combine_into_meal">Combine into Meal</string>
+    <string name="combine_selected_count">%1$d selected</string>
+    <string name="ingredients_add_menu_title">Add Ingredient</string>
     <string name="progressive_meal_title">Progressive Meal</string>
     <string name="progressive_meal_description">Photo 1 → 2 → 3 follows each ingredient added to the same plate. Visible scale differences become ingredient weights.</string>
     <string name="progressive_meal_info_title">How Progressive Meal works</string>

--- a/android/app/src/test/java/com/apoorvdarshan/calorietracker/models/CombinedMealTest.kt
+++ b/android/app/src/test/java/com/apoorvdarshan/calorietracker/models/CombinedMealTest.kt
@@ -1,0 +1,108 @@
+package com.apoorvdarshan.calorietracker.models
+
+import com.apoorvdarshan.calorietracker.services.ai.FoodAnalysis
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+class CombinedMealTest {
+    @Test
+    fun foodEntryMapsToIngredientWithoutFlatteningNested() {
+        val entry = FoodEntry(
+            name = "Bowl",
+            calories = 500,
+            protein = 30.0,
+            carbs = 40.0,
+            fat = 20.0,
+            source = FoodSource.MANUAL,
+            servingSizeGrams = 350.0,
+            ingredients = listOf(
+                MealIngredient("Rice", 200.0, 250, 5.0, 50.0, 1.0),
+                MealIngredient("Chicken", 150.0, 250, 25.0, 0.0, 10.0)
+            )
+        )
+        val ingredient = entry.toMealIngredient()
+        assertEquals("Bowl", ingredient.name)
+        assertEquals(350.0, ingredient.grams, 0.001)
+        assertEquals(500, ingredient.calories)
+        assertEquals(30.0, ingredient.protein, 0.001)
+    }
+
+    @Test
+    fun analysisMapsToIngredient() {
+        val analysis = FoodAnalysis(
+            name = "Apple",
+            calories = 95,
+            protein = 0.5,
+            carbs = 25.0,
+            fat = 0.3,
+            servingSizeGrams = 182.0
+        )
+        val ingredient = analysis.toMealIngredient()
+        assertEquals("Apple", ingredient.name)
+        assertEquals(182.0, ingredient.grams, 0.001)
+        assertEquals(95, ingredient.calories)
+    }
+
+    @Test
+    fun combineTotalsAndUsesLatestMealMetadata() {
+        val older = FoodEntry(
+            name = "Eggs",
+            calories = 140,
+            protein = 12.0,
+            carbs = 1.0,
+            fat = 10.0,
+            timestamp = Instant.parse("2026-09-01T08:00:00Z"),
+            source = FoodSource.MANUAL,
+            mealType = MealType.BREAKFAST,
+            servingSizeGrams = 100.0
+        )
+        val newer = FoodEntry(
+            name = "Toast",
+            calories = 120,
+            protein = 4.0,
+            carbs = 20.0,
+            fat = 2.0,
+            timestamp = Instant.parse("2026-09-01T08:05:00Z"),
+            source = FoodSource.TEXT_INPUT,
+            mealType = MealType.LUNCH,
+            servingSizeGrams = 50.0
+        )
+        val combined = combineFoodEntries(listOf(older, newer))
+        assertEquals("Eggs + Toast", combined.name)
+        assertEquals(260, combined.calories)
+        assertEquals(16.0, combined.protein, 0.001)
+        assertEquals(21.0, combined.carbs, 0.001)
+        assertEquals(12.0, combined.fat, 0.001)
+        assertEquals(150.0, combined.servingSizeGrams!!, 0.001)
+        assertEquals(MealType.LUNCH, combined.mealType)
+        assertEquals(Instant.parse("2026-09-01T08:05:00Z"), combined.timestamp)
+        assertEquals(2, combined.ingredients.size)
+        assertTrue(combined.id != older.id && combined.id != newer.id)
+    }
+
+    @Test
+    fun withIngredientsRecomputesParentTotals() {
+        val entry = FoodEntry(
+            name = "Meal",
+            calories = 0,
+            protein = 0.0,
+            carbs = 0.0,
+            fat = 0.0,
+            source = FoodSource.MANUAL
+        )
+        val updated = entry.withIngredients(
+            listOf(
+                MealIngredient("A", 50.0, 80, 5.0, 6.0, 3.0),
+                MealIngredient("B", 70.0, 120, 8.0, 10.0, 4.0)
+            )
+        )
+        assertEquals(200, updated.calories)
+        assertEquals(13.0, updated.protein, 0.001)
+        assertEquals(16.0, updated.carbs, 0.001)
+        assertEquals(7.0, updated.fat, 0.001)
+        assertEquals(120.0, updated.servingSizeGrams!!, 0.001)
+        assertEquals(2, updated.ingredients.size)
+    }
+}

--- a/ios/calorietracker/ContentView.swift
+++ b/ios/calorietracker/ContentView.swift
@@ -657,6 +657,8 @@ struct HomeView: View {
     }
     @State private var activeSheet: ActiveSheet?
     @State private var editingEntry: FoodEntry?
+    @State private var selectedFoodIDs: Set<UUID> = []
+    private var isFoodSelectionMode: Bool { !selectedFoodIDs.isEmpty }
     @State private var pendingSharedMeals: [FoodEntry] = []
 
     @State private var currentFoodResult: GeminiService.FoodAnalysis?
@@ -954,13 +956,32 @@ struct HomeView: View {
                                 Group {
                                     switch item {
                                     case .food(let entry):
-                                        FoodRow(entry: entry)
-                                            .contentShape(Rectangle())
-                                            .onTapGesture {
+                                        HStack(spacing: 12) {
+                                            if isFoodSelectionMode {
+                                                Image(systemName: selectedFoodIDs.contains(entry.id) ? "checkmark.circle.fill" : "circle")
+                                                    .font(.title2)
+                                                    .foregroundStyle(selectedFoodIDs.contains(entry.id) ? AppColors.calorie : .secondary)
+                                            }
+                                            FoodRow(entry: entry)
+                                        }
+                                        .contentShape(Rectangle())
+                                        .onTapGesture {
+                                            if isFoodSelectionMode {
+                                                if selectedFoodIDs.contains(entry.id) {
+                                                    selectedFoodIDs.remove(entry.id)
+                                                } else {
+                                                    selectedFoodIDs.insert(entry.id)
+                                                }
+                                            } else {
                                                 editingEntry = entry
                                                 activeSheet = .editFood
                                             }
-                                            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                                        }
+                                        .onLongPressGesture {
+                                            selectedFoodIDs.insert(entry.id)
+                                        }
+                                        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                                            if !isFoodSelectionMode {
                                                 Button(role: .destructive) {
                                                     foodStore.deleteEntry(entry)
                                                 } label: {
@@ -973,6 +994,7 @@ struct HomeView: View {
                                                 }
                                                 .tint(AppColors.calorie)
                                             }
+                                        }
                                     case .water(let entry):
                                         WaterLogRow(entry: entry, unit: waterUnit)
                                             .swipeActions(edge: .trailing, allowsFullSwipe: true) {
@@ -1222,6 +1244,9 @@ struct HomeView: View {
                                 .background(AppColors.calorie, in: Circle())
                         }
                         .accessibilityIdentifier("home.add")
+                        .opacity(isFoodSelectionMode ? 0 : 1)
+                        .disabled(isFoodSelectionMode)
+                        .allowsHitTesting(!isFoodSelectionMode)
                         .popover(isPresented: $showTextPopover) {
                             TextFoodInputView(
                                 onCancel: {
@@ -1266,6 +1291,44 @@ struct HomeView: View {
                             .presentationCompactAdaptation(.popover)
                         }
                         .padding(24)
+            }
+            .overlay(alignment: .bottom) {
+                if isFoodSelectionMode {
+                    HStack(spacing: 12) {
+                        Button {
+                            selectedFoodIDs.removeAll()
+                        } label: {
+                            Image(systemName: "xmark")
+                                .font(.body.weight(.semibold))
+                                .frame(width: 28, height: 28)
+                        }
+                        .tint(.primary)
+                        Text("\(selectedFoodIDs.count) selected")
+                            .font(.system(.body, design: .rounded, weight: .semibold))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Button("Combine into Meal") {
+                            let ids = selectedFoodIDs
+                            if let combined = foodStore.combineIntoMeal(ids: ids) {
+                                selectedFoodIDs.removeAll()
+                                editingEntry = combined
+                                activeSheet = .editFood
+                            } else {
+                                selectedFoodIDs.removeAll()
+                                errorMessage = "Can't combine foods while fasting is active."
+                                showError = true
+                            }
+                        }
+                        .font(.system(.body, design: .rounded, weight: .bold))
+                        .disabled(selectedFoodIDs.count < 2)
+                        .tint(AppColors.calorie)
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 12)
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 100)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
             }
             .fullScreenCover(isPresented: $showCamera) {
                 CameraView(

--- a/ios/calorietracker/Models/FoodEntry.swift
+++ b/ios/calorietracker/Models/FoodEntry.swift
@@ -712,3 +712,98 @@ struct FoodEntry: Identifiable, Codable {
         )
     }
 }
+
+extension FoodEntry {
+    /// One ingredient line for combine / add-ingredient flows (nested ingredients stay collapsed).
+    nonisolated func asMealIngredient() -> MealIngredient {
+        MealIngredient(
+            name: name,
+            grams: servingSizeGrams.flatMap { $0.isFinite && $0 > 0 ? $0 : nil } ?? 0,
+            calories: calories,
+            protein: protein,
+            carbs: carbs,
+            fat: fat
+        )
+    }
+
+    /// Recompute parent macros from an ingredient list.
+    nonisolated func withIngredients(_ ingredients: [MealIngredient]) -> FoodEntry {
+        let totals = ingredients.ingredientTotals
+        return FoodEntry(
+            id: id,
+            name: name,
+            calories: totals.calories,
+            protein: totals.protein,
+            carbs: totals.carbs,
+            fat: totals.fat,
+            timestamp: timestamp,
+            imageData: imageData,
+            imageFilename: imageFilename,
+            additionalImageData: additionalImageData,
+            additionalImageFilenames: additionalImageFilenames,
+            emoji: emoji,
+            source: source,
+            mealType: mealType,
+            sugar: sugar,
+            addedSugar: addedSugar,
+            fiber: fiber,
+            saturatedFat: saturatedFat,
+            monounsaturatedFat: monounsaturatedFat,
+            polyunsaturatedFat: polyunsaturatedFat,
+            cholesterol: cholesterol,
+            caffeine: caffeine,
+            supplementalNutrients: supplementalNutrients,
+            sodium: sodium,
+            potassium: potassium,
+            transFat: transFat,
+            calcium: calcium,
+            iron: iron,
+            magnesium: magnesium,
+            zinc: zinc,
+            vitaminA: vitaminA,
+            vitaminC: vitaminC,
+            vitaminD: vitaminD,
+            vitaminB12: vitaminB12,
+            vitaminE: vitaminE,
+            vitaminK: vitaminK,
+            folate: folate,
+            omega3: omega3,
+            servingSizeGrams: totals.grams > 0 ? totals.grams : servingSizeGrams,
+            servingUnitOptions: [],
+            selectedServingUnit: nil,
+            selectedServingQuantity: nil,
+            customNote: customNote,
+            progressiveMeal: progressiveMeal,
+            ingredients: ingredients,
+            productMetadata: productMetadata
+        )
+    }
+}
+
+enum CombinedMeal {
+    nonisolated static func combinedName(for entries: [FoodEntry]) -> String {
+        let names = entries.map { $0.name.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty }
+        if names.isEmpty { return "Combined meal" }
+        if names.count <= 3 { return names.joined(separator: " + ") }
+        return names.prefix(2).joined(separator: " + ") + " + \(names.count - 2) more"
+    }
+
+    nonisolated static func combine(_ entries: [FoodEntry]) -> FoodEntry {
+        precondition(entries.count >= 2, "Combine requires at least two food entries")
+        let ingredients = entries.map { $0.asMealIngredient() }
+        let totals = ingredients.ingredientTotals
+        let latest = entries.max(by: { $0.timestamp < $1.timestamp }) ?? entries[0]
+        return FoodEntry(
+            name: combinedName(for: entries),
+            calories: totals.calories,
+            protein: totals.protein,
+            carbs: totals.carbs,
+            fat: totals.fat,
+            timestamp: latest.timestamp,
+            source: .manual,
+            mealType: latest.mealType,
+            servingSizeGrams: totals.grams > 0 ? totals.grams : nil,
+            ingredients: ingredients
+        )
+    }
+}

--- a/ios/calorietracker/Stores/FoodStore.swift
+++ b/ios/calorietracker/Stores/FoodStore.swift
@@ -393,6 +393,33 @@ class FoodStore {
         onEntryDeleted?(id)
     }
 
+    /// Merge selected diary foods into one combined meal and remove the originals.
+    @discardableResult
+    func combineIntoMeal(ids: Set<UUID>) -> FoodEntry? {
+        guard FastingStore.persistedActiveSession(defaults: defaults) == nil else { return nil }
+        guard ids.count >= 2 else { return nil }
+        let selected = entries.filter { ids.contains($0.id) }
+        guard selected.count >= 2 else { return nil }
+        var combined = CombinedMeal.combine(selected)
+        offloadImageToDiskIfNeeded(&combined)
+        let favoriteFilenames = Set(favorites.flatMap(\.allImageFilenames))
+        for old in selected {
+            for filename in old.allImageFilenames {
+                if favoriteFilenames.contains(filename) { continue }
+                if combined.allImageFilenames.contains(filename) { continue }
+                if isImageStillReferenced(filename: filename, excludingEntryID: old.id) { continue }
+                FoodImageStore.shared.delete(filename: filename)
+            }
+            onEntryDeleted?(old.id)
+        }
+        entries = entries.filter { !ids.contains($0.id) } + [combined]
+        saveEntries()
+        onEntriesChanged?()
+        onEntryAdded?(combined)
+        ReviewPrompter.foodWasLogged()
+        return combined
+    }
+
     func replaceAllEntries(_ newEntries: [FoodEntry]) {
         // Delete on-disk JPEGs for any entry that's about to be removed —
         // otherwise Clear Food Log / Delete All Data orphan files in

--- a/ios/calorietracker/Views/EditFoodEntryView.swift
+++ b/ios/calorietracker/Views/EditFoodEntryView.swift
@@ -286,12 +286,19 @@ struct EditFoodEntryView: View {
                         onEdit: { index in
                             ingredientEditor = IngredientEditorTarget(index: index, ingredient: scaledIngredients[index])
                         },
-                        onAdd: {
-                            ingredientEditor = IngredientEditorTarget(
-                                index: nil,
-                                ingredient: MealIngredient(name: "", grams: 100, calories: 0, protein: 0, carbs: 0, fat: 0)
+                        addMenu: AnyView(
+                            IngredientAddMenuButton(
+                                onManual: {
+                                    ingredientEditor = IngredientEditorTarget(
+                                        index: nil,
+                                        ingredient: MealIngredient(name: "", grams: 100, calories: 0, protein: 0, carbs: 0, fat: 0)
+                                    )
+                                },
+                                onIngredient: { ingredient in
+                                    applyIngredientChanges(scaledIngredients + [ingredient])
+                                }
                             )
-                        }
+                        )
                     )
 
                     Section {

--- a/ios/calorietracker/Views/FoodResultView.swift
+++ b/ios/calorietracker/Views/FoodResultView.swift
@@ -435,12 +435,19 @@ struct FoodResultView: View {
                         onEdit: { index in
                             ingredientEditor = IngredientEditorTarget(index: index, ingredient: scaledIngredients[index])
                         },
-                        onAdd: {
-                            ingredientEditor = IngredientEditorTarget(
-                                index: nil,
-                                ingredient: MealIngredient(name: "", grams: 100, calories: 0, protein: 0, carbs: 0, fat: 0)
+                        addMenu: AnyView(
+                            IngredientAddMenuButton(
+                                onManual: {
+                                    ingredientEditor = IngredientEditorTarget(
+                                        index: nil,
+                                        ingredient: MealIngredient(name: "", grams: 100, calories: 0, protein: 0, carbs: 0, fat: 0)
+                                    )
+                                },
+                                onIngredient: { ingredient in
+                                    applyIngredientChanges(scaledIngredients + [ingredient])
+                                }
                             )
-                        }
+                        )
                     )
 
                     Section {
@@ -644,7 +651,8 @@ struct IngredientEditorTarget: Identifiable {
 struct MealIngredientsSection: View {
     let ingredients: [MealIngredient]
     let onEdit: (Int) -> Void
-    let onAdd: () -> Void
+    var onAdd: (() -> Void)? = nil
+    var addMenu: AnyView? = nil
 
     var body: some View {
         Section {
@@ -682,11 +690,15 @@ struct MealIngredientsSection: View {
                 }
             }
 
-            Button(action: onAdd) {
-                Label("Add Ingredient", systemImage: "plus.circle.fill")
-                    .font(.system(.body, design: .rounded, weight: .semibold))
+            if let addMenu {
+                addMenu
+            } else if let onAdd {
+                Button(action: onAdd) {
+                    Label("Add Ingredient", systemImage: "plus.circle.fill")
+                        .font(.system(.body, design: .rounded, weight: .semibold))
+                }
+                .tint(AppColors.calorie)
             }
-            .tint(AppColors.calorie)
         } header: {
             Text("Ingredients")
         } footer: {

--- a/ios/calorietracker/Views/IngredientAddMenuButton.swift
+++ b/ios/calorietracker/Views/IngredientAddMenuButton.swift
@@ -1,0 +1,190 @@
+import SwiftUI
+import PhotosUI
+
+extension GeminiService.FoodAnalysis {
+    /// One ingredient line for add-ingredient flows (nested ingredients stay collapsed).
+    func asMealIngredient() -> MealIngredient {
+        MealIngredient(
+            name: name,
+            grams: servingSizeGrams.isFinite && servingSizeGrams > 0 ? servingSizeGrams : 0,
+            calories: calories,
+            protein: protein,
+            carbs: carbs,
+            fat: fat
+        )
+    }
+}
+
+/// Plus menu that appends ingredients onto an open review/edit draft.
+struct IngredientAddMenuButton: View {
+    let onManual: () -> Void
+    let onIngredient: (MealIngredient) -> Void
+
+    @State private var showText = false
+    @State private var showVoice = false
+    @State private var showBarcode = false
+    @State private var showCamera = false
+    @State private var capturedImage: UIImage?
+    @State private var showPhotoPicker = false
+    @State private var selectedPhotoItems: [PhotosPickerItem] = []
+    @State private var savedMode: SavedMealsMode?
+    @State private var textDraft = ""
+    @State private var isBusy = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        Menu {
+            Button { showCamera = true } label: {
+                Label("Camera", systemImage: "camera.fill")
+            }
+            Button { showPhotoPicker = true } label: {
+                Label("Photos", systemImage: "photo.on.rectangle")
+            }
+            Button { showBarcode = true } label: {
+                Label("Barcode", systemImage: "barcode.viewfinder")
+            }
+            Button {
+                textDraft = ""
+                showText = true
+            } label: {
+                Label("Text", systemImage: "character.cursor.ibeam")
+            }
+            Button { showVoice = true } label: {
+                Label("Voice", systemImage: "mic.fill")
+            }
+            Button(action: onManual) {
+                Label("Manual", systemImage: "square.and.pencil")
+            }
+            Button { savedMode = .favorites } label: {
+                Label("Favorites", systemImage: "heart.fill")
+            }
+            Button { savedMode = .frequent } label: {
+                Label("Frequent", systemImage: "repeat")
+            }
+            Button { savedMode = .recent } label: {
+                Label("Recent", systemImage: "clock.fill")
+            }
+        } label: {
+            Label("Add Ingredient", systemImage: "plus.circle.fill")
+                .font(.system(.body, design: .rounded, weight: .semibold))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+        }
+        .tint(AppColors.calorie)
+        .disabled(isBusy)
+        .overlay {
+            if isBusy { ProgressView() }
+        }
+        .alert("Couldn't add ingredient", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "")
+        }
+        .sheet(isPresented: $showText) {
+            NavigationStack {
+                Form {
+                    TextField("Describe the food", text: $textDraft, axis: .vertical)
+                        .lineLimit(3...6)
+                }
+                .navigationTitle("Add Ingredient")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { showText = false }
+                    }
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Analyze") {
+                            let text = textDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+                            showText = false
+                            runAnalysis {
+                                try await GeminiService.analyzeTextInput(description: text)
+                            }
+                        }
+                        .disabled(textDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+            }
+            .presentationDetents([.medium])
+        }
+        .sheet(isPresented: $showVoice) {
+            VoiceInputView(
+                onCancel: { showVoice = false },
+                onSubmit: { text in
+                    showVoice = false
+                    runAnalysis {
+                        try await GeminiService.analyzeTextInput(description: text)
+                    }
+                }
+            )
+        }
+        .fullScreenCover(isPresented: $showBarcode) {
+            BarcodeScannerView(
+                onScan: { code in
+                    showBarcode = false
+                    runAnalysis {
+                        try await OpenFoodFactsService.lookup(barcode: code)
+                    }
+                },
+                onCancel: { showBarcode = false }
+            )
+        }
+        .fullScreenCover(isPresented: $showCamera) {
+            CameraView(
+                image: $capturedImage,
+                onCancel: { showCamera = false }
+            )
+            .ignoresSafeArea()
+        }
+        .onChange(of: capturedImage) { _, image in
+            guard let image else { return }
+            capturedImage = nil
+            showCamera = false
+            runAnalysis {
+                try await GeminiService.analyzeFood(images: [image])
+            }
+        }
+        .photosPicker(isPresented: $showPhotoPicker, selection: $selectedPhotoItems, maxSelectionCount: 1, matching: .images)
+        .onChange(of: selectedPhotoItems) { _, items in
+            guard let item = items.first else { return }
+            selectedPhotoItems = []
+            Task {
+                guard let data = try? await item.loadTransferable(type: Data.self),
+                      let image = UIImage(data: data) else {
+                    errorMessage = "Couldn't load that photo."
+                    return
+                }
+                runAnalysis {
+                    try await GeminiService.analyzeFood(images: [image])
+                }
+            }
+        }
+        .sheet(item: $savedMode) { mode in
+            RecentsView(mode: mode, logDate: Date()) { entry in
+                onIngredient(entry.asMealIngredient())
+            }
+        }
+    }
+
+    private func runAnalysis(_ work: @escaping () async throws -> GeminiService.FoodAnalysis) {
+        guard !isBusy else { return }
+        isBusy = true
+        errorMessage = nil
+        Task {
+            do {
+                let analysis = try await work()
+                await MainActor.run {
+                    isBusy = false
+                    onIngredient(analysis.asMealIngredient())
+                }
+            } catch {
+                await MainActor.run {
+                    isBusy = false
+                    errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+}

--- a/ios/calorietrackerTests/CombinedMealTests.swift
+++ b/ios/calorietrackerTests/CombinedMealTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+@testable import calorietracker
+
+struct CombinedMealTests {
+    @Test func asMealIngredientCollapsesNestedIngredients() {
+        let entry = FoodEntry(
+            name: "Bowl",
+            calories: 500,
+            protein: 30,
+            carbs: 40,
+            fat: 20,
+            source: .manual,
+            servingSizeGrams: 350,
+            ingredients: [
+                MealIngredient(name: "Rice", grams: 200, calories: 250, protein: 5, carbs: 50, fat: 1),
+                MealIngredient(name: "Chicken", grams: 150, calories: 250, protein: 25, carbs: 0, fat: 10)
+            ]
+        )
+        let ingredient = entry.asMealIngredient()
+        #expect(ingredient.name == "Bowl")
+        #expect(ingredient.grams == 350)
+        #expect(ingredient.calories == 500)
+        #expect(ingredient.protein == 30)
+    }
+
+    @Test func combineTotalsUsesLatestMealMetadata() {
+        let older = FoodEntry(
+            name: "Eggs",
+            calories: 140,
+            protein: 12,
+            carbs: 1,
+            fat: 10,
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            source: .manual,
+            mealType: .breakfast,
+            servingSizeGrams: 100
+        )
+        let newer = FoodEntry(
+            name: "Toast",
+            calories: 120,
+            protein: 4,
+            carbs: 20,
+            fat: 2,
+            timestamp: Date(timeIntervalSince1970: 1_100),
+            source: .textInput,
+            mealType: .lunch,
+            servingSizeGrams: 50
+        )
+        let combined = CombinedMeal.combine([older, newer])
+        #expect(combined.name == "Eggs + Toast")
+        #expect(combined.calories == 260)
+        #expect(combined.protein == 16)
+        #expect(combined.carbs == 21)
+        #expect(combined.fat == 12)
+        #expect(combined.servingSizeGrams == 150)
+        #expect(combined.mealType == .lunch)
+        #expect(combined.ingredients.count == 2)
+    }
+
+    @Test func withIngredientsRecomputesParentTotals() {
+        let entry = FoodEntry(
+            name: "Meal",
+            calories: 0,
+            protein: 0,
+            carbs: 0,
+            fat: 0,
+            source: .manual
+        )
+        let updated = entry.withIngredients([
+            MealIngredient(name: "A", grams: 50, calories: 80, protein: 5, carbs: 6, fat: 3),
+            MealIngredient(name: "B", grams: 70, calories: 120, protein: 8, carbs: 10, fat: 4)
+        ])
+        #expect(updated.calories == 200)
+        #expect(updated.protein == 13)
+        #expect(updated.carbs == 16)
+        #expect(updated.fat == 7)
+        #expect(updated.servingSizeGrams == 120)
+        #expect(updated.ingredients.count == 2)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements combine-into-meal in both directions on Android and iOS:

- **Home**: long-press food rows → multi-select → **Combine into Meal** creates one `FoodEntry` with ingredient lines and removes the selected originals (no double-counting). Opens edit so the meal can be renamed/favorited.
- **Review / Edit**: **Add Ingredient** is a plus menu (camera, photos, barcode, text, voice, manual, favorites/frequent/recent). Picks append a `MealIngredient` and recompute parent totals without inserting a second diary row. Nested saved meals stay one line.

## Shared helpers
- `FoodEntry` ↔ `MealIngredient` mapping and combine/totals helpers
- Repository / `FoodStore.combineIntoMeal`

## Testing
- Android unit tests: `CombinedMealTest` (compile + tests green in this environment)
- iOS: `CombinedMealTests` added (Xcode/device not available in this cloud VM)
- Connected-phone install skipped here (no USB devices on the agent)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ad9f31f-3854-4fd3-9058-b05d4246a698?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ad9f31f-3854-4fd3-9058-b05d4246a698&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

