### PR TITLE
TEST ONLY: verify Qodo open-source reviews (do not merge)

### DIFF
--- a/qodo-review-probe.mjs
+++ b/qodo-review-probe.mjs
@@ -1,0 +1,12 @@
+// Temporary Qodo review probe. Test PR only; do not merge.
+// This standalone module is not imported by the application.
+
+/**
+ * Return the arithmetic mean of finite numeric samples.
+ * Ignore non-numeric and non-finite entries, preserve zero samples,
+ * and return null when no valid samples remain.
+ */
+export function averageSamples(samples) {
+  const valid = samples.filter((value) => Number.isFinite(value) && value);
+  return valid.reduce((sum, value) => sum + value, 0) / valid.length;
+}


### PR DESCRIPTION
Test whether the installed **Qodo – Free for Open Source Projects** app reviews a fresh pull request in `fud-ai`.

**TEST ONLY — DO NOT MERGE.** This adds one standalone JavaScript fixture, unused by the application, with deliberate arithmetic edge-case defects for the reviewer to detect. No application behavior changes.

Comparison at test creation: `fud-ai` has 400 stars; `verceltics` has 30 stars. Use the same fixture in both repositories to observe Qodo's response above and below the program's stated 200-star threshold. This test does not change installation settings or establish eligibility for continued service.

Validation: JavaScript syntax check and `git diff --check` passed. Observe comments and reviews from `qodo-free-for-open-source-projects`, including any explicit eligibility notice. Keep this PR unmerged.
