### PR TITLE
Update Italian translation

### DIFF
--- a/ios/calorietracker/Localizable.xcstrings
+++ b/ios/calorietracker/Localizable.xcstrings
@@ -1238,6 +1238,12 @@
             "state": "translated",
             "value": "Нежно-розовый"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosa confetto"
+          }
         }
       }
     },
@@ -1448,6 +1454,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Коралловый"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Corallo"
           }
         }
       }
@@ -1848,6 +1860,12 @@
             "state": "translated",
             "value": "Графитовый"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grafite"
+          }
         }
       }
     },
@@ -2054,6 +2072,12 @@
             "state": "translated",
             "value": "Индиго"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indaco"
+          }
         }
       }
     },
@@ -2164,6 +2188,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Лавандовый"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lavanda"
           }
         }
       }
@@ -2276,6 +2306,12 @@
             "state": "translated",
             "value": "Лаймовый"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lime"
+          }
         }
       }
     },
@@ -2386,6 +2422,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Мокко"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marrone moka"
           }
         }
       }
@@ -2591,6 +2633,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Розовое золото"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oro rosa"
           }
         }
       }
@@ -3259,7 +3307,14 @@
       }
     },
     "": {
-      "localizations": {}
+      "localizations": {
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ""
+          }
+        }
+      }
     },
     "!": {
       "comment": "An exclamation mark.",
@@ -3272,6 +3327,12 @@
           }
         },
         "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "!"
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "translated",
             "value": "!"
@@ -3290,6 +3351,12 @@
           }
         },
         "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "."
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "translated",
             "value": "."
@@ -3404,6 +3471,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Небесно-голубой"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Azzurro cielo"
           }
         }
       }
@@ -3711,6 +3784,12 @@
             "state": "translated",
             "value": "Жёлтый"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giallo"
+          }
         }
       }
     },
@@ -3918,6 +3997,12 @@
             "state": "translated",
             "value": "·"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "·"
+          }
         }
       }
     },
@@ -3930,6 +4015,12 @@
           }
         },
         "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "/ %@"
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "translated",
             "value": "/ %@"
@@ -3958,6 +4049,12 @@
             "state": "translated",
             "value": "/%1$@%2$@"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "/%1$@%2$@"
+          }
         }
       }
     },
@@ -3972,6 +4069,12 @@
           }
         },
         "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%"
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "translated",
             "value": "%"
@@ -3998,6 +4101,12 @@
             "state": "translated",
             "value": "%1$@ / %2$lldg"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ / %2$lldg"
+          }
         }
       }
     },
@@ -4016,6 +4125,12 @@
           }
         },
         "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ %2$@"
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "translated",
             "value": "%1$@ %2$@"
@@ -4140,6 +4255,12 @@
             "state": "translated",
             "value": "%1$@%2$@ осталось"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@%2$@ rimanenti"
+          }
         }
       }
     },
@@ -4162,6 +4283,12 @@
             "state": "translated",
             "value": "%1$@%2$lld ккал"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@%2$lld kcal"
+          }
         }
       }
     },
@@ -4174,6 +4301,12 @@
           }
         },
         "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld"
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "translated",
             "value": "%lld"
@@ -4202,6 +4335,12 @@
             "state": "translated",
             "value": "%1$lld %2$@"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld %2$@"
+          }
         }
       }
     },
@@ -4225,6 +4364,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%1$lld %2$@ · нажмите, чтобы просмотреть или удалить"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld %2$@ · tocca per visualizzare o eliminare"
           }
         }
       }
@@ -4572,6 +4717,12 @@
             "state": "translated",
             "value": "%lld кал"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld cal"
+          }
         }
       }
     },
@@ -4589,6 +4740,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld см"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld cm"
           }
         }
       }
@@ -4626,6 +4783,24 @@
                 "stringUnit": {
                   "state": "translated",
                   "value": "%lld дней"
+                }
+              }
+            }
+          }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld giorno"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld giorni"
                 }
               }
             }
@@ -4678,6 +4853,24 @@
               }
             }
           }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%1$lld alimento verrà aggiunto a %3$@."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%1$lld alimenti verranno aggiunti a %3$@."
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -4696,6 +4889,12 @@
             "state": "translated",
             "value": "%lld фут"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld ft"
+          }
         }
       }
     },
@@ -4711,6 +4910,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld г"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld g"
           }
         }
       }
@@ -4728,6 +4933,12 @@
             "state": "translated",
             "value": "%lld дюйм"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld in"
+          }
         }
       }
     },
@@ -4743,6 +4954,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld ккал"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld kcal"
           }
         }
       }
@@ -4762,6 +4979,12 @@
             "state": "translated",
             "value": "%lld ккал / день"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld kcal / giorno"
+          }
         }
       }
     },
@@ -4777,6 +5000,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld осталось"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld rimanenti"
           }
         }
       }
@@ -4802,6 +5031,12 @@
             "state": "translated",
             "value": "%1$lld/%2$lld осталось"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld/%2$lld rimanenti"
+          }
         }
       }
     },
@@ -4824,6 +5059,12 @@
             "state": "translated",
             "value": "%1$lld%2$@"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld%2$@"
+          }
         }
       }
     },
@@ -4836,6 +5077,12 @@
           }
         },
         "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld%%"
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "translated",
             "value": "%lld%%"
