### PR TITLE
Fix Android ANR during meal photo analysis (#199)

### DIFF
--- a/android/app/src/androidTest/java/com/apoorvdarshan/calorietracker/services/FoodImageDecoderTest.kt
+++ b/android/app/src/androidTest/java/com/apoorvdarshan/calorietracker/services/FoodImageDecoderTest.kt
@@ -42,6 +42,19 @@ class FoodImageDecoderTest {
         }
     }
 
+    @Test fun uploadPreprocessorCapsDimensionsWithoutChangingOriginal() {
+        withPhoto(null) { file ->
+            val original = file.readBytes()
+            val upload = FoodImagePreprocessor.prepareForUpload(original)
+            assertTrue(upload.isNotEmpty())
+            assertFalse(upload.contentEquals(original))
+            val decoded = FoodImageDecoder.decode(upload)!!
+            assertTrue(maxOf(decoded.width, decoded.height) <= 1_600)
+            decoded.recycle()
+            assertArrayEquals(original, file.readBytes())
+        }
+    }
+
     @Test fun untaggedPhotosAndInvalidInputsAreSafe() {
         withPhoto(null) { file ->
             val bitmap = FoodImageDecoder.decode(file)!!

--- a/android/app/src/androidTest/java/com/apoorvdarshan/calorietracker/services/FoodImageDecoderTest.kt
+++ b/android/app/src/androidTest/java/com/apoorvdarshan/calorietracker/services/FoodImageDecoderTest.kt
@@ -43,13 +43,13 @@ class FoodImageDecoderTest {
     }
 
     @Test fun uploadPreprocessorCapsDimensionsWithoutChangingOriginal() {
-        withPhoto(null) { file ->
+        withPhoto(null, width = 2_400, height = 1_800) { file ->
             val original = file.readBytes()
             val upload = FoodImagePreprocessor.prepareForUpload(original)
             assertTrue(upload.isNotEmpty())
             assertFalse(upload.contentEquals(original))
             val decoded = FoodImageDecoder.decode(upload)!!
-            assertTrue(maxOf(decoded.width, decoded.height) <= 1_600)
+            assertEquals(1_600, maxOf(decoded.width, decoded.height))
             decoded.recycle()
             assertArrayEquals(original, file.readBytes())
         }
@@ -102,12 +102,17 @@ class FoodImageDecoderTest {
         }
     }
 
-    private fun withPhoto(orientation: Int?, block: (File) -> Unit) {
+    private fun withPhoto(
+        orientation: Int?,
+        width: Int = 120,
+        height: Int = 80,
+        block: (File) -> Unit
+    ) {
         val file = File.createTempFile("orientation-", ".jpg", context.cacheDir)
         try {
-            val bitmap = Bitmap.createBitmap(120, 80, Bitmap.Config.ARGB_8888)
-            for (y in 0 until 80) for (x in 0 until 120) {
-                bitmap.setPixel(x, y, colors[(if (y >= 40) 2 else 0) + (if (x >= 60) 1 else 0)])
+            val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+            for (y in 0 until height) for (x in 0 until width) {
+                bitmap.setPixel(x, y, colors[(if (y >= height / 2) 2 else 0) + (if (x >= width / 2) 1 else 0)])
             }
             file.outputStream().use { bitmap.compress(Bitmap.CompressFormat.JPEG, 100, it) }
             bitmap.recycle()

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/AnthropicClient.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/AnthropicClient.kt
@@ -1,5 +1,7 @@
 package com.apoorvdarshan.calorietracker.services.ai
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
@@ -36,38 +38,40 @@ object AnthropicClient {
         val url = "$baseUrl/messages"
 
         suspend fun request(requestPrompt: String): AnthropicTextResponse {
-            val content = JSONArray().apply {
-                imageBytesList.forEach {
-                    put(
-                        JSONObject()
-                            .put("type", "image")
-                            .put(
-                                "source",
+            val bodyStr = withContext(Dispatchers.IO) {
+                RetryPolicy.execute {
+                    val content = JSONArray().apply {
+                        imageBytesList.forEach {
+                            put(
                                 JSONObject()
-                                    .put("type", "base64")
-                                    .put("media_type", "image/jpeg")
-                                    .put("data", Base64.getEncoder().encodeToString(it))
+                                    .put("type", "image")
+                                    .put(
+                                        "source",
+                                        JSONObject()
+                                            .put("type", "base64")
+                                            .put("media_type", "image/jpeg")
+                                            .put("data", Base64.getEncoder().encodeToString(it))
+                                    )
                             )
+                        }
+                        put(JSONObject().put("type", "text").put("text", requestPrompt))
+                    }
+
+                    val body = JSONObject()
+                        .put("model", model)
+                        .put("max_tokens", maxTokens)
+                        .put("messages", JSONArray().put(JSONObject().put("role", "user").put("content", content)))
+
+                    client.newCall(
+                        Request.Builder()
+                            .url(url)
+                            .addHeader("Content-Type", "application/json")
+                            .addHeader("x-api-key", apiKey)
+                            .addHeader("anthropic-version", API_VERSION)
+                            .post(body.toString().toRequestBody(jsonMedia))
+                            .build()
                     )
                 }
-                put(JSONObject().put("type", "text").put("text", requestPrompt))
-            }
-
-            val body = JSONObject()
-                .put("model", model)
-                .put("max_tokens", maxTokens)
-                .put("messages", JSONArray().put(JSONObject().put("role", "user").put("content", content)))
-
-            val bodyStr = RetryPolicy.execute {
-                client.newCall(
-                    Request.Builder()
-                        .url(url)
-                        .addHeader("Content-Type", "application/json")
-                        .addHeader("x-api-key", apiKey)
-                        .addHeader("anthropic-version", API_VERSION)
-                        .post(body.toString().toRequestBody(jsonMedia))
-                        .build()
-                )
             }
             return AnthropicResponseParser.parse(bodyStr)
         }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/FoodAnalysisService.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/FoodAnalysisService.kt
@@ -11,7 +11,9 @@ import com.apoorvdarshan.calorietracker.models.UserProfile
 import com.apoorvdarshan.calorietracker.services.GoalEvidence
 import com.apoorvdarshan.calorietracker.services.health.HealthEnergySummary
 import com.apoorvdarshan.calorietracker.services.ondevice.LocalGemmaRuntime
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import java.util.Locale
 
@@ -514,7 +516,9 @@ class FoodAnalysisService(
         if (primary.requiresApiKey && primaryKey.isNullOrEmpty()) throw AiError.NoApiKey
         val maxTokens = prefs.maxResponseTokens.first()
         val requestTimeoutSeconds = prefs.aiRequestTimeoutSeconds.first()
-        val uploadImages = imageBytesList.map(FoodImagePreprocessor::prepareForUpload)
+        val uploadImages = withContext(Dispatchers.IO) {
+            imageBytesList.map(FoodImagePreprocessor::prepareForUpload)
+        }
 
         return try {
             dispatch(primary, primaryModel, primaryBaseUrl, primaryKey, finalPrompt, uploadImages, maxTokens, requestTimeoutSeconds)

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/GeminiClient.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/GeminiClient.kt
@@ -1,5 +1,7 @@
 package com.apoorvdarshan.calorietracker.services.ai
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -28,34 +30,35 @@ object GeminiClient {
     ): String {
         val url = "$baseUrl/models/$model:generateContent"
 
-        val parts = JSONArray().apply {
-            imageBytesList.forEach {
-                put(
-                    JSONObject().put(
-                        "inlineData",
-                        JSONObject()
-                            .put("mimeType", "image/jpeg")
-                            .put("data", Base64.getEncoder().encodeToString(it))
-                    )
+        val bodyStr = withContext(Dispatchers.IO) {
+            RetryPolicy.execute {
+                val parts = JSONArray().apply {
+                    imageBytesList.forEach {
+                        put(
+                            JSONObject().put(
+                                "inlineData",
+                                JSONObject()
+                                    .put("mimeType", "image/jpeg")
+                                    .put("data", Base64.getEncoder().encodeToString(it))
+                            )
+                        )
+                    }
+                    put(JSONObject().put("text", prompt))
+                }
+
+                val body = JSONObject().apply {
+                    put("contents", JSONArray().put(JSONObject().put("parts", parts)))
+                }
+
+                client.newCall(
+                    Request.Builder()
+                        .url(url)
+                        .addHeader("Content-Type", "application/json")
+                        .addHeader("X-goog-api-key", apiKey)
+                        .post(body.toString().toRequestBody(jsonMedia))
+                        .build()
                 )
             }
-            put(JSONObject().put("text", prompt))
-        }
-
-        val body = JSONObject().apply {
-            put("contents", JSONArray().put(JSONObject().put("parts", parts)))
-        }
-
-        val requestBody = body.toString().toRequestBody(jsonMedia)
-        val bodyStr = RetryPolicy.execute {
-            client.newCall(
-                Request.Builder()
-                    .url(url)
-                    .addHeader("Content-Type", "application/json")
-                    .addHeader("X-goog-api-key", apiKey)
-                    .post(requestBody)
-                    .build()
-            )
         }
 
         return parseText(bodyStr)

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/OpenAICompatibleClient.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/OpenAICompatibleClient.kt
@@ -2,6 +2,8 @@ package com.apoorvdarshan.calorietracker.services.ai
 
 import com.apoorvdarshan.calorietracker.models.OpenRouterReasoningEffort
 import com.apoorvdarshan.calorietracker.models.AIProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonPrimitive
@@ -45,42 +47,49 @@ object OpenAICompatibleClient {
         val url = "$baseUrl/chat/completions"
 
         suspend fun request(requestPrompt: String, compactRetry: Boolean): OpenAITextResponse {
-            val content = JSONArray().apply {
-                imageBytesList.forEach {
-                    put(
-                        JSONObject()
-                            .put("type", "image_url")
-                            .put(
-                                "image_url",
-                                JSONObject().put("url", "data:image/jpeg;base64,${Base64.getEncoder().encodeToString(it)}")
+            val bodyStr = withContext(Dispatchers.IO) {
+                RetryPolicy.execute {
+                    val content = JSONArray().apply {
+                        imageBytesList.forEach {
+                            put(
+                                JSONObject()
+                                    .put("type", "image_url")
+                                    .put(
+                                        "image_url",
+                                        JSONObject().put(
+                                            "url",
+                                            "data:image/jpeg;base64,${Base64.getEncoder().encodeToString(it)}"
+                                        )
+                                    )
                             )
-                    )
+                        }
+                        put(JSONObject().put("type", "text").put("text", requestPrompt))
+                    }
+
+                    val body = JSONObject()
+                        .put("model", model)
+                        .put("messages", JSONArray().put(JSONObject().put("role", "user").put("content", content)))
+                        .put(tokenLimitParameter(provider, model), maxTokens)
+                    if (provider == AIProvider.OPENROUTER) {
+                        body.put(
+                            "reasoning",
+                            JSONObject(reasoningEffort.requestOptions(compactRetry, exclude = true).orEmpty())
+                        )
+                    }
+
+                    val builder = Request.Builder()
+                        .url(url)
+                        .addHeader("Content-Type", "application/json")
+                        .post(body.toString().toRequestBody(jsonMedia))
+                    if (!apiKey.isNullOrEmpty()) builder.addHeader("Authorization", "Bearer $apiKey")
+                    if (provider == AIProvider.OPENROUTER) {
+                        builder.addHeader("HTTP-Referer", "https://github.com/apoorvdarshan/fud-ai")
+                        builder.addHeader("X-Title", "Fud AI")
+                    }
+
+                    client.newCall(builder.build())
                 }
-                put(JSONObject().put("type", "text").put("text", requestPrompt))
             }
-
-            val body = JSONObject()
-                .put("model", model)
-                .put("messages", JSONArray().put(JSONObject().put("role", "user").put("content", content)))
-                .put(tokenLimitParameter(provider, model), maxTokens)
-            if (provider == AIProvider.OPENROUTER) {
-                body.put(
-                    "reasoning",
-                    JSONObject(reasoningEffort.requestOptions(compactRetry, exclude = true).orEmpty())
-                )
-            }
-
-            val builder = Request.Builder()
-                .url(url)
-                .addHeader("Content-Type", "application/json")
-                .post(body.toString().toRequestBody(jsonMedia))
-            if (!apiKey.isNullOrEmpty()) builder.addHeader("Authorization", "Bearer $apiKey")
-            if (provider == AIProvider.OPENROUTER) {
-                builder.addHeader("HTTP-Referer", "https://github.com/apoorvdarshan/fud-ai")
-                builder.addHeader("X-Title", "Fud AI")
-            }
-
-            val bodyStr = RetryPolicy.execute { client.newCall(builder.build()) }
             return OpenAIResponseParser.parse(bodyStr)
         }
 

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
@@ -2633,16 +2633,16 @@ private fun AnalyzingOverlay(imageBytes: ByteArray? = null) {
             verticalArrangement = Arrangement.spacedBy(24.dp),
             modifier = Modifier.padding(horizontal = 32.dp)
         ) {
-            if (bitmap != null) {
+            bitmap?.let { bmp ->
                 androidx.compose.foundation.Image(
-                    bitmap = bitmap.asImageBitmap(),
+                    bitmap = bmp.asImageBitmap(),
                     contentDescription = null,
                     contentScale = androidx.compose.ui.layout.ContentScale.Fit,
                     modifier = Modifier
                         .size(250.dp)
                         .clip(RoundedCornerShape(16.dp))
                 )
-            } else {
+            } ?: run {
                 Icon(
                     Icons.Filled.ImageSearch,
                     contentDescription = null,

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
@@ -2660,7 +2660,7 @@ private fun AnalyzingOverlay(imageBytes: ByteArray? = null) {
             // "Looking up nutrition..." (see ContentView.swift cases .analyzing /
             // .analyzingText). pendingImageBytes is the discriminator.
             Text(
-                if (bitmap != null) stringResource(R.string.home_analyzing_food) else stringResource(R.string.home_looking_up_nutrition),
+                if (imageBytes != null) stringResource(R.string.home_analyzing_food) else stringResource(R.string.home_looking_up_nutrition),
                 fontSize = 17.sp,
                 fontWeight = FontWeight.SemiBold,
                 color = AppColors.Calorie

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
@@ -121,6 +121,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalDensity
@@ -185,8 +186,10 @@ import java.time.temporal.WeekFields
 import java.util.Locale
 import kotlin.math.roundToInt
 import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 
 private enum class AddMenuGroup {
     PhotoAndScan,
@@ -2614,8 +2617,10 @@ private fun AnalyzingOverlay(imageBytes: ByteArray? = null) {
     // Verbatim port of ios/calorietracker/Views/AnalyzingView.swift:
     //   VStack { (image | text.magnifyingglass) → ProgressView(.large) → "Analyzing your food..." }
     //   filling the screen, opaque background, calorie-pink accents.
-    val bitmap = remember(imageBytes) {
-        imageBytes?.let { FoodImageDecoder.decode(it) }
+    val bitmap by produceState<android.graphics.Bitmap?>(initialValue = null, imageBytes) {
+        value = withContext(Dispatchers.IO) {
+            imageBytes?.let { FoodImageDecoder.decode(it, 720) }
+        }
     }
     Box(
         Modifier


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #199

## Problem
While analyzing a meal photo (OpenRouter / vision providers), Android sometimes showed "App isn't responding". Network I/O was already async via OkHttp, but CPU-heavy work ran on the main thread around the call:

1. **`FoodAnalysisService`** — `FoodImagePreprocessor.prepareForUpload` (decode + JPEG compress) ran on the caller thread from `viewModelScope.launch` (Main).
2. **Vision API clients** — `OpenAICompatibleClient`, `GeminiClient`, and `AnthropicClient` Base64-encoded images and built large JSON request bodies on the caller/Main thread before the suspend network call.
3. **`HomeScreen` `AnalyzingOverlay`** — `FoodImageDecoder.decode` ran at full resolution on the composition/UI thread.

## Fix
- **`FoodAnalysisService.callAi`**: wrap `prepareForUpload` in `withContext(Dispatchers.IO)`.
- **Vision clients**: move Base64 encoding, JSON body construction, and request building into `withContext(Dispatchers.IO)` (including inside `RetryPolicy.execute` so retries rebuild off-main as well).
- **`AnalyzingOverlay`**: decode preview with `produceState` + `Dispatchers.IO`, capped at **720px** (same as `FoodResultSheet` / `ContextNoteSheet`).

Behavior is unchanged: same upload quality (1600px / JPEG 80), same API payloads, same UX — only thread placement and overlay preview subsampling differ.

## Test
- Added `uploadPreprocessorCapsDimensionsWithoutChangingOriginal` to existing `FoodImageDecoderTest` (androidTest) to verify upload preprocessing caps dimensions without mutating stored originals.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b481f9a-42d6-45eb-abf5-6f6f253592cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b481f9a-42d6-45eb-abf5-6f6f253592cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Image uploads are prepared with a maximum dimension of 1,600 pixels while preserving original photos.
  - Food image processing and AI requests now run more efficiently, helping keep the app responsive during analysis.
  - Analysis previews load asynchronously and use a maximum dimension of 720 pixels for faster display.
  - Improved handling of large photos helps maintain consistent upload sizing across food analysis workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves expensive meal-photo preprocessing and vision request construction off the main thread, and asynchronously decodes a capped analysis preview.
- Runs upload preprocessing on `Dispatchers.IO`.
- Builds OpenAI-compatible, Gemini, and Anthropic vision requests on `Dispatchers.IO`, including retries.
- Loads the analyzing-overlay preview asynchronously with a 720px dimension cap.
- Adds an instrumentation test covering upload resizing and preservation of the original file.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/FoodAnalysisService.kt | Moves upload image preprocessing to the IO dispatcher without changing provider fallback inputs. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/OpenAICompatibleClient.kt | Moves vision payload construction and retry execution off the caller dispatcher while preserving request fields. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/GeminiClient.kt | Moves Gemini vision request construction and execution to the IO dispatcher. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/AnthropicClient.kt | Moves Anthropic vision request construction and execution to the IO dispatcher. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt | Replaces synchronous full-resolution overlay decoding with asynchronous decoding capped at 720px. |
| android/app/src/androidTest/java/com/apoorvdarshan/calorietracker/services/FoodImageDecoderTest.kt | Adds coverage that upload preprocessing caps dimensions without modifying the original image file. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as HomeScreen
    participant VM as HomeViewModel
    participant Service as FoodAnalysisService
    participant IO as Dispatchers.IO
    participant AI as Vision Provider
    UI->>VM: Analyze meal photos
    VM->>Service: Analyze image bytes
    Service->>IO: Decode, resize, and compress uploads
    IO-->>Service: Prepared JPEG bytes
    Service->>IO: Base64 encode and build request
    IO->>AI: Execute request with retry policy
    AI-->>IO: Analysis response
    IO-->>Service: Response body
    Service-->>VM: Parsed food analysis
    par Overlay preview
        UI->>IO: Decode preview capped at 720px
        IO-->>UI: Preview bitmap
    end
```

<sub>Reviews (3): Last reviewed commit: ["Show photo analysis message while previe..."](https://github.com/apoorvdarshan/fud-ai/commit/c86e1434d65cf270d9cc5bfd0f87d5e06772b819) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62556538)</sub>

<!-- /greptile_comment -->