### PR TITLE
iOS: CloudKit backup smoke test, a11y IDs, and schema docs

### DIFF
--- a/docs/cloud-backup.md
+++ b/docs/cloud-backup.md
@@ -19,7 +19,7 @@ Off by default in Settings → Data Management. Sign-in runs only when the user 
 | `FudAIBackup` | `backupAsset` | Asset |
 | `FudAIBackup` | `contentSha256` | String |
 
-The app writes a single record named `current` in the user’s private database (`CloudBackupService.swift`).
+The app writes a single record named `current` in the user’s private database (`CloudBackupService.swift`). The smoke test uses a separate record named `smoke-test` so it never overwrites or deletes the user’s real backup.
 
 **Production — deploy before App Store release:**
 
@@ -33,7 +33,7 @@ The app writes a single record named `current` in the user’s private database 
 
 ### CloudKit smoke test (device)
 
-Automated backup → restore → delete check. Safe for Release builds; runs once per launch when the argument is present.
+Automated upload → download/validate → delete check against the dedicated `smoke-test` record. Safe for Release builds; runs once per launch when the argument is present. Does not call production restore (no local prefs, photos, or HealthKit recovery flags are changed). If upload succeeds but a later step fails, the smoke-test record is still deleted before exit.
 
 **Launch argument:** `-fudai.cloudBackup.smokeTest`
 
@@ -44,7 +44,7 @@ Automated backup → restore → delete check. Safe for Release builds; runs onc
 1. Product → Scheme → Edit Scheme → **Run** → **Arguments**.
 2. Under **Arguments Passed On Launch**, add `-fudai.cloudBackup.smokeTest`.
 3. Select a physical iPhone (simulator iCloud is unreliable for CloudKit private DB).
-4. Run. On first launch the app uploads, restores, deletes the cloud backup, then restores local backup prefs to their pre-test values.
+4. Run. On first launch the app uploads to `smoke-test`, validates the downloaded archive hash, deletes the smoke-test record, and leaves the user’s `current` backup and local data untouched.
 
 **Run on an installed Release build:**
 

--- a/docs/cloud-backup.md
+++ b/docs/cloud-backup.md
@@ -5,8 +5,83 @@ Off by default in Settings → Data Management. Sign-in runs only when the user 
 ## iOS
 
 1. Enable the iCloud CloudKit container `iCloud.com.apoorvdarshan.calorietracker` in the Apple Developer portal and Xcode.
-2. Deploy the `FudAIBackup` record type to the CloudKit **Production** schema before shipping.
+2. Deploy the `FudAIBackup` record type to the CloudKit **Production** schema before shipping (see below).
 3. The phone’s iCloud account is enough. There is no Sign in with Apple.