@@ -4857,6 +5104,12 @@
             "state": "translated",
             "value": "%lldg"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lldg"
+          }
         }
       }
     },
@@ -4874,6 +5127,12 @@
             "state": "translated",
             "value": "%lldg · авто"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lldg · auto"
+          }
         }
       }
     },
@@ -4886,6 +5145,12 @@
           }
         },
         "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "•"
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "translated",
             "value": "•"
@@ -4908,6 +5173,12 @@
             "state": "translated",
             "value": "~%@ г"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "~%@ g"
+          }
         }
       }
     },
@@ -4924,6 +5195,12 @@
             "state": "translated",
             "value": "0"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "0"
+          }
         }
       }
     },
@@ -4936,6 +5213,12 @@
           }
         },
         "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "27%"
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "translated",
             "value": "27%"
@@ -5150,6 +5433,12 @@
             "state": "translated",
             "value": "О адаптивных целях"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Info su Obiettivi adattivi"
+          }
         }
       }
     },
@@ -5165,6 +5454,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "О настройке «Граммы по умолчанию»"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Info su Grammi predefiniti"
           }
         }
       }
@@ -5276,6 +5571,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "О цели расхода калорий"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Info su Obiettivi consumo energetico"
           }
         }
       }
@@ -5389,6 +5690,12 @@
             "state": "translated",
             "value": "Принять и продолжить"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accetta e continua"
+          }
         }
       }
     },
@@ -5405,6 +5712,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Активный"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attivo"
           }
         }
       }
@@ -5615,6 +5928,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Адаптивные цели"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obiettivi adattivi"
           }
         }
       }
@@ -5928,6 +6247,12 @@
             "state": "translated",
             "value": "Добавлено"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiunto"
+          }
         }
       }
     },
@@ -5944,6 +6269,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Добавленный сахар"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zuccheri aggiunti"
           }
         }
       }
@@ -6063,6 +6394,12 @@
             "state": "translated",
             "value": "Агрессивно, но выполнимо. Требует высокой дисциплины."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggressivo ma fattibile. Richiede molta disciplina."
+          }
         }
       }
     },
@@ -6080,6 +6417,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Доступ к ИИ"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accesso IA"
           }
         }
       }
@@ -6300,6 +6643,12 @@
             "state": "translated",
             "value": "Не удалось получить предложение ИИ"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suggerimento IA non riuscito"
+          }
         }
       }
     },
@@ -6317,6 +6666,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Все четыре напоминания умные — они не срабатывают в дни, когда вы уже внесли данные. Напоминание о жире отключено по умолчанию, так как большинство пользователей не измеряет его каждый день."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tutti e quattro i promemoria sono intelligenti: non si attivano nei giorni in cui hai già registrato i dati. Quello per il grasso corporeo è disattivato di default poiché la maggior parte degli utenti non lo misura ogni giorno."
           }
         }
       }
@@ -6435,6 +6790,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Разрешить напоминания о приемах пищи"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti promemoria pasti"
           }
         }
       }
@@ -6958,6 +7319,12 @@
             "state": "translated",
             "value": "Анализ…"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analisi in corso…"
+          }
         }
       }
     },
@@ -7076,6 +7443,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "и"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "e"
           }
         }
       }
@@ -7486,6 +7859,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Версия приложения"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versione dell'app"
           }
         }
       }
@@ -8498,6 +8877,12 @@
             "state": "translated",
             "value": "Ср.: %lld ккал"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Media: %lld kcal"
+          }
         }
       }
     },
@@ -8614,6 +8999,12 @@
             "state": "translated",
             "value": "Штрихкод"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codice a barre"
+          }
         }
       }
     },
@@ -8629,6 +9020,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Базовый URL"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL di base"
           }
         }
       }
@@ -8647,6 +9044,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Получайте напоминания\nо записи приёмов пищи"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ricevi promemoria per\nregistrare i pasti"
           }
         }
       }
@@ -8759,6 +9162,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Лучшая серия"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Miglior serie"
           }
         }
       }
@@ -8876,6 +9285,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Синий"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blu"
           }
         }
       }
@@ -9385,6 +9800,12 @@
             "state": "translated",
             "value": "Замеры тела"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Misure corporee"
+          }
         }
       }
     },
@@ -9403,6 +9824,12 @@
             "state": "translated",
             "value": "Показатели тела"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metriche corporee"
+          }
         }
       }
     },
@@ -9420,6 +9847,12 @@
             "state": "translated",
             "value": "Завтрак"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Colazione"
+          }
         }
       }
     },
@@ -9436,6 +9869,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Завтрак → Обед → Ужин"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Colazione → Pranzo → Cena"
           }
         }
       }
@@ -9554,6 +9993,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Кальций"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calcio"
           }
         }
       }
@@ -10055,6 +10500,12 @@
             "state": "translated",
             "value": "Камера + Камера"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fotocamera + fotocamera"
+          }
         }
       }
     },
@@ -10460,6 +10911,12 @@
             "state": "translated",
             "value": "Углеводы"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carboidrati"
+          }
         }
       }
     },
@@ -10476,6 +10933,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Углеводы (г)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carboidrati (g)"
           }
         }
       }
