### PR TITLE
Fix Health Connect unavailable detection and guidance (#209)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -34,6 +34,11 @@
         <intent>
             <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE" />
         </intent>
+        <!-- Android 14+ resolves this to the system-integrated Health Connect controller
+             (e.g. com.google.android.healthconnect.controller), not the standalone app. -->
+        <intent>
+            <action android:name="android.health.connect.action.MANAGE_HEALTH_PERMISSIONS" />
+        </intent>
     </queries>
 
     <application

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/health/HealthConnectManager.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/health/HealthConnectManager.kt
@@ -2,6 +2,7 @@ package com.apoorvdarshan.calorietracker.services.health
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.UserManager
 import androidx.health.connect.client.HealthConnectFeatures
@@ -67,6 +68,15 @@ internal fun resolveHealthConnectAvailability(
     else -> HealthConnectAvailability.UNAVAILABLE
 }
 
+internal fun resolveHealthConnectAvailabilityFromSdkStatus(
+    isProfile: Boolean,
+    sdkStatus: Int
+): HealthConnectAvailability = resolveHealthConnectAvailability(
+    isProfile = isProfile,
+    sdkAvailable = sdkStatus == HealthConnectClient.SDK_AVAILABLE,
+    providerUpdateRequired = sdkStatus == HealthConnectClient.SDK_UNAVAILABLE_PROVIDER_UPDATE_REQUIRED
+)
+
 class HealthConnectManager(
     private val context: Context,
     private val scheduleRetries: Boolean = true
@@ -99,13 +109,13 @@ class HealthConnectManager(
             runCatching {
                 (context.getSystemService(Context.USER_SERVICE) as? UserManager)?.isProfile == true
             }.getOrDefault(false)
-        val sdkStatus = HealthConnectClient.getSdkStatus(context)
-        return resolveHealthConnectAvailability(
-            isProfile = isProfile,
-            sdkAvailable = sdkStatus == HealthConnectClient.SDK_AVAILABLE,
-            providerUpdateRequired =
-                sdkStatus == HealthConnectClient.SDK_UNAVAILABLE_PROVIDER_UPDATE_REQUIRED
+        val sdkStatus = HealthConnectClient.getSdkStatus(context, HEALTH_CONNECT_PROVIDER_PACKAGE)
+        val resolved = resolveHealthConnectAvailabilityFromSdkStatus(isProfile, sdkStatus)
+        android.util.Log.i(
+            "FudAIHealth",
+            "Health Connect availability: sdkStatus=$sdkStatus isProfile=$isProfile resolved=$resolved"
         )
+        return resolved
     }
 
     fun isAvailable(): Boolean = availability() == HealthConnectAvailability.AVAILABLE
@@ -207,6 +217,19 @@ class HealthConnectManager(
         } else {
             generic
         }).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+
+    /** Play Store deep link for installing or updating the Health Connect provider. */
+    fun providerPlayStoreIntent(): Intent {
+        val marketUri = Uri.parse(
+            "market://details?id=$HEALTH_CONNECT_PROVIDER_PACKAGE&url=healthconnect%3A%2F%2Fonboarding"
+        )
+        return Intent(Intent.ACTION_VIEW, marketUri).apply {
+            setPackage("com.android.vending")
+            putExtra("overlay", true)
+            putExtra("callerId", context.packageName)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
     }
 
     // -- Weight -----------------------------------------------------------
@@ -772,6 +795,7 @@ class HealthConnectManager(
 
         private const val ACTION_MANAGE_HEALTH_PERMISSIONS =
             "android.health.connect.action.MANAGE_HEALTH_PERMISSIONS"
+        internal const val HEALTH_CONNECT_PROVIDER_PACKAGE = "com.google.android.apps.healthdata"
         private const val CLIENT_PREFIX = "fudai_"
         private const val WORKOUT_BURN_CLIENT_PREFIX = "fudai_workout_burn|"
         private const val WORKOUT_BURN_SEPARATOR = '|'

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt
@@ -304,6 +304,7 @@ fun SettingsScreen(container: AppContainer, nav: NavHostController, vm: Settings
     var showRebalanceBlockedAlert by remember { mutableStateOf(false) }
     var showAdaptiveLockHint by remember { mutableStateOf(false) }
     var permissionDeniedMessage by remember { mutableStateOf<String?>(null) }
+    var permissionDeniedHealthAvailability by remember { mutableStateOf<HealthConnectAvailability?>(null) }
     var showHealthPermissionHelp by remember { mutableStateOf(false) }
     var showDefaultGramsInfo by remember { mutableStateOf(false) }
     var showHealthEnergyGoalsInfo by remember { mutableStateOf(false) }
@@ -399,19 +400,33 @@ fun SettingsScreen(container: AppContainer, nav: NavHostController, vm: Settings
     val healthUnavailableMsg = stringResource(R.string.settings_health_unavailable)
     val healthProfileUnsupportedMsg = stringResource(R.string.settings_health_profile_unsupported)
     val healthSystemUnavailableMsg = stringResource(R.string.settings_health_system_unavailable)
+    val healthOpenSettingsFailedMsg = stringResource(R.string.settings_health_open_settings_failed)
 
-    fun healthAvailabilityMessage(): String = when (container.health.availability()) {
+    fun healthAvailabilityMessage(availability: HealthConnectAvailability): String = when (availability) {
         HealthConnectAvailability.PROFILE_UNSUPPORTED -> healthProfileUnsupportedMsg
         HealthConnectAvailability.PROVIDER_UPDATE_REQUIRED -> healthUnavailableMsg
-        HealthConnectAvailability.UNAVAILABLE,
-        HealthConnectAvailability.AVAILABLE -> healthSystemUnavailableMsg
+        HealthConnectAvailability.UNAVAILABLE -> healthSystemUnavailableMsg
+        HealthConnectAvailability.AVAILABLE -> healthOpenSettingsFailedMsg
+    }
+
+    fun showHealthAvailabilityAlert(availability: HealthConnectAvailability = container.health.availability()) {
+        permissionDeniedHealthAvailability = availability
+        permissionDeniedMessage = healthAvailabilityMessage(availability)
+    }
+
+    fun clearPermissionAlert() {
+        permissionDeniedMessage = null
+        permissionDeniedHealthAvailability = null
     }
 
     val notificationLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission()
     ) { granted ->
         if (granted) vm.setNotificationsEnabled(true)
-        else permissionDeniedMessage = notifDeniedMsg
+        else {
+            permissionDeniedHealthAvailability = null
+            permissionDeniedMessage = notifDeniedMsg
+        }
     }
 
     // Health Connect honors partial grants: any granted permission connects the app, and
@@ -435,7 +450,12 @@ fun SettingsScreen(container: AppContainer, nav: NavHostController, vm: Settings
 
     fun openHealthConnectAccess() {
         runCatching { activityContext.startActivity(container.health.manageAccessIntent()) }
-            .onFailure { permissionDeniedMessage = healthAvailabilityMessage() }
+            .onFailure { showHealthAvailabilityAlert(HealthConnectAvailability.AVAILABLE) }
+    }
+
+    fun openHealthConnectPlayStore() {
+        runCatching { activityContext.startActivity(container.health.providerPlayStoreIntent()) }
+            .onFailure { showHealthAvailabilityAlert(HealthConnectAvailability.UNAVAILABLE) }
     }
 
     fun onNotificationsToggle(enabled: Boolean) {
@@ -476,7 +496,7 @@ fun SettingsScreen(container: AppContainer, nav: NavHostController, vm: Settings
             return
         }
         if (!container.health.isAvailable()) {
-            permissionDeniedMessage = healthAvailabilityMessage()
+            showHealthAvailabilityAlert()
             return
         }
         // Don't pre-check granted state — Health Connect's contract handles the
@@ -494,7 +514,7 @@ fun SettingsScreen(container: AppContainer, nav: NavHostController, vm: Settings
             return
         }
         if (!container.health.isAvailable()) {
-            permissionDeniedMessage = healthAvailabilityMessage()
+            showHealthAvailabilityAlert()
             return
         }
         pendingHealthPermissionAction = HealthConnectPermissionAction.ENERGY_GOALS
@@ -1743,13 +1763,40 @@ fun SettingsScreen(container: AppContainer, nav: NavHostController, vm: Settings
     }
 
     permissionDeniedMessage?.let { msg ->
-        FudGlassDialog(onDismissRequest = { permissionDeniedMessage = null }) {
+        val healthAvailability = permissionDeniedHealthAvailability
+        FudGlassDialog(onDismissRequest = { clearPermissionAlert() }) {
             Text(stringResource(R.string.settings_permission_title), fontSize = 21.sp, fontWeight = FontWeight.Bold)
             Text(msg, color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.68f))
-            FudGlassDialogActions(
-                primaryText = stringResource(R.string.action_ok),
-                onPrimary = { permissionDeniedMessage = null }
-            )
+            when (healthAvailability) {
+                HealthConnectAvailability.PROVIDER_UPDATE_REQUIRED -> {
+                    FudGlassDialogActions(
+                        primaryText = stringResource(R.string.settings_health_open_play_store),
+                        onPrimary = {
+                            clearPermissionAlert()
+                            openHealthConnectPlayStore()
+                        },
+                        dismissText = stringResource(R.string.action_cancel),
+                        onDismiss = { clearPermissionAlert() }
+                    )
+                }
+                HealthConnectAvailability.AVAILABLE -> {
+                    FudGlassDialogActions(
+                        primaryText = stringResource(R.string.settings_manage_health_access),
+                        onPrimary = {
+                            clearPermissionAlert()
+                            openHealthConnectAccess()
+                        },
+                        dismissText = stringResource(R.string.action_cancel),
+                        onDismiss = { clearPermissionAlert() }
+                    )
+                }
+                else -> {
+                    FudGlassDialogActions(
+                        primaryText = stringResource(R.string.action_ok),
+                        onPrimary = { clearPermissionAlert() }
+                    )
+                }
+            }
         }
     }
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -803,6 +803,8 @@
     <string name="settings_health_unavailable">Install or update Health Connect from the Play Store, then re-tap the toggle.</string>
     <string name="settings_health_profile_unsupported">Health Connect can show Fud AI as approved, but Android does not allow Health Connect from a Work Profile, Private Space, or cloned app profile. Install and open Fud AI in your phone\'s main profile.</string>
     <string name="settings_health_system_unavailable">Health Connect\'s system service is unavailable. It requires Android 9 or newer; on a newer phone, install Android and Google Play system updates, restart, then try again.</string>
+    <string name="settings_health_open_play_store">Open Play Store</string>
+    <string name="settings_health_open_settings_failed">Couldn\'t open Health Connect. Try opening it from Settings, then return to Fud AI.</string>
 
     <!-- Settings sheets / pickers -->
     <string name="sheet_ai_provider">AI Provider</string>

--- a/android/app/src/test/java/com/apoorvdarshan/calorietracker/services/health/HealthConnectAvailabilityTest.kt
+++ b/android/app/src/test/java/com/apoorvdarshan/calorietracker/services/health/HealthConnectAvailabilityTest.kt
@@ -1,5 +1,6 @@
 package com.apoorvdarshan.calorietracker.services.health
 
+import androidx.health.connect.client.HealthConnectClient
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -46,5 +47,47 @@ class HealthConnectAvailabilityTest {
                 providerUpdateRequired = false
             )
         )
+    }
+
+    @Test
+    fun secondaryProfileOverridesAvailableSdkStatus() {
+        assertEquals(
+            HealthConnectAvailability.PROFILE_UNSUPPORTED,
+            resolveHealthConnectAvailability(
+                isProfile = true,
+                sdkAvailable = true,
+                providerUpdateRequired = false
+            )
+        )
+    }
+
+    @Test
+    fun sdkStatusCodesMapToAvailability() {
+        assertEquals(
+            HealthConnectAvailability.AVAILABLE,
+            resolveHealthConnectAvailabilityFromSdkStatus(
+                isProfile = false,
+                sdkStatus = HealthConnectClient.SDK_AVAILABLE
+            )
+        )
+        assertEquals(
+            HealthConnectAvailability.PROVIDER_UPDATE_REQUIRED,
+            resolveHealthConnectAvailabilityFromSdkStatus(
+                isProfile = false,
+                sdkStatus = HealthConnectClient.SDK_UNAVAILABLE_PROVIDER_UPDATE_REQUIRED
+            )
+        )
+        assertEquals(
+            HealthConnectAvailability.UNAVAILABLE,
+            resolveHealthConnectAvailabilityFromSdkStatus(
+                isProfile = false,
+                sdkStatus = HealthConnectClient.SDK_UNAVAILABLE
+            )
+        )
+    }
+
+    @Test
+    fun healthConnectProviderPackageMatchesManifestQuery() {
+        assertEquals("com.google.android.apps.healthdata", HealthConnectManager.HEALTH_CONNECT_PROVIDER_PACKAGE)
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #209

## Problem
On Android 14+ (Pixel 8/10 and similar), users saw **"Health Connect's system service is unavailable"** even when Health Connect was installed and permissions were granted. Two root causes:

1. **Missing `<queries>` intent** — `manageAccessIntent()` uses `android.health.connect.action.MANAGE_HEALTH_PERMISSIONS`, which resolves to the system-integrated Health Connect controller on Android 14+, not the standalone `com.google.android.apps.healthdata` package. Without the intent query, the system could not resolve the activity and settings access failed.
2. **Incorrect UI mapping** — `SettingsScreen.healthAvailabilityMessage()` grouped `AVAILABLE` with `UNAVAILABLE`, so any fallback error path showed the misleading "system service unavailable" copy.

## Changes
- **AndroidManifest.xml**: Added `<queries>` intent for `android.health.connect.action.MANAGE_HEALTH_PERMISSIONS` (kept existing healthdata package + rationale intent).
- **HealthConnectManager**: Log raw `sdkStatus`, `isProfile`, and resolved enum; use explicit provider package for `getSdkStatus()`; add `providerPlayStoreIntent()` for provider-update guidance.
- **SettingsScreen**: Fix availability → message mapping; add contextual dialog CTAs (Open Play Store for provider update, Open Health Connect for settings failures).
- **HealthConnectAvailabilityTest**: Cover SDK status → availability mapping and profile precedence.

## Testing
- Unit tests added/extended in `HealthConnectAvailabilityTest` (not run in cloud — no Android SDK).
- Manual verification recommended on a Pixel device with Android 14+: toggle Health Connect sync, tap "Manage Health Access", confirm system permissions UI opens instead of the unavailable error.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36ff9e02-4562-43f4-b064-17bab39b42d5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36ff9e02-4562-43f4-b064-17bab39b42d5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