+
+### CloudKit schema
+
+**Container:** `iCloud.com.apoorvdarshan.calorietracker`
+
+**Private Database — Development (done):**
+
+| Record type | Field | Type |
+|-------------|-------|------|
+| `FudAIBackup` | `backupAsset` | Asset |
+| `FudAIBackup` | `contentSha256` | String |
+
+The app writes a single record named `current` in the user’s private database (`CloudBackupService.swift`).
+
+**Production — deploy before App Store release:**
+
+1. Open [CloudKit Console](https://icloud.developer.apple.com/) and select container `iCloud.com.apoorvdarshan.calorietracker`.
+2. Choose **Schema** in the left sidebar.
+3. Confirm **Development** shows record type `FudAIBackup` with fields `backupAsset` (Asset) and `contentSha256` (String). If Development is missing them, add the record type and fields there first, then test on a Development build.
+4. Open the **Deploy Schema Changes…** action (top of the Schema page).
+5. Review the diff — it should add `FudAIBackup` with the two fields above to **Production**.
+6. Click **Deploy to Production** and confirm. Production schema changes are irreversible; double-check field types before confirming.
+7. After deploy, run the smoke test below on a **Release** device build signed with the production profile.
+
+### CloudKit smoke test (device)
+
+Automated backup → restore → delete check. Safe for Release builds; runs once per launch when the argument is present.
+
+**Launch argument:** `-fudai.cloudBackup.smokeTest`
+
+**Requirements:** iPhone signed into iCloud; Development schema for debug builds, Production schema deployed for Release builds.
+
+**Run from Xcode (Release configuration recommended for pre-ship validation):**
+
+1. Product → Scheme → Edit Scheme → **Run** → **Arguments**.
+2. Under **Arguments Passed On Launch**, add `-fudai.cloudBackup.smokeTest`.
+3. Select a physical iPhone (simulator iCloud is unreliable for CloudKit private DB).
+4. Run. On first launch the app uploads, restores, deletes the cloud backup, then restores local backup prefs to their pre-test values.
+
+**Run on an installed Release build:**
+
+```bash
+# Replace DEVICE_UDID with the connected iPhone UDID from Xcode or `xcrun xctrace list devices`
+xcrun devicectl device process launch --device DEVICE_UDID \
+  com.apoorvdarshan.calorietracker \
+  -fudai.cloudBackup.smokeTest
+```
+
+Or attach the same argument in an Xcode **Test** or **Profile** scheme when validating a Release archive.
+
+**Expected log line** (Xcode console or Console.app, filter `CloudBackupSmoke` or `FudAICloudBackupSmokeTest`):
+
+```
+FudAICloudBackupSmokeTest: PASS
+```
+
+On failure:
+
+```
+FudAICloudBackupSmokeTest: FAIL: <reason>
+```
+
+Common failures: not signed into iCloud, Production schema not deployed (Release builds), or network/CloudKit outage.
+
+### UI automation identifiers
+
+Settings → Data Management → iCloud Backup controls:
+
+| Control | Accessibility identifier |
+|---------|-------------------------|
+| Toggle | `settings.cloudBackup.toggle` |
+| Last backup label | `settings.cloudBackup.lastBackup` |
+| Back up now | `settings.cloudBackup.backupNow` |
+| Restore now | `settings.cloudBackup.restoreNow` |
+| Delete cloud backup | `settings.cloudBackup.delete` |
 
 ## Android
 

--- a/ios/calorietracker/Services/CloudBackupService.swift
+++ b/ios/calorietracker/Services/CloudBackupService.swift
@@ -1,12 +1,17 @@
 import CloudKit
 import Foundation
 import Observation
+import os
 
 @Observable
 final class CloudBackupService {
     static let enabledKey = "cloudBackupEnabled"
     static let lastAtKey = "cloudBackupLastAt"
     static let lastHashKey = "cloudBackupLastHash"
+    static let smokeTestLaunchArgument = "-fudai.cloudBackup.smokeTest"
+
+    private static var didRunSmokeTestThisLaunch = false
+    private static let smokeLogger = Logger(subsystem: "com.apoorvdarshan.calorietracker", category: "CloudBackupSmoke")
 
     private let recordType = "FudAIBackup"
     private let recordName = "current"
@@ -179,6 +184,67 @@ final class CloudBackupService {
             return
         }
         try? await backupNow(skipIfUnchanged: true)
+    }
+
+    /// Release-safe CloudKit integration check: upload → download → delete.
+    /// Logs `FudAICloudBackupSmokeTest: PASS` or `FAIL: <reason>` to stdout and os_log.
+    func runSmokeTestIfRequested() async {
+        guard CommandLine.arguments.contains(Self.smokeTestLaunchArgument) else { return }
+        guard !Self.didRunSmokeTestThisLaunch else { return }
+        Self.didRunSmokeTestThisLaunch = true
+        await runSmokeTest()
+    }
+
+    func runSmokeTest() async {
+        let savedEnabled = enabled
+        let savedLastAt = lastAt
+        let savedLastHash = defaults.string(forKey: Self.lastHashKey)
+
+        defer {
+            enabled = savedEnabled
+            defaults.set(savedEnabled, forKey: Self.enabledKey)
+            if let savedLastAt {
+                defaults.set(savedLastAt, forKey: Self.lastAtKey)
+                lastAt = savedLastAt
+            } else {
+                defaults.removeObject(forKey: Self.lastAtKey)
+                lastAt = nil
+            }
+            if let savedLastHash {
+                defaults.set(savedLastHash, forKey: Self.lastHashKey)
+            } else {
+                defaults.removeObject(forKey: Self.lastHashKey)
+            }
+        }
+
+        do {
+            try await backupNow()
+            guard try await fetchRecord() != nil else {
+                logSmokeTestFailure("backup record missing after upload")
+                return
+            }
+            try await restoreNow()
+            try await deleteCloudBackup()
+            guard try await fetchRecord() == nil else {
+                logSmokeTestFailure("record still present after delete")
+                return
+            }
+            logSmokeTestPass()
+        } catch {
+            logSmokeTestFailure(error.localizedDescription)
+        }
+    }
+
+    private func logSmokeTestPass() {
+        let line = "FudAICloudBackupSmokeTest: PASS"
+        print(line)
+        Self.smokeLogger.info("\(line, privacy: .public)")
+    }
+
+    private func logSmokeTestFailure(_ reason: String) {
+        let line = "FudAICloudBackupSmokeTest: FAIL: \(reason)"
+        print(line)
+        Self.smokeLogger.error("\(line, privacy: .public)")
     }
 
     private func upload(zip: Data, hash: String) async throws {

--- a/ios/calorietracker/Services/CloudBackupService.swift
+++ b/ios/calorietracker/Services/CloudBackupService.swift
@@ -9,6 +9,7 @@ final class CloudBackupService {
     static let lastAtKey = "cloudBackupLastAt"
     static let lastHashKey = "cloudBackupLastHash"
     static let smokeTestLaunchArgument = "-fudai.cloudBackup.smokeTest"
+    static let smokeTestRecordName = "smoke-test"
 
     private static var didRunSmokeTestThisLaunch = false
     private static let smokeLogger = Logger(subsystem: "com.apoorvdarshan.calorietracker", category: "CloudBackupSmoke")
@@ -162,17 +163,7 @@ final class CloudBackupService {
     func deleteCloudBackup() async throws {
         busy = true
         defer { busy = false }
-        try await checkAccount()
-        let id = CKRecord.ID(recordName: recordName)
-        do {
-            try await container.privateCloudDatabase.deleteRecord(withID: id)
-        } catch let error as CKError where error.code == .unknownItem {
-            // already gone
-        }
-        hasCloudBackup = false
-        defaults.removeObject(forKey: Self.lastAtKey)
-        defaults.removeObject(forKey: Self.lastHashKey)
-        lastAt = nil
+        try await deleteCloudRecord(named: recordName)
     }
 
     func autoBackupIfNeeded() async {
@@ -196,42 +187,42 @@ final class CloudBackupService {
     }
 
     func runSmokeTest() async {
-        let savedEnabled = enabled
-        let savedLastAt = lastAt
-        let savedLastHash = defaults.string(forKey: Self.lastHashKey)
-
-        defer {
-            enabled = savedEnabled
-            defaults.set(savedEnabled, forKey: Self.enabledKey)
-            if let savedLastAt {
-                defaults.set(savedLastAt, forKey: Self.lastAtKey)
-                lastAt = savedLastAt
-            } else {
-                defaults.removeObject(forKey: Self.lastAtKey)
-                lastAt = nil
-            }
-            if let savedLastHash {
-                defaults.set(savedLastHash, forKey: Self.lastHashKey)
-            } else {
-                defaults.removeObject(forKey: Self.lastHashKey)
-            }
-        }
+        var smokeUploaded = false
 
         do {
-            try await backupNow()
-            guard try await fetchRecord() != nil else {
+            try await checkAccount()
+            let values = snapshotValues()
+            let photos = snapshotPhotos()
+            let hash = CloudBackupArchive.contentHash(values: values, photos: photos)
+            let zip = try CloudBackupArchive.pack(
+                values: values,
+                photos: photos,
+                exportedAt: ISO8601DateFormatter().string(from: Date()),
+                appVersion: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+            )
+            try await upload(zip: zip, hash: hash, toRecord: Self.smokeTestRecordName)
+            smokeUploaded = true
+
+            guard let record = try await fetchRecord(named: Self.smokeTestRecordName) else {
                 logSmokeTestFailure("backup record missing after upload")
                 return
             }
-            try await restoreNow()
-            try await deleteCloudBackup()
-            guard try await fetchRecord() == nil else {
+            try validateDownloadedBackup(record: record, expectedHash: hash)
+
+            try await deleteCloudRecord(named: Self.smokeTestRecordName)
+            smokeUploaded = false
+
+            guard try await fetchRecord(named: Self.smokeTestRecordName) == nil else {
                 logSmokeTestFailure("record still present after delete")
                 return
             }
             logSmokeTestPass()
         } catch {
             logSmokeTestFailure(error.localizedDescription)
+        }
+
+        if smokeUploaded {
+            try? await deleteCloudRecord(named: Self.smokeTestRecordName)
         }
     }
 
@@ -247,22 +238,50 @@ final class CloudBackupService {
         Self.smokeLogger.error("\(line, privacy: .public)")
     }
 
-    private func upload(zip: Data, hash: String) async throws {
+    private func upload(zip: Data, hash: String, toRecord named: String? = nil) async throws {
+        let name = named ?? recordName
         let temp = FileManager.default.temporaryDirectory.appendingPathComponent("fudai-backup.zip")
         try zip.write(to: temp, options: .atomic)
-        let id = CKRecord.ID(recordName: recordName)
-        let record = (try? await fetchRecord()) ?? CKRecord(recordType: recordType, recordID: id)
+        let id = CKRecord.ID(recordName: name)
+        let record = (try? await fetchRecord(named: name)) ?? CKRecord(recordType: recordType, recordID: id)
         record[assetField] = CKAsset(fileURL: temp)
         record[shaField] = hash as CKRecordValue
         _ = try await container.privateCloudDatabase.save(record)
     }
 
-    private func fetchRecord() async throws -> CKRecord? {
-        let id = CKRecord.ID(recordName: recordName)
+    private func fetchRecord(named name: String? = nil) async throws -> CKRecord? {
+        let id = CKRecord.ID(recordName: name ?? recordName)
         do {
             return try await container.privateCloudDatabase.record(for: id)
         } catch let error as CKError where error.code == .unknownItem {
             return nil
+        }
+    }
+
+    private func deleteCloudRecord(named name: String) async throws {
+        try await checkAccount()
+        let id = CKRecord.ID(recordName: name)
+        do {
+            try await container.privateCloudDatabase.deleteRecord(withID: id)
+        } catch let error as CKError where error.code == .unknownItem {
+            // already gone
+        }
+        guard name == recordName else { return }
+        hasCloudBackup = false
+        defaults.removeObject(forKey: Self.lastAtKey)
+        defaults.removeObject(forKey: Self.lastHashKey)
+        lastAt = nil
+    }
+
+    private func validateDownloadedBackup(record: CKRecord, expectedHash: String) throws {
+        guard let asset = record[assetField] as? CKAsset,
+              let url = asset.fileURL
+        else { throw CloudBackupError.noBackup }
+        let zip = try Data(contentsOf: url)
+        let (document, _) = try CloudBackupArchive.unpack(zip)
+        guard document.contentSha256 == expectedHash else { throw CloudBackupError.invalidFormat }
+        if let recordSha = record[shaField] as? String, recordSha != expectedHash {
+            throw CloudBackupError.invalidFormat
         }
     }
 

--- a/ios/calorietracker/Views/CloudBackupSettingsView.swift
+++ b/ios/calorietracker/Views/CloudBackupSettingsView.swift
@@ -18,20 +18,25 @@ struct CloudBackupSettingsSection: View {
             )) {
                 Label("iCloud Backup", systemImage: "icloud")
             }
+            .accessibilityIdentifier("settings.cloudBackup.toggle")
             .disabled(backup.busy)
 
             if let last = backup.lastAt {
                 (Text("Last backup: ") + Text(shortDate(last)))
                     .font(.footnote)
                     .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("settings.cloudBackup.lastBackup")
             }
 
             if backup.enabled {
                 Button("Back up now") { Task { await run { try await backup.backupNow() } } }
+                    .accessibilityIdentifier("settings.cloudBackup.backupNow")
                     .disabled(backup.busy)
                 Button("Restore now") { Task { await run { try await backup.restoreNow() } } }
+                    .accessibilityIdentifier("settings.cloudBackup.restoreNow")
                     .disabled(backup.busy)
                 Button("Delete cloud backup", role: .destructive) { showDeleteConfirm = true }
+                    .accessibilityIdentifier("settings.cloudBackup.delete")
                     .disabled(backup.busy)
             }
         } footer: {

--- a/ios/calorietracker/calorietrackerApp.swift
+++ b/ios/calorietracker/calorietrackerApp.swift
@@ -112,6 +112,7 @@ struct calorietrackerApp: App {
                 refreshWidgetSnapshot()
             }
             .task {
+                await cloudBackupService.runSmokeTestIfRequested()
                 await weeklyChallengeStore.retryPendingDeletionIfNeeded()
             }
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Finishes the iCloud / CloudKit backup validation path that was started locally but lost during branch moves.

- **`CloudBackupService.runSmokeTest()`** — Release-safe integration check: upload → restore → delete, then verify the record is gone. Logs a single line `FudAICloudBackupSmokeTest: PASS` or `FAIL: <reason>` to stdout and `os_log`.
- **Launch argument `-fudai.cloudBackup.smokeTest`** — wired in `calorietrackerApp` `.task`; runs once per launch via `runSmokeTestIfRequested()`. Local backup prefs (`enabled`, `lastAt`, `lastHash`) are restored after the test; the cloud record is deleted at the end (intentional for validation).
- **Accessibility identifiers** on Cloud Backup Settings controls for UI automation.
- **`docs/cloud-backup.md`** — Development schema status, exact Production Deploy Schema steps in CloudKit Console, device smoke-test instructions, and a11y ID table.

## Still requires local human / device

1. **Production schema deploy** — click **Deploy to Production** in CloudKit Console for `FudAIBackup` before shipping Release builds.
2. **Real-device validation** — run `-fudai.cloudBackup.smokeTest` on a physical iPhone (Release build recommended) and confirm `FudAICloudBackupSmokeTest: PASS` in Console.app. Note: smoke test removes the `current` cloud backup record when it finishes.

## Test plan

- [ ] Xcode → Edit Scheme → add `-fudai.cloudBackup.smokeTest` → Run on physical iPhone signed into iCloud
- [ ] Confirm `FudAICloudBackupSmokeTest: PASS` in console
- [ ] Optional: UI test navigation to Settings → Data Management using new `settings.cloudBackup.*` identifiers
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fab813f-e57e-4dfe-b240-8bd0a5175112?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fab813f-e57e-4dfe-b240-8bd0a5175112&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a dedicated CloudKit upload/download/delete smoke test, launch-argument integration, accessibility identifiers, and operational schema documentation. The revised test avoids restoring local data, but one post-upload failure path still exits before deleting its smoke record.

- Adds smoke-test upload and archive-hash validation against a dedicated CloudKit record.
- Runs the validation once per process when the launch argument is supplied.
- Documents CloudKit production deployment and physical-device verification.
- Adds stable accessibility identifiers to backup settings controls.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a successful smoke upload can still leave its CloudKit record behind when the verification fetch returns nil.

apoorvdarshan states that the cleanup issue was fixed, but the nil-fetch guard is a concrete residual counterexample: it returns from runSmokeTest() while smokeUploaded is true and before the cleanup block executes.

**Files Needing Attention:** ios/calorietracker/Services/CloudBackupService.swift

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ios/calorietracker/Services/CloudBackupService.swift | Adds the dedicated smoke-test lifecycle and validation, but the nil-fetch guard bypasses post-upload cleanup. |
| ios/calorietracker/calorietrackerApp.swift | Invokes the launch-argument-gated smoke test from the application task. |
| ios/calorietracker/Views/CloudBackupSettingsView.swift | Adds accessibility identifiers to backup settings controls without changing their actions. |
| docs/cloud-backup.md | Documents the CloudKit schema deployment, device smoke-test procedure, and accessibility identifiers. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Upload smoke-test record] --> B[smokeUploaded = true]
    B --> C{Fetch returns record?}
    C -->|Yes| D[Validate and delete]
    C -->|No| E[Log failure and return]
    E -. bypasses .-> F[Post-catch cleanup]
    D --> G[Verify deletion and pass]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20apoorvdarshan%2Ffud-ai%20PR%20%23247%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=247&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aios%2Fcalorietracker%2FServices%2FCloudBackupService.swift%3A206-209%0A**Missing%20record%20bypasses%20cleanup**%0A%0AWhen%20CloudKit%20accepts%20the%20upload%20but%20the%20following%20fetch%20returns%20no%20record%2C%20this%20guard%20returns%20from%20%60runSmokeTest%28%29%60%20while%20%60smokeUploaded%60%20is%20true%2C%20bypassing%20the%20cleanup%20block%20and%20leaving%20the%20smoke-test%20record%20in%20the%20user's%20private%20database.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20let%20record%20%3D%20try%20await%20fetchRecord%28named%3A%20Self.smokeTestRecordName%29%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20throw%20CloudBackupError.noBackup%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=247&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22apoorvdarshan%2Ffud-ai%22%20on%20the%20existing%20branch%20%22cursor%2Ffinish-cloudkit-backup-smoke-docs-f026%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Ffinish-cloudkit-backup-smoke-docs-f026%22.%0A%0A%23%23%23%20Issue%201%0Aios%2Fcalorietracker%2FServices%2FCloudBackupService.swift%3A206-209%0A**Missing%20record%20bypasses%20cleanup**%0A%0AWhen%20CloudKit%20accepts%20the%20upload%20but%20the%20following%20fetch%20returns%20no%20record%2C%20this%20guard%20returns%20from%20%60runSmokeTest%28%29%60%20while%20%60smokeUploaded%60%20is%20true%2C%20bypassing%20the%20cleanup%20block%20and%20leaving%20the%20smoke-test%20record%20in%20the%20user's%20private%20database.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20let%20record%20%3D%20try%20await%20fetchRecord%28named%3A%20Self.smokeTestRecordName%29%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20throw%20CloudBackupError.noBackup%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=247&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aios%2Fcalorietracker%2FServices%2FCloudBackupService.swift%3A206-209%0A**Missing%20record%20bypasses%20cleanup**%0A%0AWhen%20CloudKit%20accepts%20the%20upload%20but%20the%20following%20fetch%20returns%20no%20record%2C%20this%20guard%20returns%20from%20%60runSmokeTest%28%29%60%20while%20%60smokeUploaded%60%20is%20true%2C%20bypassing%20the%20cleanup%20block%20and%20leaving%20the%20smoke-test%20record%20in%20the%20user's%20private%20database.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20let%20record%20%3D%20try%20await%20fetchRecord%28named%3A%20Self.smokeTestRecordName%29%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20throw%20CloudBackupError.noBackup%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=247&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
ios/calorietracker/Services/CloudBackupService.swift:206-209
**Missing record bypasses cleanup**

When CloudKit accepts the upload but the following fetch returns no record, this guard returns from `runSmokeTest()` while `smokeUploaded` is true, bypassing the cleanup block and leaving the smoke-test record in the user's private database.

```suggestion
            guard let record = try await fetchRecord(named: Self.smokeTestRecordName) else {
                throw CloudBackupError.noBackup
            }
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix CloudKit smoke test: dedicated recor..."](https://github.com/apoorvdarshan/fud-ai/commit/15f6452b3806e7adb730c16de3d13e68fcd887f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62557696)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->