@@ -10495,6 +10958,12 @@
             "state": "translated",
             "value": "Изменяет основной цвет приложения и иконку для вкладок, кнопок, значков, графиков и колец прогресса."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifica il colore principale dell'app e l'icona della schermata Home usata per pannelli, pulsanti, icone, grafici e anelli di avanzamento."
+          }
         }
       }
     },
@@ -10512,6 +10981,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Проверить обновления"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifica aggiornamenti"
           }
         }
       }
@@ -10632,6 +11107,12 @@
             "state": "translated",
             "value": "Проверяем соответствие вашим целям..."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifica compatibilità con i tuoi obiettivi..."
+          }
         }
       }
     },
@@ -10650,6 +11131,12 @@
             "state": "translated",
             "value": "Проверка обновлений…"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifica aggiornamenti in corso…"
+          }
         }
       }
     },
@@ -10666,6 +11153,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Китайский"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cinese"
           }
         }
       }
@@ -10684,6 +11177,12 @@
             "state": "translated",
             "value": "Холестерин"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Colesterolo"
+          }
         }
       }
     },
@@ -10701,6 +11200,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Выберите ИИ"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scegli la tua IA"
           }
         }
       }
@@ -11119,6 +11624,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Очистить количество"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancella quantità"
           }
         }
       }
@@ -11833,6 +12344,12 @@
             "state": "translated",
             "value": "Подключиться к\nApple Health"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connettiti ad\nApple Health"
+          }
         }
       }
     },
@@ -12051,6 +12568,12 @@
             "state": "translated",
             "value": "Копировать %@"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia %@"
+          }
         }
       }
     },
@@ -12068,6 +12591,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Копировать все продукты"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia tutti gli alimenti"
           }
         }
       }
@@ -12087,6 +12616,12 @@
             "state": "translated",
             "value": "Копировать из"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia da"
+          }
         }
       }
     },
@@ -12102,6 +12637,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Копировать из дня"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia da un giorno"
           }
         }
       }
@@ -12222,6 +12763,12 @@
             "state": "translated",
             "value": "Текущая %1$@ → Последняя %2$@"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versione attuale %1$@ -> più recente %2$@"
+          }
         }
       }
     },
@@ -12238,6 +12785,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Текущая серия"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Serie attuale"
           }
         }
       }
@@ -12256,6 +12809,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Сейчас %lld%%"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attualmente %lld%%"
           }
         }
       }
@@ -12670,6 +13229,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ежедневные тренировки или интенсивные 3–4 раза в неделю"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esercizio quotidiano o intenso 3–4 volte a settimana"
           }
         }
       }
@@ -13089,6 +13654,12 @@
             "state": "translated",
             "value": "Дата и Время"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Data e ora"
+          }
         }
       }
     },
@@ -13106,6 +13677,12 @@
             "state": "translated",
             "value": "Дней в цели"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giorni in obiettivo"
+          }
         }
       }
     },
@@ -13122,6 +13699,12 @@
             "state": "translated",
             "value": "Дробная"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Decimale"
+          }
         }
       }
     },
@@ -13137,6 +13720,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Граммы по умолчанию"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grammi come predefiniti"
           }
         }
       }
@@ -13644,6 +14233,12 @@
             "state": "translated",
             "value": "Delts Workout Tracker в App Store"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delts Workout Tracker su App Store"
+          }
         }
       }
     },
@@ -13856,6 +14451,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ужин"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cena"
           }
         }
       }
@@ -14268,6 +14869,12 @@
             "state": "translated",
             "value": "Нидерландский"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Olandese"
+          }
         }
       }
     },
@@ -14283,6 +14890,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "напр. «Это половина порции» или «Приготовлено на оливковом масле»"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ad es. \"Questa è mezza porzione\" o \"Cotto con olio d'oliva\""
           }
         }
       }
@@ -14300,6 +14913,12 @@
             "state": "translated",
             "value": "напр. anthropic/claude-sonnet-4"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ad es. anthropic/claude-sonnet-4"
+          }
         }
       }
     },
@@ -14315,6 +14934,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "напр. gpt-4o-mini"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ad es. gpt-4o-mini"
           }
         }
       }
@@ -14728,6 +15353,12 @@
             "state": "translated",
             "value": "Цель расхода калорий"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obiettivi consumo energetico"
+          }
         }
       }
     },
@@ -14839,6 +15470,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Английский"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inglese"
           }
         }
       }
@@ -15152,6 +15789,12 @@
             "state": "translated",
             "value": "Тренировки 1–3 раза в неделю"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esercizio 1–3 volte a settimana"
+          }
         }
       }
     },
@@ -15168,6 +15811,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Тренировки 4–5 раз в неделю"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esercizio 4–5 volte a settimana"
           }
         }
       }
@@ -15381,6 +16030,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Максимально активный"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estremamente attivo"
           }
         }
       }
@@ -15699,6 +16354,12 @@
             "state": "translated",
             "value": "Жиры"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grassi"
+          }
         }
       }
     },
@@ -15715,6 +16376,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Жиры (г)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grassi (g)"
           }
         }
       }
@@ -15733,6 +16400,12 @@
             "state": "translated",
             "value": "Жиры"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grassi"
+          }
         }
       }
     },
@@ -15748,6 +16421,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Избранное"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preferito"
           }
         }
       }
@@ -16061,6 +16740,12 @@
             "state": "translated",
             "value": "Клетчатка"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fibre"
