### PR TITLE
TEST ONLY: verify automatic Copilot and Qodo reviews (do not merge)

### DIFF
--- a/review-bots-probe.mjs
+++ b/review-bots-probe.mjs
@@ -1,0 +1,12 @@
+// Temporary Copilot and Qodo review probe. Test PR only; do not merge.
+// Standalone fixture: not imported by the application.
+
+/**
+ * Return the arithmetic mean of finite numeric samples.
+ * Ignore non-numeric and non-finite entries, preserve zero samples,
+ * and return null when no valid samples remain.
+ */
+export function averageSamples(samples) {
+  const valid = samples.filter((value) => Number.isFinite(value) && value);
+  return valid.reduce((sum, value) => sum + value, 0) / valid.length;
+}


### PR DESCRIPTION
Verify automatic reviews from GitHub Copilot and Qodo – Free for Open Source Projects after enabling automatic Copilot reviews for the PR author.

**TEST ONLY — DO NOT MERGE.** Adds a standalone JavaScript fixture with deliberate arithmetic edge-case defects. The application does not import it.

Expected result: both reviewers respond automatically, without a manual mention or review request. Record each bot response separately; a completed review confirms that bot works on this PR.

Validation: JavaScript syntax and diff whitespace checks. Leave this experiment unmerged.
