### PR TITLE
Full-screen meal photo viewer (closes #211)

### DIFF
--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/FullscreenMealPhotoViewer.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/FullscreenMealPhotoViewer.kt
@@ -1,0 +1,136 @@
+package com.apoorvdarshan.calorietracker.ui.components
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.apoorvdarshan.calorietracker.R
+import kotlin.math.roundToInt
+
+data class MealPhotoViewerState(
+    val bitmaps: List<Bitmap>,
+    val startIndex: Int = 0
+)
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun FullscreenMealPhotoViewer(
+    state: MealPhotoViewerState,
+    onDismiss: () -> Unit
+) {
+    if (state.bitmaps.isEmpty()) return
+
+    val startIndex = state.startIndex.coerceIn(0, state.bitmaps.lastIndex)
+    val pagerState = rememberPagerState(initialPage = startIndex) { state.bitmaps.size }
+    var dragOffset by remember { mutableFloatStateOf(0f) }
+    val dismissThresholdPx = with(LocalDensity.current) { 120.dp.toPx() }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black)
+                .offset { IntOffset(0, dragOffset.roundToInt()) }
+                .graphicsLayer {
+                    alpha = 1f - (dragOffset / 300f).coerceIn(0f, 0.35f)
+                }
+                .pointerInput(Unit) {
+                    detectVerticalDragGestures(
+                        onVerticalDrag = { _, dragAmount ->
+                            if (dragAmount > 0f || dragOffset > 0f) {
+                                dragOffset = (dragOffset + dragAmount).coerceAtLeast(0f)
+                            }
+                        },
+                        onDragEnd = {
+                            if (dragOffset > dismissThresholdPx) {
+                                onDismiss()
+                            } else {
+                                dragOffset = 0f
+                            }
+                        },
+                        onDragCancel = { dragOffset = 0f }
+                    )
+                }
+        ) {
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.fillMaxSize()
+            ) { page ->
+                androidx.compose.foundation.Image(
+                    bitmap = state.bitmaps[page].asImageBitmap(),
+                    contentDescription = stringResource(R.string.cd_meal_photo, page + 1),
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(18.dp)
+                    .size(44.dp)
+                    .clip(CircleShape)
+                    .background(Color.Black.copy(alpha = 0.45f))
+            ) {
+                Icon(
+                    Icons.Filled.Close,
+                    contentDescription = stringResource(R.string.cd_close),
+                    tint = Color.White
+                )
+            }
+
+            if (state.bitmaps.size > 1) {
+                Text(
+                    "${pagerState.currentPage + 1}/${state.bitmaps.size}",
+                    color = Color.White,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(18.dp)
+                        .clip(CircleShape)
+                        .background(Color.Black.copy(alpha = 0.45f))
+                        .padding(horizontal = 12.dp, vertical = 8.dp)
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/EditFoodEntrySheet.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/EditFoodEntrySheet.kt
@@ -78,6 +78,8 @@ import com.apoorvdarshan.calorietracker.models.ServingAmountExpression
 import com.apoorvdarshan.calorietracker.models.SupplementalNutrient
 import com.apoorvdarshan.calorietracker.models.totals
 import com.apoorvdarshan.calorietracker.ui.components.DateWheelPicker
+import com.apoorvdarshan.calorietracker.ui.components.FullscreenMealPhotoViewer
+import com.apoorvdarshan.calorietracker.ui.components.MealPhotoViewerState
 import com.apoorvdarshan.calorietracker.ui.components.FudGlassDialog
 import com.apoorvdarshan.calorietracker.ui.components.FudGlassDialogActions
 import com.apoorvdarshan.calorietracker.ui.components.FudGlassTextField
@@ -172,6 +174,7 @@ fun EditFoodEntrySheet(
     var showDatePicker by remember { mutableStateOf(false) }
     var showTimePicker by remember { mutableStateOf(false) }
     var showDeleteConfirmation by remember { mutableStateOf(false) }
+    var photoViewerState by remember { mutableStateOf<MealPhotoViewerState?>(null) }
     val isDark = MaterialTheme.colorScheme.background.luminance() < 0.5f
     val sheetSurface = if (isDark) MaterialTheme.colorScheme.surface else Color(0xFFFAF3EE)
     val context = LocalContext.current
@@ -419,6 +422,12 @@ fun EditFoodEntrySheet(
                                         modifier = Modifier
                                             .size(240.dp)
                                             .clip(RoundedCornerShape(20.dp))
+                                            .clickable {
+                                                photoViewerState = MealPhotoViewerState(
+                                                    bitmaps = photos.map { it.second },
+                                                    startIndex = index
+                                                )
+                                            }
                                     )
                                     IconButton(
                                         onClick = { removedImageFilenames = removedImageFilenames + filename },
@@ -869,6 +878,12 @@ fun EditFoodEntrySheet(
                 }
             },
             onDismiss = { ingredientEditor = null }
+        )
+    }
+    photoViewerState?.let { viewerState ->
+        FullscreenMealPhotoViewer(
+            state = viewerState,
+            onDismiss = { photoViewerState = null }
         )
     }
 }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodResultSheet.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodResultSheet.kt
@@ -71,7 +71,10 @@ import com.apoorvdarshan.calorietracker.models.totals
 import com.apoorvdarshan.calorietracker.models.UserProfile
 import com.apoorvdarshan.calorietracker.models.allergenAnalysis
 import com.apoorvdarshan.calorietracker.services.ai.FoodAnalysis
+import com.apoorvdarshan.calorietracker.ui.components.FullscreenMealPhotoViewer
+import com.apoorvdarshan.calorietracker.ui.components.MealPhotoViewerState
 import com.apoorvdarshan.calorietracker.ui.theme.AppColors
+import androidx.compose.foundation.clickable
 import kotlin.math.roundToInt
 import java.time.Instant
 
@@ -182,6 +185,7 @@ fun FoodResultSheet(
     var editableOmega3 by rememberSaveable(analysis) { mutableStateOf(analysis.omega3) }
     var editableIngredients by rememberSaveable(analysis, stateSaver = foodDraftSaver<List<MealIngredient>>()) { mutableStateOf(analysis.ingredients) }
     var ingredientEditor by rememberSaveable(stateSaver = foodDraftSaver<IngredientEditorTarget?>()) { mutableStateOf<IngredientEditorTarget?>(null) }
+    var photoViewerState by remember { mutableStateOf<MealPhotoViewerState?>(null) }
     var mealMenuExpanded by rememberSaveable { mutableStateOf(false) }
     var servingMenuExpanded by rememberSaveable { mutableStateOf(false) }
     val isDark = MaterialTheme.colorScheme.background.luminance() < 0.5f
@@ -375,6 +379,12 @@ fun FoodResultSheet(
                                         modifier = Modifier
                                             .size(240.dp)
                                             .clip(RoundedCornerShape(20.dp))
+                                            .clickable {
+                                                photoViewerState = MealPhotoViewerState(
+                                                    bitmaps = bitmaps,
+                                                    startIndex = index
+                                                )
+                                            }
                                     )
                                     if (bitmaps.size > 1) {
                                         Text(
@@ -719,6 +729,12 @@ fun FoodResultSheet(
                 }
             },
             onDismiss = { ingredientEditor = null }
+        )
+    }
+    photoViewerState?.let { viewerState ->
+        FullscreenMealPhotoViewer(
+            state = viewerState,
+            onDismiss = { photoViewerState = null }
         )
     }
 }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