+          }
         }
       }
     },
@@ -16177,6 +16862,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Фолат"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Folati"
           }
         }
       }
@@ -16394,6 +17085,12 @@
             "state": "translated",
             "value": "Еда"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alimento"
+          }
         }
       }
     },
@@ -16510,6 +17207,12 @@
             "state": "translated",
             "value": "Дневник питания"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diario alimentare"
+          }
         }
       }
     },
@@ -16525,6 +17228,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Порядок в дневнике питания"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ordine diario alimentare"
           }
         }
       }
@@ -16738,6 +17447,12 @@
             "state": "translated",
             "value": "Продукты будут скопированы в %@. Исходные записи останутся без изменений."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gli alimenti verranno copiati in %@. Le voci originali rimarranno invariate."
+          }
         }
       }
     },
@@ -16856,6 +17571,12 @@
             "state": "translated",
             "value": "Французский"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Francese"
+          }
         }
       }
     },
@@ -16971,6 +17692,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Изображение + Заметка"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Da foto + nota"
           }
         }
       }
@@ -17181,6 +17908,12 @@
       "isCommentAutoGenerated": true,
       "localizations": {
         "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fud AI 4.4"
+          }
+        },
+        "it": {
           "stringUnit": {
             "state": "translated",
             "value": "Fud AI 4.4"
@@ -17491,6 +18224,12 @@
             "state": "translated",
             "value": "Розовый Fud"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosa Fud"
+          }
         }
       }
     },
@@ -17509,6 +18248,12 @@
             "state": "translated",
             "value": "г"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "g"
+          }
         }
       }
     },
@@ -17525,6 +18270,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Набрать вес"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aumentare di peso"
           }
         }
       }
@@ -17642,6 +18393,12 @@
             "state": "translated",
             "value": "Мягко и устойчиво. Отлично подходит для долгосрочных привычек."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delicato e sostenibile. Ideale per abitudini a lungo termine."
+          }
         }
       }
     },
@@ -17659,6 +18416,12 @@
             "state": "translated",
             "value": "Немецкий"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tedesco"
+          }
         }
       }
     },
@@ -17674,6 +18437,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Получайте мягкие напоминания во время еды,\nчтобы не забыть сделать запись."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ricevi promemoria discreti agli orari dei pasti\nper non dimenticare di registrarli."
           }
         }
       }
@@ -17889,6 +18658,12 @@
             "state": "translated",
             "value": "Узнайте сегодняшнюю сумму калорий и белка."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ottieni il totale odierno di calorie e proteine."
+          }
         }
       }
     },
@@ -17907,6 +18682,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Цель"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obiettivo"
           }
         }
       }
@@ -18115,6 +18896,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Целевой % жира"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obiettivo % massa grassa"
           }
         }
       }
@@ -18535,6 +19322,12 @@
             "state": "translated",
             "value": "Зелёный"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verde"
+          }
         }
       }
     },
@@ -18651,6 +19444,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Индекс здоровья"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punteggio salute"
           }
         }
       }
@@ -18866,6 +19665,12 @@
             "state": "translated",
             "value": "Привет, Siri, %@"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ehi Siri, %@"
+          }
         }
       }
     },
@@ -18881,6 +19686,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Скрывать напоминания о завтраке, обеде и ужине, пока активен этот фокус."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nascondi i promemoria di colazione, pranzo e cena mentre questa Full immersion è attiva."
           }
         }
       }
@@ -18899,6 +19710,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Скрывать напоминания Fud AI о приемах пищи, пока активен фокус."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nascondi i promemoria dei pasti di Fud AI mentre è attiva una Full immersion."
           }
         }
       }
@@ -19017,6 +19834,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Хинди"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hindi"
           }
         }
       }
@@ -19237,6 +20060,12 @@
             "state": "translated",
             "value": "Карточки нутриентов на главном экране"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schede nutrienti schermata Home"
+          }
         }
       }
     },
@@ -19254,6 +20083,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Нутриенты на главном экране"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nutrienti schermata Home"
           }
         }
       }
@@ -20057,6 +20892,12 @@
             "state": "translated",
             "value": "Я принимаю Условия использования и Политику конфиденциальности, включая описанную выше передачу данных ИИ-провайдеру."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accetto i Termini di servizio e l'Informativa sulla privacy, inclusa la condivisione dei dati con il provider IA descritta sopra."
+          }
         }
       }
     },
@@ -20074,6 +20915,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Не удалось записать эту еду. %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile registrare questo alimento. %@"
           }
         }
       }
@@ -20598,6 +21445,12 @@
             "state": "translated",
             "value": "Изображение прикреплено"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Immagine allegata"
+          }
         }
       }
     },
@@ -20615,6 +21468,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Влияние на сегодня"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impatto su oggi"
           }
         }
       }
@@ -21136,6 +21995,12 @@
             "state": "translated",
             "value": "Интенсивные тренировки 6–7 раз в неделю"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esercizio intenso 6–7 volte a settimana"
+          }
         }
       }
     },
@@ -21253,6 +22118,12 @@
             "state": "translated",
             "value": "Железо"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ferro"
+          }
         }
       }
     },
@@ -21269,6 +22140,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Итальянский"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Italiano"
           }
         }
       }
@@ -21287,6 +22164,12 @@
             "state": "translated",
             "value": "Японский"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giapponese"
