### PR TITLE
Add full-screen meal photo viewer (#211)

### DIFF
--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/FoodImageStore.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/FoodImageStore.kt
@@ -48,6 +48,10 @@ class FoodImageStore(context: Context) {
     fun load(filename: String): Bitmap? =
         runCatching { FoodImageDecoder.decode(File(dir, filename)) }.getOrNull()
 
+    /** Bounded decode for full-screen viewer — avoids loading full-resolution on the main thread. */
+    fun loadForViewer(filename: String, maxDimension: Int = VIEWER_MAX_DIMENSION): Bitmap? =
+        runCatching { FoodImageDecoder.decode(File(dir, filename), maxDimension) }.getOrNull()
+
     fun loadThumbnail(filename: String, maxDimension: Int = THUMBNAIL_MAX_DIMENSION): Bitmap? {
         val key = "$filename:$maxDimension"
         thumbnailCache.get(key)?.takeUnless { it.isRecycled }?.let { return it }
@@ -138,6 +142,7 @@ class FoodImageStore(context: Context) {
         private const val DIR_NAME = "fudai-food-images"
         private const val THUMBNAIL_DIR_NAME = "fudai-food-thumbnails-v2"
         private const val THUMBNAIL_MAX_DIMENSION = 320
+        const val VIEWER_MAX_DIMENSION = 2048
         private const val THUMBNAIL_CACHE_KB = 12 * 1024
     }
 }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/FullScreenImageViewer.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/FullScreenImageViewer.kt
@@ -1,0 +1,136 @@
+package com.apoorvdarshan.calorietracker.ui.components
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.apoorvdarshan.calorietracker.R
+import kotlin.math.abs
+
+/**
+ * Full-screen meal photo viewer. Supports horizontal paging for multi-photo entries,
+ * a close button, and vertical drag-to-dismiss.
+ */
+@Composable
+fun FullScreenImageViewer(
+    bitmaps: List<Bitmap>,
+    initialIndex: Int = 0,
+    onDismiss: () -> Unit
+) {
+    if (bitmaps.isEmpty()) return
+
+    val startIndex = initialIndex.coerceIn(0, bitmaps.lastIndex)
+    val pagerState = rememberPagerState(
+        initialPage = startIndex,
+        pageCount = { bitmaps.size }
+    )
+    var dragOffset by remember { mutableFloatStateOf(0f) }
+    val dismissThresholdPx = 180f
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            decorFitsSystemWindows = false,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true
+        )
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = (1f - (abs(dragOffset) / 500f)).coerceIn(0.35f, 1f)))
+                .graphicsLayer { translationY = dragOffset }
+                .pointerInput(Unit) {
+                    detectVerticalDragGestures(
+                        onVerticalDrag = { change, dragAmount ->
+                            change.consume()
+                            dragOffset += dragAmount
+                        },
+                        onDragEnd = {
+                            if (abs(dragOffset) > dismissThresholdPx) {
+                                onDismiss()
+                            } else {
+                                dragOffset = 0f
+                            }
+                        },
+                        onDragCancel = { dragOffset = 0f }
+                    )
+                }
+        ) {
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.fillMaxSize()
+            ) { page ->
+                androidx.compose.foundation.Image(
+                    bitmap = bitmaps[page].asImageBitmap(),
+                    contentDescription = stringResource(R.string.cd_meal_photo, page + 1),
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+
+            if (bitmaps.size > 1) {
+                Text(
+                    text = "${pagerState.currentPage + 1}/${bitmaps.size}",
+                    color = Color.White,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .statusBarsPadding()
+                        .padding(start = 20.dp, top = 12.dp)
+                        .background(Color.White.copy(alpha = 0.18f), RoundedCornerShape(50))
+                        .padding(horizontal = 12.dp, vertical = 6.dp)
+                )
+            }
+
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .statusBarsPadding()
+                    .padding(end = 12.dp, top = 4.dp)
+                    .size(44.dp)
+                    .background(Color.White.copy(alpha = 0.22f), CircleShape)
+            ) {
+                Icon(
+                    Icons.Filled.Close,
+                    contentDescription = stringResource(R.string.cd_close),
+                    tint = Color.White
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/EditFoodEntrySheet.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/EditFoodEntrySheet.kt
@@ -81,7 +81,9 @@ import com.apoorvdarshan.calorietracker.ui.components.DateWheelPicker
 import com.apoorvdarshan.calorietracker.ui.components.FudGlassDialog
 import com.apoorvdarshan.calorietracker.ui.components.FudGlassDialogActions
 import com.apoorvdarshan.calorietracker.ui.components.FudGlassTextField
+import com.apoorvdarshan.calorietracker.ui.components.FullScreenImageViewer
 import com.apoorvdarshan.calorietracker.ui.theme.AppColors
+import android.graphics.Bitmap
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
@@ -123,6 +125,7 @@ fun EditFoodEntrySheet(
     var currentBaseEntry by remember(entry) { mutableStateOf(entry) }
     // Stage removals separately so tapping × does not reset the other editor fields.
     var removedImageFilenames by remember(entry) { mutableStateOf(emptySet<String>()) }
+    var previewPhotos by remember { mutableStateOf<Pair<List<Bitmap>, Int>?>(null) }
     var noteText by remember(entry) { mutableStateOf(entry.customNote ?: "") }
     var isReprocessing by remember { mutableStateOf(false) }
     var errorText by remember { mutableStateOf<String?>(null) }
@@ -414,11 +417,14 @@ fun EditFoodEntrySheet(
                                 Box {
                                     androidx.compose.foundation.Image(
                                         bitmap = bitmap.asImageBitmap(),
-                                        contentDescription = "Photo ${index + 1}",
+                                        contentDescription = stringResource(R.string.cd_view_full_photo),
                                         contentScale = androidx.compose.ui.layout.ContentScale.Crop,
                                         modifier = Modifier
                                             .size(240.dp)
                                             .clip(RoundedCornerShape(20.dp))
+                                            .clickable {
+                                                previewPhotos = photos.map { it.second } to index
+                                            }
                                     )
                                     IconButton(
                                         onClick = { removedImageFilenames = removedImageFilenames + filename },
@@ -869,6 +875,13 @@ fun EditFoodEntrySheet(
                 }
             },
             onDismiss = { ingredientEditor = null }
+        )
+    }
+    previewPhotos?.let { (bitmaps, index) ->
+        FullScreenImageViewer(
+            bitmaps = bitmaps,
+            initialIndex = index,
+            onDismiss = { previewPhotos = null }
         )
     }
 }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodResultSheet.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodResultSheet.kt
@@ -38,6 +38,10 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -59,6 +63,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.apoorvdarshan.calorietracker.services.FoodImageDecoder
+import com.apoorvdarshan.calorietracker.services.FoodImageStore
 import com.apoorvdarshan.calorietracker.R
 import com.apoorvdarshan.calorietracker.models.FoodEntry
 import com.apoorvdarshan.calorietracker.models.FoodSource
@@ -110,11 +115,10 @@ fun FoodResultSheet(
     ) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val bitmaps = remember(imageBytesList) {
-        imageBytesList.mapNotNull { FoodImageDecoder.decode(it, 720) }
-    }
-    val previewBitmaps = remember(imageBytesList) {
-        imageBytesList.mapNotNull { FoodImageDecoder.decode(it, 2048) }
+    val thumbnails = remember(imageBytesList) {
+        imageBytesList.mapIndexedNotNull { sourceIndex, bytes ->
+            FoodImageDecoder.decode(bytes, 720)?.let { sourceIndex to it }
+        }
     }
     val state = rememberModalBottomSheetState(
         skipPartiallyExpanded = true,
@@ -188,6 +192,21 @@ fun FoodResultSheet(
     var editableIngredients by rememberSaveable(analysis, stateSaver = foodDraftSaver<List<MealIngredient>>()) { mutableStateOf(analysis.ingredients) }
     var ingredientEditor by rememberSaveable(stateSaver = foodDraftSaver<IngredientEditorTarget?>()) { mutableStateOf<IngredientEditorTarget?>(null) }
     var previewPhotoIndex by remember { mutableStateOf<Int?>(null) }
+    var viewerBitmaps by remember { mutableStateOf<List<android.graphics.Bitmap>?>(null) }
+
+    LaunchedEffect(previewPhotoIndex) {
+        val index = previewPhotoIndex
+        if (index == null) {
+            viewerBitmaps = null
+            return@LaunchedEffect
+        }
+        viewerBitmaps = withContext(Dispatchers.IO) {
+            thumbnails.map { (sourceIndex, thumb) ->
+                FoodImageDecoder.decode(imageBytesList[sourceIndex], FoodImageStore.VIEWER_MAX_DIMENSION)
+                    ?: thumb
+            }
+        }
+    }
     var mealMenuExpanded by rememberSaveable { mutableStateOf(false) }
     var servingMenuExpanded by rememberSaveable { mutableStateOf(false) }
     val isDark = MaterialTheme.colorScheme.background.luminance() < 0.5f
@@ -367,12 +386,12 @@ fun FoodResultSheet(
                     Modifier.fillMaxWidth().padding(vertical = 8.dp),
                     contentAlignment = Alignment.Center
                 ) {
-                    if (bitmaps.isNotEmpty()) {
+                    if (thumbnails.isNotEmpty()) {
                         LazyRow(
                             horizontalArrangement = Arrangement.spacedBy(12.dp),
                             contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 8.dp)
                         ) {
-                            itemsIndexed(bitmaps) { index, bitmap ->
+                            itemsIndexed(thumbnails, key = { _, thumb -> thumb.first }) { index, (_, bitmap) ->
                                 Box {
                                     androidx.compose.foundation.Image(
                                         bitmap = bitmap.asImageBitmap(),
@@ -383,9 +402,9 @@ fun FoodResultSheet(
                                             .clip(RoundedCornerShape(20.dp))
                                             .clickable { previewPhotoIndex = index }
                                     )
-                                    if (bitmaps.size > 1) {
+                                    if (thumbnails.size > 1) {
                                         Text(
-                                            "${index + 1}/${bitmaps.size}",
+                                            "${index + 1}/${thumbnails.size}",
                                             color = Color.White,
                                             fontSize = 11.sp,
                                             fontWeight = FontWeight.SemiBold,
@@ -729,8 +748,23 @@ fun FoodResultSheet(
         )
     }
     previewPhotoIndex?.let { index ->
-        val images = previewBitmaps.ifEmpty { bitmaps }
-        if (images.isNotEmpty()) {
+        val images = viewerBitmaps
+        if (images == null) {
+            Dialog(
+                onDismissRequest = { previewPhotoIndex = null },
+                properties = DialogProperties(dismissOnBackPress = true, dismissOnClickOutside = false)
+            ) {
+                Box(
+                    Modifier
+                        .size(96.dp)
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(Color.Black.copy(alpha = 0.72f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(color = Color.White, modifier = Modifier.size(36.dp))
+                }
+            }
+        } else if (images.isNotEmpty()) {
             FullScreenImageViewer(
                 bitmaps = images,
                 initialIndex = index.coerceIn(0, images.lastIndex),

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodResultSheet.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodResultSheet.kt
@@ -2,6 +2,7 @@ package com.apoorvdarshan.calorietracker.ui.home
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -71,6 +72,7 @@ import com.apoorvdarshan.calorietracker.models.totals
 import com.apoorvdarshan.calorietracker.models.UserProfile
 import com.apoorvdarshan.calorietracker.models.allergenAnalysis
 import com.apoorvdarshan.calorietracker.services.ai.FoodAnalysis
+import com.apoorvdarshan.calorietracker.ui.components.FullScreenImageViewer
 import com.apoorvdarshan.calorietracker.ui.theme.AppColors
 import kotlin.math.roundToInt
 import java.time.Instant
@@ -110,6 +112,9 @@ fun FoodResultSheet(
 ) {
     val bitmaps = remember(imageBytesList) {
         imageBytesList.mapNotNull { FoodImageDecoder.decode(it, 720) }
+    }
+    val previewBitmaps = remember(imageBytesList) {
+        imageBytesList.mapNotNull { FoodImageDecoder.decode(it, 2048) }
     }
     val state = rememberModalBottomSheetState(
         skipPartiallyExpanded = true,
@@ -182,6 +187,7 @@ fun FoodResultSheet(
     var editableOmega3 by rememberSaveable(analysis) { mutableStateOf(analysis.omega3) }
     var editableIngredients by rememberSaveable(analysis, stateSaver = foodDraftSaver<List<MealIngredient>>()) { mutableStateOf(analysis.ingredients) }
     var ingredientEditor by rememberSaveable(stateSaver = foodDraftSaver<IngredientEditorTarget?>()) { mutableStateOf<IngredientEditorTarget?>(null) }
+    var previewPhotoIndex by remember { mutableStateOf<Int?>(null) }
     var mealMenuExpanded by rememberSaveable { mutableStateOf(false) }
     var servingMenuExpanded by rememberSaveable { mutableStateOf(false) }
     val isDark = MaterialTheme.colorScheme.background.luminance() < 0.5f
@@ -370,11 +376,12 @@ fun FoodResultSheet(
                                 Box {
                                     androidx.compose.foundation.Image(
                                         bitmap = bitmap.asImageBitmap(),
-                                        contentDescription = "Photo ${index + 1}",
+                                        contentDescription = stringResource(R.string.cd_view_full_photo),
                                         contentScale = androidx.compose.ui.layout.ContentScale.Crop,
                                         modifier = Modifier
                                             .size(240.dp)
                                             .clip(RoundedCornerShape(20.dp))
+                                            .clickable { previewPhotoIndex = index }
                                     )
                                     if (bitmaps.size > 1) {
                                         Text(
@@ -720,6 +727,16 @@ fun FoodResultSheet(
             },
             onDismiss = { ingredientEditor = null }
         )
+    }
+    previewPhotoIndex?.let { index ->
+        val images = previewBitmaps.ifEmpty { bitmaps }
+        if (images.isNotEmpty()) {
+            FullScreenImageViewer(
+                bitmaps = images,
+                initialIndex = index.coerceIn(0, images.lastIndex),
+                onDismiss = { previewPhotoIndex = null }
+            )
+        }
     }
 }
 

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
@@ -163,6 +163,7 @@ import com.apoorvdarshan.calorietracker.models.WaterEntry
 import com.apoorvdarshan.calorietracker.models.WaterUnit
 import com.apoorvdarshan.calorietracker.services.ai.FoodAnalysis
 import com.apoorvdarshan.calorietracker.ui.components.InAppCameraCaptureDialog
+import com.apoorvdarshan.calorietracker.ui.components.FullScreenImageViewer
 import com.apoorvdarshan.calorietracker.ui.components.MacroCard
 import com.apoorvdarshan.calorietracker.ui.components.DateWheelPicker
 import com.apoorvdarshan.calorietracker.ui.components.FudGlassDialog
@@ -2271,6 +2272,7 @@ private fun FoodRow(
     val bitmap = remember(entry.allImageFilenames) {
         entry.allImageFilenames.firstOrNull()?.let { container.imageStore.loadThumbnail(it) }
     }
+    var previewPhotos by remember { mutableStateOf<Pair<List<android.graphics.Bitmap>, Int>?>(null) }
     // iOS layout: large 76dp square thumb · column with (Name + heart on left,
     // time on right) · pink kcal · serving · macro tag pills row.
     Row(
@@ -2311,13 +2313,23 @@ private fun FoodRow(
             Modifier
                 .size(76.dp)
                 .clip(RoundedCornerShape(14.dp))
-                .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.06f)),
+                .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.06f))
+                .then(
+                    if (bitmap != null && !selectionMode) {
+                        Modifier.clickable {
+                            val photos = entry.allImageFilenames.mapNotNull { container.imageStore.load(it) }
+                            if (photos.isNotEmpty()) previewPhotos = photos to 0
+                        }
+                    } else {
+                        Modifier
+                    }
+                ),
             contentAlignment = Alignment.Center
         ) {
             when {
                 bitmap != null -> androidx.compose.foundation.Image(
                     bitmap = bitmap.asImageBitmap(),
-                    contentDescription = entry.name,
+                    contentDescription = stringResource(R.string.cd_view_full_photo),
                     contentScale = androidx.compose.ui.layout.ContentScale.Crop,
                     modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(14.dp))
                 )
@@ -2419,6 +2431,13 @@ private fun FoodRow(
                 MacroChip("F", entry.fat)
             }
         }
+    }
+    previewPhotos?.let { (bitmaps, index) ->
+        FullScreenImageViewer(
+            bitmaps = bitmaps,
+            initialIndex = index,
+            onDismiss = { previewPhotos = null }
+        )
     }
 }
 

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
@@ -186,8 +186,12 @@ import java.time.temporal.WeekFields
 import java.util.Locale
 import kotlin.math.roundToInt
 import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 
 private enum class AddMenuGroup {
     PhotoAndScan,
@@ -2269,10 +2273,13 @@ private fun FoodRow(
     val ctx = LocalContext.current
     val timeFmt = DateTimeFormatter.ofPattern(clockTimePattern(ctx), Locale.US).withZone(ZoneId.systemDefault())
     val container = (ctx.applicationContext as com.apoorvdarshan.calorietracker.FudAIApp).container
+    val scope = rememberCoroutineScope()
+    val hasPhotos = entry.allImageFilenames.isNotEmpty()
     val bitmap = remember(entry.allImageFilenames) {
-        entry.allImageFilenames.firstOrNull()?.let { container.imageStore.loadThumbnail(it) }
+        entry.allImageFilenames.firstNotNullOfOrNull { container.imageStore.loadThumbnail(it) }
     }
     var previewPhotos by remember { mutableStateOf<Pair<List<android.graphics.Bitmap>, Int>?>(null) }
+    var isLoadingPreview by remember { mutableStateOf(false) }
     // iOS layout: large 76dp square thumb · column with (Name + heart on left,
     // time on right) · pink kcal · serving · macro tag pills row.
     Row(
@@ -2315,10 +2322,18 @@ private fun FoodRow(
                 .clip(RoundedCornerShape(14.dp))
                 .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.06f))
                 .then(
-                    if (bitmap != null && !selectionMode) {
+                    if (hasPhotos && !selectionMode) {
                         Modifier.clickable {
-                            val photos = entry.allImageFilenames.mapNotNull { container.imageStore.load(it) }
-                            if (photos.isNotEmpty()) previewPhotos = photos to 0
+                            scope.launch {
+                                isLoadingPreview = true
+                                val loaded = withContext(Dispatchers.IO) {
+                                    entry.allImageFilenames.mapNotNull { filename ->
+                                        container.imageStore.loadForViewer(filename)
+                                    }
+                                }
+                                isLoadingPreview = false
+                                if (loaded.isNotEmpty()) previewPhotos = loaded to 0
+                            }
                         }
                     } else {
                         Modifier
@@ -2429,6 +2444,22 @@ private fun FoodRow(
                 MacroChip("P", entry.protein)
                 MacroChip("C", entry.carbs)
                 MacroChip("F", entry.fat)
+            }
+        }
+    }
+    if (isLoadingPreview) {
+        Dialog(
+            onDismissRequest = {},
+            properties = DialogProperties(dismissOnBackPress = false, dismissOnClickOutside = false)
+        ) {
+            Box(
+                Modifier
+                    .size(96.dp)
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(Color.Black.copy(alpha = 0.72f)),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(color = Color.White, modifier = Modifier.size(36.dp))
             }
         }
     }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/AllergenSensitivitiesScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/AllergenSensitivitiesScreen.kt
@@ -93,6 +93,9 @@ fun AllergenSensitivitiesScreen(
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+    val importReadFailed = stringResource(R.string.settings_allergen_import_read_failed)
+    val importNoneFound = stringResource(R.string.settings_allergen_import_none_found)
+    val importFailed = stringResource(R.string.settings_allergen_import_failed)
     var allergens by rememberSaveable { mutableStateOf(current) }
     var value by rememberSaveable { mutableStateOf("") }
     var pendingDelete by rememberSaveable { mutableStateOf<String?>(null) }
@@ -145,22 +148,21 @@ fun AllergenSensitivitiesScreen(
         scope.launch {
             val result = runCatching {
                 val images = withContext(Dispatchers.IO) { loadImages() }
-                if (images.isEmpty()) error(context.getString(R.string.settings_allergen_import_read_failed))
+                if (images.isEmpty()) error(importReadFailed)
                 foodAnalysis.extractAllergensFromLabReport(images)
             }
             isImporting = false
             result.fold(
                 onSuccess = { names ->
                     if (names.isEmpty()) {
-                        importError = context.getString(R.string.settings_allergen_import_none_found)
+                        importError = importNoneFound
                     } else {
                         selectedImport = names.toSet()
                         pendingImport = names
                     }
                 },
                 onFailure = { error ->
-                    importError = error.message
-                        ?: context.getString(R.string.settings_allergen_import_failed)
+                    importError = error.message ?: importFailed
                 }
             )
         }
@@ -172,7 +174,7 @@ fun AllergenSensitivitiesScreen(
         if (uri == null) return@rememberLauncherForActivityResult
         runLabReportImport {
             val bytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
-                ?: error(context.getString(R.string.settings_allergen_import_read_failed))
+                ?: error(importReadFailed)
             listOf(bytes)
         }
     }
@@ -182,7 +184,7 @@ fun AllergenSensitivitiesScreen(
     ) { uri ->
         if (uri == null) return@rememberLauncherForActivityResult
         runLabReportImport {
-            labReportImagesFromUri(context, uri)
+            labReportImagesFromUri(context, uri, importReadFailed)
         }
     }
 
@@ -503,10 +505,10 @@ fun AllergenSensitivitiesScreen(
     }
 }
 
-private fun labReportImagesFromUri(context: Context, uri: Uri): List<ByteArray> {
+private fun labReportImagesFromUri(context: Context, uri: Uri, readFailedMessage: String): List<ByteArray> {
     val mime = context.contentResolver.getType(uri).orEmpty()
     val bytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
-        ?: error(context.getString(R.string.settings_allergen_import_read_failed))
+        ?: error(readFailedMessage)
     val isPdf = mime.equals("application/pdf", ignoreCase = true) ||
         (uri.lastPathSegment?.endsWith(".pdf", ignoreCase = true) == true)
     return if (isPdf) {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1022,6 +1022,8 @@
     <string name="cd_hold_to_record">Hold to record, tap to lock</string>
     <string name="cd_cancel_recording">Cancel recording</string>
     <string name="cd_remove_image">Remove image</string>
+    <string name="cd_meal_photo">Photo %1$d</string>
+    <string name="cd_view_full_photo">View full photo</string>
     <string name="cd_add_image">Add image</string>
     <string name="cd_open_camera">Open camera</string>
     <string name="cd_close_camera">Close camera</string>

--- a/ios/calorietracker/ContentView.swift
+++ b/ios/calorietracker/ContentView.swift
@@ -3215,6 +3215,7 @@ final class BarcodeScannerViewController: UIViewController, AVCaptureMetadataOut
 struct FoodRow: View {
     let entry: FoodEntry
     @Environment(FoodStore.self) private var foodStore
+    @State private var imagePreview: FullScreenImagePreview?
 
     private var servingText: String? {
         guard let grams = entry.servingSizeGrams else {
@@ -3237,28 +3238,36 @@ struct FoodRow: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            // Thumbnail
+            // Thumbnail — tap opens full-screen viewer without opening edit.
             if let imageData = entry.imageData, let uiImage = UIImage(data: imageData) {
-                Image(uiImage: uiImage)
-                    .resizable()
-                    .scaledToFill()
-                    .frame(width: 56, height: 56)
-                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12, style: .continuous)
-                            .strokeBorder(AppColors.calorie.opacity(0.15), lineWidth: 1)
-                    )
-                    .overlay(alignment: .bottomTrailing) {
-                        if !entry.additionalImageData.isEmpty {
-                            Text("+\(entry.additionalImageData.count)")
-                                .font(.caption2.weight(.bold))
-                                .foregroundStyle(.white)
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 3)
-                                .background(.black.opacity(0.65), in: Capsule())
-                                .padding(4)
+                Button {
+                    let images = entry.allImageData.compactMap(UIImage.init(data:))
+                    guard !images.isEmpty else { return }
+                    imagePreview = FullScreenImagePreview(images: images)
+                } label: {
+                    Image(uiImage: uiImage)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: 56, height: 56)
+                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                .strokeBorder(AppColors.calorie.opacity(0.15), lineWidth: 1)
+                        )
+                        .overlay(alignment: .bottomTrailing) {
+                            if !entry.additionalImageData.isEmpty {
+                                Text("+\(entry.additionalImageData.count)")
+                                    .font(.caption2.weight(.bold))
+                                    .foregroundStyle(.white)
+                                    .padding(.horizontal, 6)
+                                    .padding(.vertical, 3)
+                                    .background(.black.opacity(0.65), in: Capsule())
+                                    .padding(4)
+                            }
                         }
-                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("View full photo")
             } else if let emoji = entry.emoji {
                 Text(emoji)
                     .font(.system(size: 28))
@@ -3313,6 +3322,7 @@ struct FoodRow: View {
             }
         }
         .padding(.vertical, 4)
+        .fullScreenImagePreview($imagePreview)
     }
 }
 

--- a/ios/calorietracker/Views/EditFoodEntryView.swift
+++ b/ios/calorietracker/Views/EditFoodEntryView.swift
@@ -225,11 +225,15 @@ struct EditFoodEntryView: View {
                                         .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
                                         .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
                                         .onTapGesture {
-                                            let previewImages = photos.compactMap { $0.data.flatMap(UIImage.init(data:)) }
-                                            guard !previewImages.isEmpty else { return }
+                                            let previewItems = photos.compactMap { photo -> (FoodEntryPhoto.ID, UIImage)? in
+                                                guard let image = photo.data.flatMap(UIImage.init(data:)) else { return nil }
+                                                return (photo.id, image)
+                                            }
+                                            guard !previewItems.isEmpty else { return }
+                                            let initialIndex = previewItems.firstIndex(where: { $0.0 == photo.id }) ?? 0
                                             imagePreview = FullScreenImagePreview(
-                                                images: previewImages,
-                                                initialIndex: min(index, previewImages.count - 1)
+                                                images: previewItems.map(\.1),
+                                                initialIndex: initialIndex
                                             )
                                         }
                                         .accessibilityAddTraits(.isButton)

--- a/ios/calorietracker/Views/EditFoodEntryView.swift
+++ b/ios/calorietracker/Views/EditFoodEntryView.swift
@@ -52,6 +52,7 @@ struct EditFoodEntryView: View {
     @State private var reprocessingError: String? = nil
     @State private var isDeleteConfirmationPresented = false
     @State private var removedPhotoIDs = Set<FoodEntryPhoto.ID>()
+    @State private var imagePreview: FullScreenImagePreview?
 
     @State private var name: String
     @State private var servingSizeGrams: Double
@@ -222,6 +223,17 @@ struct EditFoodEntryView: View {
                                         }
                                         .frame(width: 220, height: 200)
                                         .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                                        .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                                        .onTapGesture {
+                                            let previewImages = photos.compactMap { $0.data.flatMap(UIImage.init(data:)) }
+                                            guard !previewImages.isEmpty else { return }
+                                            imagePreview = FullScreenImagePreview(
+                                                images: previewImages,
+                                                initialIndex: min(index, previewImages.count - 1)
+                                            )
+                                        }
+                                        .accessibilityAddTraits(.isButton)
+                                        .accessibilityLabel("View full photo")
                                         .overlay(alignment: .topTrailing) {
                                             Button {
                                                 removedPhotoIDs.insert(photo.id)
@@ -530,6 +542,7 @@ struct EditFoodEntryView: View {
                         }
                     )
                 }
+                .fullScreenImagePreview($imagePreview)
             }
         }
     }

--- a/ios/calorietracker/Views/FoodResultView.swift
+++ b/ios/calorietracker/Views/FoodResultView.swift
@@ -63,6 +63,7 @@ struct FoodResultView: View {
     @State private var editableIngredients: [MealIngredient]
     @State private var ingredientEditor: IngredientEditorTarget?
     @State private var showWhatIfSheet = false
+    @State private var imagePreview: FullScreenImagePreview?
     @State private var submissionGate = FoodSubmissionGate()
     @State var mealType: MealType = .currentMeal
 
@@ -310,6 +311,12 @@ struct FoodResultView: View {
                                             .scaledToFill()
                                             .frame(width: 220, height: 200)
                                             .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                                            .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                                            .onTapGesture {
+                                                imagePreview = FullScreenImagePreview(images: images, initialIndex: index)
+                                            }
+                                            .accessibilityAddTraits(.isButton)
+                                            .accessibilityLabel("View full photo")
                                             .overlay(alignment: .bottomTrailing) {
                                                 if images.count > 1 {
                                                     Text("\(index + 1)/\(images.count)")
@@ -589,6 +596,7 @@ struct FoodResultView: View {
                         }
                     )
                 }
+                .fullScreenImagePreview($imagePreview)
             }
         }
     }

--- a/ios/calorietracker/Views/FullScreenImageViewer.swift
+++ b/ios/calorietracker/Views/FullScreenImageViewer.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+/// Session payload for presenting one or more meal photos full-screen.
+struct FullScreenImagePreview: Identifiable {
+    let id = UUID()
+    let images: [UIImage]
+    let initialIndex: Int
+
+    init(images: [UIImage], initialIndex: Int = 0) {
+        self.images = images
+        self.initialIndex = min(max(0, initialIndex), max(images.count - 1, 0))
+    }
+}
+
+/// Full-screen meal photo viewer with page swipe (multi-photo), close button, and swipe-down dismiss.
+struct FullScreenImageViewer: View {
+    let images: [UIImage]
+    let initialIndex: Int
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var currentIndex: Int
+    @State private var dragOffset: CGFloat = 0
+    @State private var backdropOpacity: Double = 1
+
+    init(images: [UIImage], initialIndex: Int = 0) {
+        self.images = images
+        self.initialIndex = initialIndex
+        _currentIndex = State(initialValue: min(max(0, initialIndex), max(images.count - 1, 0)))
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black
+                .opacity(backdropOpacity)
+                .ignoresSafeArea()
+
+            TabView(selection: $currentIndex) {
+                ForEach(Array(images.enumerated()), id: \.offset) { index, image in
+                    Image(uiImage: image)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .tag(index)
+                        .accessibilityLabel("Photo \(index + 1)")
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: images.count > 1 ? .automatic : .never))
+            .offset(y: dragOffset)
+
+            VStack {
+                HStack {
+                    if images.count > 1 {
+                        Text("\(currentIndex + 1)/\(images.count)")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(.white.opacity(0.18), in: Capsule())
+                    }
+                    Spacer()
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 15, weight: .bold))
+                            .foregroundStyle(.white)
+                            .frame(width: 36, height: 36)
+                            .background(.white.opacity(0.22), in: Circle())
+                            .frame(width: 44, height: 44)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Close")
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+                Spacer()
+            }
+        }
+        .statusBarHidden(true)
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 24)
+                .onChanged { value in
+                    let vertical = value.translation.height
+                    let horizontal = abs(value.translation.width)
+                    // Prefer vertical dismiss; ignore mostly-horizontal page swipes.
+                    guard abs(vertical) > horizontal else { return }
+                    dragOffset = vertical
+                    backdropOpacity = Double(max(0.35, 1 - abs(vertical) / 420))
+                }
+                .onEnded { value in
+                    let shouldDismiss = abs(value.translation.height) > 120
+                        || abs(value.predictedEndTranslation.height) > 420
+                    if shouldDismiss {
+                        dismiss()
+                    } else {
+                        withAnimation(.spring(response: 0.32, dampingFraction: 0.86)) {
+                            dragOffset = 0
+                            backdropOpacity = 1
+                        }
+                    }
+                }
+        )
+    }
+}
+
+extension View {
+    func fullScreenImagePreview(_ preview: Binding<FullScreenImagePreview?>) -> some View {
+        fullScreenCover(item: preview) { session in
+            FullScreenImageViewer(images: session.images, initialIndex: session.initialIndex)
+        }
+    }
+}

--- a/ios/calorietracker/Views/FullScreenImageViewer.swift
+++ b/ios/calorietracker/Views/FullScreenImageViewer.swift
@@ -21,6 +21,7 @@ struct FullScreenImageViewer: View {
     @State private var currentIndex: Int
     @State private var dragOffset: CGFloat = 0
     @State private var backdropOpacity: Double = 1
+    @State private var verticalDismissCommitted = false
 
     init(images: [UIImage], initialIndex: Int = 0) {
         self.images = images
@@ -84,12 +85,27 @@ struct FullScreenImageViewer: View {
                     let vertical = value.translation.height
                     let horizontal = abs(value.translation.width)
                     // Prefer vertical dismiss; ignore mostly-horizontal page swipes.
-                    guard abs(vertical) > horizontal else { return }
+                    guard abs(vertical) > horizontal else {
+                        verticalDismissCommitted = false
+                        return
+                    }
+                    verticalDismissCommitted = true
                     dragOffset = vertical
                     backdropOpacity = Double(max(0.35, 1 - abs(vertical) / 420))
                 }
                 .onEnded { value in
-                    let shouldDismiss = abs(value.translation.height) > 120
+                    let vertical = value.translation.height
+                    let horizontal = abs(value.translation.width)
+                    guard verticalDismissCommitted, abs(vertical) > horizontal else {
+                        verticalDismissCommitted = false
+                        withAnimation(.spring(response: 0.32, dampingFraction: 0.86)) {
+                            dragOffset = 0
+                            backdropOpacity = 1
+                        }
+                        return
+                    }
+                    verticalDismissCommitted = false
+                    let shouldDismiss = abs(vertical) > 120
                         || abs(value.predictedEndTranslation.height) > 420
                     if shouldDismiss {
                         dismiss()


### PR DESCRIPTION
## Summary
- Tapping a meal photo thumbnail opens a full-screen (or near full-screen) image viewer on **iOS** and **Android**
- Covers diary row thumbnails, post-analysis review sheets, and edit-entry photo galleries
- Dismiss via close button or swipe down; multi-photo entries can page horizontally

Closes #211

## Test plan
- [ ] **Diary**: Log a meal with a photo → tap the small thumbnail on the food row → confirm full picture opens → dismiss with ✕ or swipe down → confirm tapping the rest of the row still opens Edit
- [ ] **Review / result**: Capture or pick a food photo → on the review sheet, tap the large photo tile → full viewer opens
- [ ] **Edit entry**: Open an existing photo meal → tap a gallery photo (not the remove ✕) → full viewer opens; remove button still works
- [ ] **Multi-photo** (if available): swipe between photos in the viewer; counter shows `n/m`
- [ ] Verify on both iOS and Android


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full-screen meal photo viewing on Android and iOS.
  * Tap meal thumbnails in home, edit, and review screens to open a swipeable photo gallery.
  * Added page indicators, close controls, loading states, and swipe-down dismissal.
  * Android previews use higher-resolution images when available.
* **Bug Fixes**
  * Improved photo selection so the viewer opens to the tapped image.
  * Prevented horizontal swipes with minor vertical movement from accidentally dismissing the viewer.
* **Accessibility**
  * Added descriptive labels for viewing full photos and identifying individual meal photos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds full-screen, swipeable meal-photo viewers throughout the Android and iOS diary, review, and edit flows.

- Adds platform-specific full-screen viewer components with paging, counters, close controls, and swipe-down dismissal.
- Connects diary thumbnails, result photos, and edit galleries to the viewers.
- Adds bounded Android viewer decoding and associated accessibility strings.

<h3>Confidence Score: 3/5</h3>

The PR does not appear safe to merge until diary and edit-gallery decode failures stop opening the wrong photo or silently failing to open the viewer.

Android diary previews still discard failed full-resolution decodes and open the filtered list at index zero, while iOS placeholder taps still default to the first decodable image; both leave previously reported wrong-photo behavior outstanding.

**Files Needing Attention:** android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt; ios/calorietracker/Views/EditFoodEntryView.swift

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/src/main/java/com/apoorvdarshan/calorietracker/services/FoodImageStore.kt | Adds bounded 2048px image loading for Android full-screen previews. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/FullScreenImageViewer.kt | Introduces the Android full-screen pager with counters, close control, and vertical dismissal. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodResultSheet.kt | Connects analysis-result thumbnails to asynchronous, identity-preserving full-screen previews. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt | Connects diary thumbnails to the viewer, but filtered decode failures still cause incorrect or absent previews. |
| ios/calorietracker/Views/EditFoodEntryView.swift | Uses photo IDs to preserve decodable selections, while undecodable placeholders still fall back to an unrelated photo. |
| ios/calorietracker/Views/FullScreenImageViewer.swift | Introduces the iOS full-screen viewer and reusable presentation modifier. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  T[Meal photo thumbnail] --> P[Build preview image list]
  P --> V[Full-screen viewer]
  V --> G[Horizontal paging]
  V --> D[Close or swipe-down dismissal]
```

<sub>Reviews (4): Last reviewed commit: ["Merge main into feature/211-fullscreen-m..."](https://github.com/apoorvdarshan/fud-ai/commit/820021c3a8ccaa43bd216074bee2016dc108310f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62553217)</sub>

<!-- /greptile_comment -->