@@ -162,7 +162,9 @@ import com.apoorvdarshan.calorietracker.models.ServingUnitOption
 import com.apoorvdarshan.calorietracker.models.WaterEntry
 import com.apoorvdarshan.calorietracker.models.WaterUnit
 import com.apoorvdarshan.calorietracker.services.ai.FoodAnalysis
+import com.apoorvdarshan.calorietracker.ui.components.FullscreenMealPhotoViewer
 import com.apoorvdarshan.calorietracker.ui.components.InAppCameraCaptureDialog
+import com.apoorvdarshan.calorietracker.ui.components.MealPhotoViewerState
 import com.apoorvdarshan.calorietracker.ui.components.MacroCard
 import com.apoorvdarshan.calorietracker.ui.components.DateWheelPicker
 import com.apoorvdarshan.calorietracker.ui.components.FudGlassDialog
@@ -2268,8 +2270,12 @@ private fun FoodRow(
     val ctx = LocalContext.current
     val timeFmt = DateTimeFormatter.ofPattern(clockTimePattern(ctx), Locale.US).withZone(ZoneId.systemDefault())
     val container = (ctx.applicationContext as com.apoorvdarshan.calorietracker.FudAIApp).container
+    var photoViewerState by remember { mutableStateOf<MealPhotoViewerState?>(null) }
     val bitmap = remember(entry.allImageFilenames) {
         entry.allImageFilenames.firstOrNull()?.let { container.imageStore.loadThumbnail(it) }
+    }
+    val fullBitmaps = remember(entry.allImageFilenames) {
+        entry.allImageFilenames.mapNotNull { container.imageStore.load(it) }
     }
     // iOS layout: large 76dp square thumb · column with (Name + heart on left,
     // time on right) · pink kcal · serving · macro tag pills row.
@@ -2311,7 +2317,16 @@ private fun FoodRow(
             Modifier
                 .size(76.dp)
                 .clip(RoundedCornerShape(14.dp))
-                .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.06f)),
+                .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.06f))
+                .then(
+                    if (fullBitmaps.isNotEmpty()) {
+                        Modifier.clickable {
+                            photoViewerState = MealPhotoViewerState(bitmaps = fullBitmaps)
+                        }
+                    } else {
+                        Modifier
+                    }
+                ),
             contentAlignment = Alignment.Center
         ) {
             when {
@@ -2419,6 +2434,13 @@ private fun FoodRow(
                 MacroChip("F", entry.fat)
             }
         }
+    }
+
+    photoViewerState?.let { viewerState ->
+        FullscreenMealPhotoViewer(
+            state = viewerState,
+            onDismiss = { photoViewerState = null }
+        )
     }
 }
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1022,6 +1022,7 @@
     <string name="cd_hold_to_record">Hold to record, tap to lock</string>
     <string name="cd_cancel_recording">Cancel recording</string>
     <string name="cd_remove_image">Remove image</string>