+          }
         }
       }
     },
@@ -21302,6 +22185,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Фотографируй, записывай и будь здоров.\nПитание стало проще."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scatta, registra e raggiungi i tuoi obiettivi.\nLa tua nutrizione, semplificata."
           }
         }
       }
@@ -21419,6 +22308,12 @@
             "state": "translated",
             "value": "Держите питание и измерения тела\nв синхронизации автоматически."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantieni sincronizzati automaticamente\nnutrizione e misure corporee."
+          }
         }
       }
     },
@@ -21436,6 +22331,12 @@
             "state": "translated",
             "value": "Корейский"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coreano"
+          }
         }
       }
     },
@@ -21451,6 +22352,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Язык"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lingua"
           }
         }
       }
@@ -21468,6 +22375,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Сначала последние приёмы пищи"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prima i pasti più recenti"
           }
         }
       }
@@ -21782,6 +22695,12 @@
             "state": "translated",
             "value": "Лимит"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limite"
+          }
         }
       }
     },
@@ -21797,6 +22716,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Слушаю…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ascolto…"
           }
         }
       }
@@ -21814,6 +22739,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Мало или совсем без тренировок"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poco o nessun esercizio fisico"
           }
         }
       }
@@ -22024,6 +22955,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Заблокировать редактирование питания"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blocca modifica valori nutrizionali"
           }
         }
       }
@@ -22237,6 +23174,12 @@
             "state": "translated",
             "value": "Записать ${foodDescription}"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registra ${foodDescription}"
+          }
         }
       }
     },
@@ -22254,6 +23197,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Добавьте запись еды в Fud AI, описав, что вы съели."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registra un alimento in Fud AI descrivendo cosa hai mangiato."
           }
         }
       }
@@ -22469,6 +23418,12 @@
             "state": "translated",
             "value": "Записать еду"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registra alimento"
+          }
         }
       }
     },
@@ -22585,6 +23540,12 @@
             "state": "translated",
             "value": "Записать вес ${weightDescription}"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registra peso ${weightDescription}"
+          }
         }
       }
     },
@@ -22602,6 +23563,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Запишите текущий вес в Fud AI."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registra il tuo peso attuale in Fud AI."
           }
         }
       }
@@ -22722,6 +23689,12 @@
             "state": "translated",
             "value": "Записано %1$@ %2$@."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registrato %1$@ %2$@."
+          }
         }
       }
     },
@@ -22746,6 +23719,12 @@
             "state": "translated",
             "value": "Записано %1$@: %2$lld калорий и %3$@ г белка."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registrato %1$@: %2$lld calorie e %3$@ grammi di proteine."
+          }
         }
       }
     },
@@ -22762,6 +23741,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Сбросить вес"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Perdere peso"
           }
         }
       }
@@ -23371,6 +24356,12 @@
             "state": "translated",
             "value": "Магний"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Magnesio"
+          }
         }
       }
     },
@@ -23387,6 +24378,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Поддерживать"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantenimento"
           }
         }
       }
@@ -23503,6 +24500,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ручной ввод"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inserimento manuale"
           }
         }
       }
@@ -23818,6 +24821,12 @@
             "state": "translated",
             "value": "Фильтр напоминаний о еде"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtro promemoria pasti"
+          }
         }
       }
     },
@@ -23933,6 +24942,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Прием пищи"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipo di pasto"
           }
         }
       }
@@ -24438,6 +25453,12 @@
             "state": "translated",
             "value": "Мятный"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menta"
+          }
         }
       }
     },
@@ -24455,6 +25476,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Режим"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modalità"
           }
         }
       }
@@ -24572,6 +25599,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Умеренный"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Moderato"
           }
         }
       }
@@ -24790,6 +25823,12 @@
             "state": "translated",
             "value": "Мононенасыщ. жиры"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grassi monoinsaturi"
+          }
         }
       }
     },
@@ -24807,6 +25846,12 @@
             "state": "translated",
             "value": "Мононенасыщ. жиры"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grassi monoinsaturi"
+          }
         }
       }
     },
@@ -24822,6 +25867,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Подробнее о нутриентах"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Altri valori nutrizionali"
           }
         }
       }
@@ -24841,6 +25892,12 @@
             "state": "translated",
             "value": "Отключить напоминания о еде"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Silenzia promemoria pasti"
+          }
         }
       }
     },
@@ -24856,6 +25913,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Отключить напоминания о еде: ${muteMealReminders}"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Silenzia promemoria pasti: ${muteMealReminders}"
           }
         }
       }
@@ -25069,6 +26132,12 @@
             "state": "translated",
             "value": "Итоговое изменение"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Variazione netta"
+          }
         }
       }
     },
@@ -25182,6 +26251,12 @@
             "state": "translated",
             "value": "Ключ API не нужен.\nСканирование еды ИИ, голосовой ввод и тренер работают через Fud AI."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessuna chiave API richiesta.\nScansione alimenti con IA, inserimento vocale e Coach funzionano tramite Fud AI."
+          }
         }
       }
     },
@@ -25199,6 +26274,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Без обязательств — отменяйте в любое время"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun impegno — annulla quando vuoi"
           }
         }
       }
@@ -25317,6 +26398,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Нет занесённой еды в этот день"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun alimento registrato in questo giorno"
           }
         }
       }
