### PR TITLE
Add image display logic in FoodResultView

### DIFF
--- a/ios/calorietracker/Views/FoodResultView.swift
+++ b/ios/calorietracker/Views/FoodResultView.swift
@@ -300,7 +300,24 @@ struct FoodResultView: View {
         NavigationStack {
             ScrollViewReader { scrollProxy in
                 List {
-                    if !images.isEmpty {
+                    if let imageURL = productMetadata?.imageURL {
+                        Section {
+                            HStack {
+                                Spacer()
+                                AsyncImage(url: imageURL) { image in
+                                    image
+                                        .resizable()
+                                        .scaledToFit()
+                                } placeholder: {
+                                    ProgressView()
+                                }
+                                .frame(maxHeight: 100)
+                                .cornerRadius(8)
+                                Spacer()
+                            }
+                            .listRowBackground(Color.clear)
+                        }
+                    } else if !images.isEmpty {
                         Section {
                             ScrollView(.horizontal, showsIndicators: false) {
                                 LazyHStack(spacing: 12) {


### PR DESCRIPTION
Display product image if available, otherwise show images list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Product results now display remote product images when available, with a loading indicator while images load.
  - Results without a remote image continue to display available local images or the existing emoji fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->