+    <string name="cd_meal_photo">Meal photo %1$d</string>
     <string name="cd_add_image">Add image</string>
     <string name="cd_open_camera">Open camera</string>
     <string name="cd_close_camera">Close camera</string>

--- a/ios/calorietracker/ContentView.swift
+++ b/ios/calorietracker/ContentView.swift
@@ -3215,6 +3215,7 @@ final class BarcodeScannerViewController: UIViewController, AVCaptureMetadataOut
 struct FoodRow: View {
     let entry: FoodEntry
     @Environment(FoodStore.self) private var foodStore
+    @State private var photoViewerItem: MealPhotoViewerItem?
 
     private var servingText: String? {
         guard let grams = entry.servingSizeGrams else {
@@ -3239,26 +3240,34 @@ struct FoodRow: View {
         HStack(spacing: 12) {
             // Thumbnail
             if let imageData = entry.imageData, let uiImage = UIImage(data: imageData) {
-                Image(uiImage: uiImage)
-                    .resizable()
-                    .scaledToFill()
-                    .frame(width: 56, height: 56)
-                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12, style: .continuous)
-                            .strokeBorder(AppColors.calorie.opacity(0.15), lineWidth: 1)
-                    )
-                    .overlay(alignment: .bottomTrailing) {
-                        if !entry.additionalImageData.isEmpty {
-                            Text("+\(entry.additionalImageData.count)")
-                                .font(.caption2.weight(.bold))
-                                .foregroundStyle(.white)
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 3)
-                                .background(.black.opacity(0.65), in: Capsule())
-                                .padding(4)
+                Button {
+                    let images = MealPhotoLoader.images(from: entry)
+                    guard !images.isEmpty else { return }
+                    photoViewerItem = MealPhotoViewerItem(images: images)
+                } label: {
+                    Image(uiImage: uiImage)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: 56, height: 56)
+                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                .strokeBorder(AppColors.calorie.opacity(0.15), lineWidth: 1)
+                        )
+                        .overlay(alignment: .bottomTrailing) {
+                            if !entry.additionalImageData.isEmpty {
+                                Text("+\(entry.additionalImageData.count)")
+                                    .font(.caption2.weight(.bold))
+                                    .foregroundStyle(.white)
+                                    .padding(.horizontal, 6)
+                                    .padding(.vertical, 3)
+                                    .background(.black.opacity(0.65), in: Capsule())
+                                    .padding(4)
+                            }
                         }
-                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("View meal photo")
             } else if let emoji = entry.emoji {
                 Text(emoji)
                     .font(.system(size: 28))
@@ -3313,6 +3322,9 @@ struct FoodRow: View {
             }
         }
         .padding(.vertical, 4)
+        .fullScreenCover(item: $photoViewerItem) { item in
+            MealPhotoViewerView(images: item.images, startIndex: item.startIndex)
+        }
     }
 }
 

--- a/ios/calorietracker/Views/EditFoodEntryView.swift
+++ b/ios/calorietracker/Views/EditFoodEntryView.swift
@@ -52,6 +52,7 @@ struct EditFoodEntryView: View {
     @State private var reprocessingError: String? = nil
     @State private var isDeleteConfirmationPresented = false
     @State private var removedPhotoIDs = Set<FoodEntryPhoto.ID>()
+    @State private var photoViewerItem: MealPhotoViewerItem?
 
     @State private var name: String
     @State private var servingSizeGrams: Double
@@ -222,6 +223,15 @@ struct EditFoodEntryView: View {
                                         }
                                         .frame(width: 220, height: 200)
                                         .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                                        .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                                        .onTapGesture {
+                                            let images = photos.compactMap { photo -> UIImage? in
+                                                guard let data = photo.data else { return nil }
+                                                return UIImage(data: data)
+                                            }
+                                            guard !images.isEmpty else { return }
+                                            photoViewerItem = MealPhotoViewerItem(images: images, startIndex: index)
+                                        }
                                         .overlay(alignment: .topTrailing) {
                                             Button {
                                                 removedPhotoIDs.insert(photo.id)
@@ -529,6 +539,9 @@ struct EditFoodEntryView: View {
                             }
                         }
                     )
+                }
+                .fullScreenCover(item: $photoViewerItem) { item in
+                    MealPhotoViewerView(images: item.images, startIndex: item.startIndex)
                 }
             }
         }