@@ -25523,6 +26610,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Не переживайте! Мы воспользуемся стандартной формулой\nна основе вашего роста, веса и возраста."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun problema! Useremo una formula standard\nbasata su altezza, peso ed età."
           }
         }
       }
@@ -26031,6 +27124,12 @@
             "state": "translated",
             "value": "Данные о питании"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dati nutrizionali"
+          }
         }
       }
     },
@@ -26348,6 +27447,12 @@
             "state": "translated",
             "value": "из %lld ккал"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "su %lld kcal"
+          }
         }
       }
     },
@@ -26565,6 +27670,12 @@
             "state": "translated",
             "value": "Омега"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omega"
+          }
         }
       }
     },
@@ -26582,6 +27693,12 @@
             "state": "translated",
             "value": "Омега-3"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omega-3"
+          }
         }
       }
     },
@@ -26598,6 +27715,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Вкл = Кэтч-МакАрдл (использует безжировую массу тела для точного ПБМ). Выкл = Миффлин-Сент-Жор (только рост/вес/возраст). Выключите, если данные о жире устарели или недоступны."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attivo = Katch-McArdle (usa la massa magra per un BMR più accurato). Disattivo = Mifflin-St Jeor (solo altezza/peso/età). Disattiva se la misurazione della massa grassa non è recente."
           }
         }
       }
@@ -27103,6 +28226,12 @@
             "state": "translated",
             "value": "Оранжевый"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arancione"
+          }
         }
       }
     },
@@ -27219,6 +28348,12 @@
             "state": "translated",
             "value": "Другие нутриенты"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Altri nutrienti"
+          }
         }
       }
     },
@@ -27334,6 +28469,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Процентаж"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Percentuale"
           }
         }
       }
@@ -27453,6 +28594,12 @@
             "state": "translated",
             "value": "Медиатека"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Libreria foto"
+          }
         }
       }
     },
@@ -27570,6 +28717,12 @@
             "state": "translated",
             "value": "Полиненасыщ. жиры"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grassi polinsaturi"
+          }
         }
       }
     },
@@ -27586,6 +28739,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Полиненасыщ. жиры"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grassi polinsaturi"
           }
         }
       }
@@ -27604,6 +28763,12 @@
             "state": "translated",
             "value": "Португальский"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Portoghese"
+          }
         }
       }
     },
@@ -27620,6 +28785,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Калий"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Potassio"
           }
         }
       }
@@ -28038,6 +29209,12 @@
             "state": "translated",
             "value": "Белки"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proteine"
+          }
         }
       }
     },
@@ -28054,6 +29231,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Белки (г)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proteine (g)"
           }
         }
       }
@@ -28266,6 +29449,12 @@
             "state": "translated",
             "value": "Автоопределение провайдером"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatico del provider"
+          }
         }
       }
     },
@@ -28282,6 +29471,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Фиолетовый"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Viola"
           }
         }
       }
@@ -29193,6 +30388,12 @@
             "state": "translated",
             "value": "Красный"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rosso"
+          }
         }
       }
     },
@@ -29209,6 +30410,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Обновить цель расхода калорий"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiorna obiettivi consumo energetico"
           }
         }
       }
@@ -29228,6 +30435,12 @@
             "state": "translated",
             "value": "Обновить использование"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiorna utilizzo"
+          }
         }
       }
     },
@@ -29245,6 +30458,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Обновление использования"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiornamento utilizzo in corso…"
           }
         }
       }
@@ -29469,6 +30688,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Удалить запись %1$@ о %2$@? Это также удалит соответствующую запись из Apple Health."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rimuovere la voce del %1$@ di %2$@? Verrà eliminato anche il campione corrispondente da Apple Health."
           }
         }
       }
@@ -30275,6 +31500,12 @@
             "state": "translated",
             "value": "Сбросить по умолчанию"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ripristina predefiniti"
+          }
         }
       }
     },
@@ -30489,6 +31720,12 @@
             "state": "translated",
             "value": "Повторить"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riprova"
+          }
         }
       }
     },
@@ -30606,6 +31843,12 @@
             "state": "translated",
             "value": "Насыщ. жиры"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grassi saturi"
+          }
         }
       }
     },
@@ -30622,6 +31865,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Насыщенные жиры"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grassi saturi"
           }
         }
       }
@@ -31043,6 +32292,12 @@
             "state": "translated",
             "value": "Произнесите эти фразы Siri, чтобы пользоваться Fud AI без рук."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pronuncia queste frasi a Siri per usare Fud AI a mani libere."
+          }
         }
       }
     },
@@ -31159,6 +32414,12 @@
             "state": "translated",
             "value": "Потрите, чтобы узнать\nвашу специальную скидку!"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gratta per scoprire il tuo\nsconto speciale!"
+          }
         }
       }
     },
@@ -31271,6 +32532,12 @@
             "state": "translated",
             "value": "Малоподвижный"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sedentario"
+          }
         }
       }
     },
@@ -31288,6 +32555,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Отправить Тренеру"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invia con il tuo messaggio al Coach"
           }
         }
       }
@@ -31307,6 +32580,12 @@
             "state": "translated",
             "value": "Отдельно от целей по калориям, белкам, углеводам и жирам."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Separati dagli obiettivi di calorie, proteine, carboidrati e grassi."
+          }
         }
       }
     },