--- a/ios/calorietracker/Views/FoodResultView.swift
+++ b/ios/calorietracker/Views/FoodResultView.swift
@@ -63,6 +63,7 @@ struct FoodResultView: View {
     @State private var editableIngredients: [MealIngredient]
     @State private var ingredientEditor: IngredientEditorTarget?
     @State private var showWhatIfSheet = false
+    @State private var photoViewerItem: MealPhotoViewerItem?
     @State private var submissionGate = FoodSubmissionGate()
     @State var mealType: MealType = .currentMeal
 
@@ -310,6 +311,10 @@ struct FoodResultView: View {
                                             .scaledToFill()
                                             .frame(width: 220, height: 200)
                                             .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                                            .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                                            .onTapGesture {
+                                                photoViewerItem = MealPhotoViewerItem(images: images, startIndex: index)
+                                            }
                                             .overlay(alignment: .bottomTrailing) {
                                                 if images.count > 1 {
                                                     Text("\(index + 1)/\(images.count)")
@@ -588,6 +593,9 @@ struct FoodResultView: View {
                             }
                         }
                     )
+                }
+                .fullScreenCover(item: $photoViewerItem) { item in
+                    MealPhotoViewerView(images: item.images, startIndex: item.startIndex)
                 }
             }
         }

--- a/ios/calorietracker/Views/MealPhotoViewerView.swift
+++ b/ios/calorietracker/Views/MealPhotoViewerView.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+struct MealPhotoViewerItem: Identifiable {
+    let id = UUID()
+    let images: [UIImage]
+    let startIndex: Int
+
+    init(images: [UIImage], startIndex: Int = 0) {
+        self.images = images
+        self.startIndex = min(max(startIndex, 0), max(images.count - 1, 0))
+    }
+}
+
+enum MealPhotoLoader {
+    static func images(from entry: FoodEntry) -> [UIImage] {
+        var images: [UIImage] = []
+        if let data = entry.imageData, let image = UIImage(data: data) {
+            images.append(image)
+        }
+        images.append(contentsOf: entry.additionalImageData.compactMap { UIImage(data: $0) })
+        if images.isEmpty {
+            for filename in entry.allImageFilenames {
+                guard let data = FoodImageStore.shared.load(filename: filename),
+                      let image = UIImage(data: data) else { continue }
+                images.append(image)
+            }
+        }
+        return images
+    }
+}
+
+struct MealPhotoViewerView: View {
+    let images: [UIImage]
+    @State private var currentIndex: Int
+    @Environment(\.dismiss) private var dismiss
+    @State private var dragOffset: CGFloat = 0
+
+    init(images: [UIImage], startIndex: Int = 0) {
+        self.images = images
+        _currentIndex = State(initialValue: min(max(startIndex, 0), max(images.count - 1, 0)))
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            TabView(selection: $currentIndex) {
+                ForEach(Array(images.enumerated()), id: \.offset) { index, image in
+                    Image(uiImage: image)
+                        .resizable()
+                        .scaledToFit()
+                        .tag(index)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .offset(y: dragOffset)
+            .opacity(1 - min(dragOffset / 300, 0.35))
+
+            VStack {
+                HStack {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 16, weight: .bold))
+                            .foregroundStyle(.white)
+                            .frame(width: 44, height: 44)
+                            .background(.black.opacity(0.45), in: Circle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Close")
+
+                    Spacer()
+
+                    if images.count > 1 {
+                        Text("\(currentIndex + 1)/\(images.count)")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(.black.opacity(0.45), in: Capsule())
+                    }
+                }
+                .padding(.horizontal, 18)
+                .padding(.top, 12)
+
+                Spacer()
+            }
+        }
+        .gesture(
+            DragGesture(minimumDistance: 20)
+                .onChanged { value in
+                    let vertical = value.translation.height
+                    let horizontal = abs(value.translation.width)
+                    guard vertical > 0, vertical > horizontal else { return }
+                    dragOffset = vertical
+                }
+                .onEnded { value in
+                    let vertical = value.translation.height
+                    let horizontal = abs(value.translation.width)
+                    if vertical > 120, vertical > horizontal {
+                        dismiss()
+                    } else {
+                        withAnimation(.spring(response: 0.28, dampingFraction: 0.86)) {
+                            dragOffset = 0
+                        }
+                    }
+                }
+        )
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements GitHub issue #211: tap meal/food photo thumbnails to open a full-screen viewer on **iOS and Android**.

### What's included
- **New shared viewers**
  - iOS: `MealPhotoViewerView` — black full-screen cover, fit-to-screen photo, ✕ close, swipe-down dismiss, horizontal paging with `1/N` counter
  - Android: `FullscreenMealPhotoViewer` — same shell pattern as the in-app camera dialog (full-screen dialog, ✕ close, swipe-down dismiss, `HorizontalPager` + counter)
- **Wired into main photo surfaces**
  - Edit entry (`EditFoodEntryView` / `EditFoodEntrySheet`)
  - Pre-log result review (`FoodResultView` / `FoodResultSheet`)
  - Diary list thumbnails (`FoodRow` in `ContentView` / `HomeScreen`)

### Out of scope (issue #191)
- Pinch-to-zoom, save-to-gallery, share — intentionally not included to keep this PR focused.

## Test plan

### iOS
- [ ] Log a meal with 1 photo → on **Review Food**, tap the photo strip → full-screen image opens; ✕ and swipe-down both dismiss
- [ ] Log a meal with 3+ photos → tap any thumbnail → viewer opens at that photo; swipe horizontally between photos; counter shows `2/3` etc.
- [ ] Open an existing diary entry (**Edit Food**) → tap a photo (not ✕) → viewer opens; remove button still works without opening viewer
- [ ] In **Today's Diary**, tap a row's thumbnail (not the row body) → viewer opens with all photos; tapping the row body still opens edit

### Android
- [ ] Same flows as iOS for Review Food, Edit Food, and diary thumbnail tap
- [ ] Back gesture / system back dismisses the viewer
- [ ] Swipe down dismisses the viewer

Fixes #211
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-702ae888-532b-4c8c-a338-d4dff109c01e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-702ae888-532b-4c8c-a338-d4dff109c01e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