@@ -31322,6 +32601,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "URL сервера"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "URL del server"
           }
         }
       }
@@ -31742,6 +33027,12 @@
             "state": "translated",
             "value": "Отображается на главном"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrati nella schermata Home"
+          }
         }
       }
     },
@@ -31759,6 +33050,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Фразы Siri"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frasi per Siri"
           }
         }
       }
@@ -32366,6 +33663,12 @@
             "state": "translated",
             "value": "Натрий"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sodio"
+          }
         }
       }
     },
@@ -32381,6 +33684,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Сортировка"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ordina"
           }
         }
       }
@@ -32493,6 +33802,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Испанский"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spagnolo"
           }
         }
       }
@@ -32912,6 +34227,12 @@
             "state": "translated",
             "value": "Сахар"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zuccheri"
+          }
         }
       }
     },
@@ -32927,6 +34248,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Сахар, клетчатка, натрий"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zuccheri, fibre, sodio"
           }
         }
       }
@@ -32946,6 +34273,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Рекомендация ИИ"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suggerisci con IA"
           }
         }
       }
@@ -33361,6 +34694,12 @@
             "state": "translated",
             "value": "Нажмите на микрофон, чтобы начать"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tocca il microfono per iniziare"
+          }
         }
       }
     },
@@ -33471,6 +34810,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Цель"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obiettivo"
           }
         }
       }
@@ -33589,6 +34934,12 @@
             "state": "translated",
             "value": "Бирюзовый"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verde ottanio"
+          }
         }
       }
     },
@@ -33606,6 +34957,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "десятые"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "decimo"
           }
         }
       }
@@ -34017,6 +35374,12 @@
             "state": "translated",
             "value": "Самый сбалансированный темп — мотивирующий и устойчивый."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il ritmo più equilibrato, motivante e sostenibile."
+          }
         }
       }
     },
@@ -34032,6 +35395,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Цвет темы"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Colore tema"
           }
         }
       }
@@ -34050,6 +35419,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Это не записывает прием пищи. Оно показывает, как выглядел бы сегодняшний день, если записать %@."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questo non registra il pasto. Mostra come sarebbe la giornata di oggi se registrassi %@."
           }
         }
       }
@@ -34370,6 +35745,12 @@
             "state": "translated",
             "value": "Время"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ora"
+          }
         }
       }
     },
@@ -34385,6 +35766,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Диапазон времени"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intervallo di tempo"
           }
         }
       }
@@ -34410,6 +35797,12 @@
             "state": "translated",
             "value": "Сегодня записано %1$lld калорий и %2$@ г белка."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oggi hai registrato %1$lld calorie e %2$@ grammi di proteine."
+          }
         }
       }
     },
@@ -34434,6 +35827,12 @@
             "state": "translated",
             "value": "Сегодня записано %1$lld из %2$lld калорий. Осталось %3$lld калорий. Белок: %4$@ г."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oggi hai registrato %1$lld di %2$lld calorie. %3$lld calorie rimanenti. Proteine: %4$@ grammi."
+          }
         }
       }
     },
@@ -34452,6 +35851,12 @@
             "state": "translated",
             "value": "Сегодняшние калории"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calorie di oggi"
+          }
         }
       }
     },
@@ -34467,6 +35872,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Еда за сегодня"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alimenti di oggi"
           }
         }
       }
@@ -34588,6 +35999,12 @@
             "state": "translated",
             "value": "Всего записей"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Totale registrazioni"
+          }
         }
       }
     },
@@ -34604,6 +36021,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Трансжиры"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trans"
           }
         }
       }
@@ -34622,6 +36045,12 @@
             "state": "translated",
             "value": "Трансжиры"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grassi trans"
+          }
         }
       }
     },
@@ -34637,6 +36066,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Транскрипция через %@…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trascrizione tramite %@…"
           }
         }
       }
@@ -34755,6 +36190,12 @@
             "state": "translated",
             "value": "Убрать из избранного"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rimuovi dai preferiti"
+          }
         }
       }
     },
@@ -34771,6 +36212,12 @@
             "state": "translated",
             "value": "Единица"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unità"
+          }
         }
       }
     },
@@ -34786,6 +36233,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Разблокировать редактирование питания"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sblocca modifica valori nutrizionali"
           }
         }
       }
@@ -34901,6 +36354,12 @@
             "state": "translated",
             "value": "Обновить"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiorna"
+          }
         }
       }
     },
@@ -34919,6 +36378,12 @@
             "state": "translated",
             "value": "Доступно обновление"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiornamento disponibile"
+          }
         }
       }
     },
@@ -34935,6 +36400,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Использовать жир для ПБМ"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usa grasso corporeo per il BMR"
           }
         }
       }
@@ -34953,6 +36424,12 @@
             "state": "translated",
             "value": "Язык iPhone"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usa la lingua dell'iPhone"
+          }
         }
       }
     },
@@ -34968,6 +36445,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Используется при нажатии на иконку голоса для записи приёма пищи. Каждый провайдер запоминает свой язык. «Авто» — значение по умолчанию; «Язык iPhone» — текущий язык iPhone, если он поддерживается."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usato quando tocchi l'icona vocale per registrare un pasto. Ciascun provider memorizza la propria lingua. \"Automatico del provider\" mantiene quella predefinita del provider; \"Usa la lingua dell'iPhone\" invia la lingua corrente del tuo iPhone se supportata."
           }
         }
       }
@@ -35183,6 +36666,12 @@
             "state": "translated",
             "value": "Версия %@"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versione %@"
+          }
         }
       }
     },
@@ -35199,6 +36688,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Очень активный"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Molto attivo"
           }
         }
       }
@@ -35217,6 +36712,12 @@
             "state": "translated",
             "value": "Очень интенсивные ежедневные тренировки или физическая работа"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attività molto intensa quotidiana o lavoro fisico"
+          }
         }
       }
     },
@@ -35234,6 +36735,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Вид"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visualizzazione"
           }
         }
       }
@@ -35447,6 +36954,12 @@
             "state": "translated",
             "value": "Вит. A"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vit. A"
+          }
         }
       }
     },
@@ -35463,6 +36976,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Вит. C"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vit. C"
           }
         }
       }
@@ -35481,6 +37000,12 @@
             "state": "translated",
             "value": "Вит. D"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vit. D"
+          }
         }
       }
     },
@@ -35497,6 +37022,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Вит. E"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vit. E"
           }
         }
       }
@@ -35515,6 +37046,12 @@
             "state": "translated",
             "value": "Вит. K"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vit. K"
+          }
         }
       }
     },
@@ -35531,6 +37068,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Витамин A"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vitamina A"
           }
         }
       }
@@ -35549,6 +37092,12 @@
             "state": "translated",
             "value": "Витамин B12"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vitamina B12"
+          }
         }
       }
     },
@@ -35565,6 +37114,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Витамин C"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vitamina C"
           }
         }
       }
@@ -35583,6 +37138,12 @@
             "state": "translated",
             "value": "Витамин D"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vitamina D"
+          }
         }
       }
     },
@@ -35600,6 +37161,12 @@
             "state": "translated",
             "value": "Витамин E"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vitamina E"
+          }
         }
       }
     },
@@ -35616,6 +37183,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Витамин K"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vitamina K"
           }
         }
       }
@@ -35735,6 +37308,12 @@
             "state": "translated",
             "value": "Язык голоса"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lingua vocale"
+          }
         }
       }
     },
@@ -35851,6 +37430,12 @@
             "state": "translated",
             "value": "Мы будем поддерживать калории на стабильном уровне,\nчтобы сохранить ваш текущий вес."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manterremo costanti le tue calorie\nper conservare il tuo peso attuale."
+          }
         }
       }
     },
@@ -35866,6 +37451,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Мы настраиваем всё\nдля вас"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stiamo preparando\ntutto per te"
           }
         }
       }
@@ -36485,6 +38076,12 @@
             "state": "translated",
             "value": "Синхронизация веса"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sincronizzazione peso"
+          }
         }
       }
     },
@@ -36503,6 +38100,12 @@
             "state": "translated",
             "value": "Что вы съели?"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cosa hai mangiato?"
+          }
         }
       }
     },
@@ -36518,6 +38121,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Что если?"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cosa succederebbe?"
           }
         }
       }
@@ -36629,6 +38238,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Какой у вас вес?"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Qual è il tuo peso?"
           }
         }
       }
@@ -36843,6 +38458,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Что вы съели, например 100 г куриной грудки или два яйца и тост."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cosa hai mangiato, ad esempio 100g di petto di pollo o due uova con pane tostato."
           }
         }
       }
@@ -37062,6 +38683,12 @@
             "state": "translated",
             "value": "Что нового"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Novità"
+          }
         }
       }
     },
@@ -37077,6 +38704,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "При включении новые результаты открываются с граммами по умолчанию, даже если ИИ определяет порции. Вы всегда можете переключить единицы для каждого продукта."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se abilitato, i nuovi risultati degli alimenti si apriranno con i grammi selezionati anche se l'IA rileva tazze, porzioni o porzionature. Puoi comunque cambiare unità per ciascun alimento."
           }
         }
       }
@@ -37380,6 +39013,12 @@
             "state": "translated",
             "value": "целая"
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "intero"
+          }
         }
       }
     },
@@ -37395,6 +39034,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Целая"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intero"
           }
         }
       }
@@ -37998,6 +39643,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Вы достигнете цели через "
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raggiungerai il tuo obiettivo tra "
           }
         }
       }
@@ -38887,6 +40538,12 @@
             "state": "translated",
             "value": "Ваш вес, например 75 килограммов или 165 фунтов."
           }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il tuo peso, ad esempio 75 chilogrammi o 165 libbre."
+          }
         }
       }
     },
@@ -38903,6 +40560,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Цинк"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zinco"
           }
         }
       }
@@ -48374,6 +50037,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Hold the Fud AI app icon to use these shortcuts. Each slot opens its selected action directly. On iPhone, Quick Action 1–3 can also be assigned in Shortcuts to the Action Button or Back Tap."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tieni premuta l'icona dell'app Fud AI per usare queste abbreviazioni. Ogni posizione apre direttamente l'azione selezionata. Su iPhone, le Azioni rapide 1–3 possono anche essere assegnate in Comandi Rapidi al Tasto Azione o al Tocco posteriore."
           }
         }
       }


### PR DESCRIPTION
Adds Italian translations for existing iOS application strings.

Localizes colors, settings, nutrition labels, reminders, onboarding text, and other interface copy.
Preserves format placeholders and adds Italian singular/plural variants where required.