### PR TITLE
Fix Health Connect unavailable detection and guidance (#209)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -34,6 +34,11 @@
         <intent>
             <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE" />
         </intent>
+        <!-- Android 14+ resolves this to the system Health Connect controller, not the
+             standalone com.google.android.apps.healthdata package. -->
+        <intent>
+            <action android:name="android.health.connect.action.MANAGE_HEALTH_PERMISSIONS" />
+        </intent>
     </queries>
 
     <application

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/health/HealthConnectManager.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/health/HealthConnectManager.kt
@@ -2,6 +2,7 @@ package com.apoorvdarshan.calorietracker.services.health
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.UserManager
 import androidx.health.connect.client.HealthConnectFeatures
@@ -56,6 +57,23 @@ enum class HealthConnectAvailability {
     UNAVAILABLE
 }
 
+/** Which settings/unavailable copy to show; null means Health Connect is usable. */
+internal enum class HealthAvailabilityMessageKind {
+    PROFILE_UNSUPPORTED,
+    PROVIDER_UPDATE_REQUIRED,
+    SYSTEM_UNAVAILABLE
+}
+
+internal fun healthAvailabilityMessageKind(
+    availability: HealthConnectAvailability
+): HealthAvailabilityMessageKind? = when (availability) {
+    HealthConnectAvailability.AVAILABLE -> null
+    HealthConnectAvailability.PROFILE_UNSUPPORTED -> HealthAvailabilityMessageKind.PROFILE_UNSUPPORTED
+    HealthConnectAvailability.PROVIDER_UPDATE_REQUIRED ->
+        HealthAvailabilityMessageKind.PROVIDER_UPDATE_REQUIRED
+    HealthConnectAvailability.UNAVAILABLE -> HealthAvailabilityMessageKind.SYSTEM_UNAVAILABLE
+}
+
 internal fun resolveHealthConnectAvailability(
     isProfile: Boolean,
     sdkAvailable: Boolean,
@@ -99,13 +117,18 @@ class HealthConnectManager(
             runCatching {
                 (context.getSystemService(Context.USER_SERVICE) as? UserManager)?.isProfile == true
             }.getOrDefault(false)
-        val sdkStatus = HealthConnectClient.getSdkStatus(context)
-        return resolveHealthConnectAvailability(
+        val sdkStatus = HealthConnectClient.getSdkStatus(context, HEALTH_CONNECT_PROVIDER_PACKAGE)
+        val resolved = resolveHealthConnectAvailability(
             isProfile = isProfile,
             sdkAvailable = sdkStatus == HealthConnectClient.SDK_AVAILABLE,
             providerUpdateRequired =
                 sdkStatus == HealthConnectClient.SDK_UNAVAILABLE_PROVIDER_UPDATE_REQUIRED
         )
+        android.util.Log.w(
+            "FudAIHealth",
+            "Health Connect availability sdkStatus=$sdkStatus isProfile=$isProfile resolved=$resolved"
+        )
+        return resolved
     }
 
     fun isAvailable(): Boolean = availability() == HealthConnectAvailability.AVAILABLE
@@ -208,6 +231,27 @@ class HealthConnectManager(
             generic
         }).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     }
+
+    /** Play Store listing for the standalone Health Connect app (pre-Android 14 devices). */
+    fun playStoreIntent(): Intent {
+        val marketUri = Uri.parse(
+            "market://details?id=$HEALTH_CONNECT_PROVIDER_PACKAGE&url=healthconnect%3A%2F%2Fonboarding"
+        )
+        return Intent(Intent.ACTION_VIEW, marketUri).apply {
+            setPackage("com.android.vending")
+            putExtra("overlay", true)
+            putExtra("callerId", context.packageName)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+    }
+
+    fun playStoreWebIntent(): Intent =
+        Intent(Intent.ACTION_VIEW, Uri.parse(HEALTH_CONNECT_PLAY_STORE_WEB))
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+    fun openPlayStore(): Boolean =
+        runCatching { context.startActivity(playStoreIntent()) }.isSuccess ||
+            runCatching { context.startActivity(playStoreWebIntent()) }.isSuccess
 
     // -- Weight -----------------------------------------------------------
 
@@ -769,6 +813,10 @@ class HealthConnectManager(
 
     companion object {
         private val writeVersions = HealthWriteVersions()
+
+        const val HEALTH_CONNECT_PROVIDER_PACKAGE = "com.google.android.apps.healthdata"
+        const val HEALTH_CONNECT_PLAY_STORE_WEB =
+            "https://play.google.com/store/apps/details?id=$HEALTH_CONNECT_PROVIDER_PACKAGE"
 
         private const val ACTION_MANAGE_HEALTH_PERMISSIONS =
             "android.health.connect.action.MANAGE_HEALTH_PERMISSIONS"

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/health/HealthConnectManager.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/health/HealthConnectManager.kt
@@ -32,6 +32,7 @@ import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.math.roundToInt
 
 /**
@@ -124,11 +125,25 @@ class HealthConnectManager(
             providerUpdateRequired =
                 sdkStatus == HealthConnectClient.SDK_UNAVAILABLE_PROVIDER_UPDATE_REQUIRED
         )
+        logAvailabilityIfNeeded(sdkStatus, isProfile, resolved)
+        return resolved
+    }
+
+    private fun logAvailabilityIfNeeded(
+        sdkStatus: Int,
+        isProfile: Boolean,
+        resolved: HealthConnectAvailability
+    ) {
+        if (resolved == HealthConnectAvailability.AVAILABLE) {
+            lastLoggedAvailabilityKey.set(null)
+            return
+        }
+        val key = "$sdkStatus|$isProfile|$resolved"
+        if (lastLoggedAvailabilityKey.getAndSet(key) == key) return
         android.util.Log.w(
             "FudAIHealth",
             "Health Connect availability sdkStatus=$sdkStatus isProfile=$isProfile resolved=$resolved"
         )
-        return resolved
     }
 
     fun isAvailable(): Boolean = availability() == HealthConnectAvailability.AVAILABLE
@@ -812,6 +827,7 @@ class HealthConnectManager(
     }
 
     companion object {
+        private val lastLoggedAvailabilityKey = AtomicReference<String?>(null)
         private val writeVersions = HealthWriteVersions()
 
         const val HEALTH_CONNECT_PROVIDER_PACKAGE = "com.google.android.apps.healthdata"

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt
@@ -177,7 +177,9 @@ import com.apoorvdarshan.calorietracker.models.WorkoutSplit
 import com.apoorvdarshan.calorietracker.export.DiaryImportMode
 import com.apoorvdarshan.calorietracker.export.DiaryImportPreview
 import com.apoorvdarshan.calorietracker.export.DiaryImporter
+import com.apoorvdarshan.calorietracker.services.health.HealthAvailabilityMessageKind
 import com.apoorvdarshan.calorietracker.services.health.HealthConnectAvailability
+import com.apoorvdarshan.calorietracker.services.health.healthAvailabilityMessageKind
 import com.apoorvdarshan.calorietracker.services.ondevice.LocalModelId
 import com.apoorvdarshan.calorietracker.services.ondevice.LocalModelIneligibility
 import com.apoorvdarshan.calorietracker.services.ondevice.LocalModelInstallStatus
@@ -232,6 +234,11 @@ private enum class SettingsSheet {
 private enum class HealthConnectPermissionAction {
     SYNC, ENERGY_GOALS, DAILY_SUMMARY
 }
+
+private data class PermissionDialogState(
+    val message: String,
+    val healthAvailability: HealthConnectAvailability? = null
+)
 
 internal enum class SettingsCategory(
     val titleRes: Int,
@@ -303,7 +310,7 @@ fun SettingsScreen(container: AppContainer, nav: NavHostController, vm: Settings
     var showMaxPinnedAlert by remember { mutableStateOf(false) }
     var showRebalanceBlockedAlert by remember { mutableStateOf(false) }
     var showAdaptiveLockHint by remember { mutableStateOf(false) }
-    var permissionDeniedMessage by remember { mutableStateOf<String?>(null) }
+    var permissionDialog by remember { mutableStateOf<PermissionDialogState?>(null) }
     var showHealthPermissionHelp by remember { mutableStateOf(false) }
     var showDefaultGramsInfo by remember { mutableStateOf(false) }
     var showHealthEnergyGoalsInfo by remember { mutableStateOf(false) }
@@ -400,18 +407,27 @@ fun SettingsScreen(container: AppContainer, nav: NavHostController, vm: Settings
     val healthProfileUnsupportedMsg = stringResource(R.string.settings_health_profile_unsupported)
     val healthSystemUnavailableMsg = stringResource(R.string.settings_health_system_unavailable)
 
-    fun healthAvailabilityMessage(): String = when (container.health.availability()) {
-        HealthConnectAvailability.PROFILE_UNSUPPORTED -> healthProfileUnsupportedMsg
-        HealthConnectAvailability.PROVIDER_UPDATE_REQUIRED -> healthUnavailableMsg
-        HealthConnectAvailability.UNAVAILABLE,
-        HealthConnectAvailability.AVAILABLE -> healthSystemUnavailableMsg
+    fun healthAvailabilityMessage(availability: HealthConnectAvailability): String =
+        when (healthAvailabilityMessageKind(availability)) {
+            HealthAvailabilityMessageKind.PROFILE_UNSUPPORTED -> healthProfileUnsupportedMsg
+            HealthAvailabilityMessageKind.PROVIDER_UPDATE_REQUIRED -> healthUnavailableMsg
+            HealthAvailabilityMessageKind.SYSTEM_UNAVAILABLE -> healthSystemUnavailableMsg
+            null -> healthDeniedMsg
+        }
+
+    fun showHealthAvailabilityDialog() {
+        val availability = container.health.availability()
+        permissionDialog = PermissionDialogState(
+            message = healthAvailabilityMessage(availability),
+            healthAvailability = availability
+        )
     }
 
     val notificationLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission()
     ) { granted ->
         if (granted) vm.setNotificationsEnabled(true)
-        else permissionDeniedMessage = notifDeniedMsg
+        else permissionDialog = PermissionDialogState(notifDeniedMsg)
     }
 
     // Health Connect honors partial grants: any granted permission connects the app, and
@@ -435,7 +451,13 @@ fun SettingsScreen(container: AppContainer, nav: NavHostController, vm: Settings
 
     fun openHealthConnectAccess() {
         runCatching { activityContext.startActivity(container.health.manageAccessIntent()) }
-            .onFailure { permissionDeniedMessage = healthAvailabilityMessage() }
+            .onFailure { permissionDialog = PermissionDialogState(message = healthDeniedMsg) }
+    }
+
+    fun openHealthConnectStore() {
+        if (!container.health.openPlayStore()) {
+            permissionDialog = PermissionDialogState(healthUnavailableMsg)
+        }
     }
 
     fun onNotificationsToggle(enabled: Boolean) {
@@ -476,7 +498,7 @@ fun SettingsScreen(container: AppContainer, nav: NavHostController, vm: Settings
             return
         }
         if (!container.health.isAvailable()) {
-            permissionDeniedMessage = healthAvailabilityMessage()
+            showHealthAvailabilityDialog()
             return
         }
         // Don't pre-check granted state — Health Connect's contract handles the
@@ -494,7 +516,7 @@ fun SettingsScreen(container: AppContainer, nav: NavHostController, vm: Settings
             return
         }
         if (!container.health.isAvailable()) {
-            permissionDeniedMessage = healthAvailabilityMessage()
+            showHealthAvailabilityDialog()
             return
         }
         pendingHealthPermissionAction = HealthConnectPermissionAction.ENERGY_GOALS
@@ -1467,7 +1489,12 @@ fun SettingsScreen(container: AppContainer, nav: NavHostController, vm: Settings
                             showImportSheet = false
                             importPreview = null
                             importError = null
-                            permissionDeniedMessage = resources.getString(R.string.import_diary_success, selected.entries.size + selected.waterEntries.size)
+                            permissionDialog = PermissionDialogState(
+                                resources.getString(
+                                    R.string.import_diary_success,
+                                    selected.entries.size + selected.waterEntries.size
+                                )
+                            )
                         }.onFailure { error ->
                             importError = error.localizedMessage ?: importReadFailedMessage
                         }
@@ -1742,13 +1769,36 @@ fun SettingsScreen(container: AppContainer, nav: NavHostController, vm: Settings
         }
     }
 
-    permissionDeniedMessage?.let { msg ->
-        FudGlassDialog(onDismissRequest = { permissionDeniedMessage = null }) {
+    permissionDialog?.let { dialog ->
+        val getHealthConnectLabel = stringResource(R.string.settings_get_health_connect)
+        val manageHealthLabel = stringResource(R.string.settings_manage_health_access)
+        val (primaryText, onPrimary) = when (dialog.healthAvailability) {
+            HealthConnectAvailability.PROVIDER_UPDATE_REQUIRED -> getHealthConnectLabel to {
+                permissionDialog = null
+                openHealthConnectStore()
+            }
+            HealthConnectAvailability.UNAVAILABLE -> manageHealthLabel to {
+                permissionDialog = null
+                openHealthConnectAccess()
+            }
+            else -> stringResource(R.string.action_ok) to { permissionDialog = null }
+        }
+        val dismissForUnavailable = dialog.healthAvailability == HealthConnectAvailability.UNAVAILABLE
+        FudGlassDialog(onDismissRequest = { permissionDialog = null }) {
             Text(stringResource(R.string.settings_permission_title), fontSize = 21.sp, fontWeight = FontWeight.Bold)
-            Text(msg, color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.68f))
+            Text(dialog.message, color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.68f))
             FudGlassDialogActions(
-                primaryText = stringResource(R.string.action_ok),
-                onPrimary = { permissionDeniedMessage = null }
+                primaryText = primaryText,
+                onPrimary = onPrimary,
+                dismissText = if (dismissForUnavailable) getHealthConnectLabel else null,
+                onDismiss = if (dismissForUnavailable) {
+                    {
+                        permissionDialog = null
+                        openHealthConnectStore()
+                    }
+                } else {
+                    null
+                }
             )
         }
     }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt
@@ -451,7 +451,7 @@ fun SettingsScreen(container: AppContainer, nav: NavHostController, vm: Settings
 
     fun openHealthConnectAccess() {
         runCatching { activityContext.startActivity(container.health.manageAccessIntent()) }
-            .onFailure { permissionDialog = PermissionDialogState(message = healthDeniedMsg) }
+            .onFailure { showHealthAvailabilityDialog() }
     }
 
     fun openHealthConnectStore() {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -803,6 +803,7 @@
     <string name="settings_health_unavailable">Install or update Health Connect from the Play Store, then re-tap the toggle.</string>
     <string name="settings_health_profile_unsupported">Health Connect can show Fud AI as approved, but Android does not allow Health Connect from a Work Profile, Private Space, or cloned app profile. Install and open Fud AI in your phone\'s main profile.</string>
     <string name="settings_health_system_unavailable">Health Connect\'s system service is unavailable. It requires Android 9 or newer; on a newer phone, install Android and Google Play system updates, restart, then try again.</string>
+    <string name="settings_get_health_connect">Get Health Connect</string>
 
     <!-- Settings sheets / pickers -->
     <string name="sheet_ai_provider">AI Provider</string>

--- a/android/app/src/test/java/com/apoorvdarshan/calorietracker/services/health/HealthConnectAvailabilityTest.kt
+++ b/android/app/src/test/java/com/apoorvdarshan/calorietracker/services/health/HealthConnectAvailabilityTest.kt
@@ -47,4 +47,47 @@ class HealthConnectAvailabilityTest {
             )
         )
     }
+
+    @Test
+    fun availableNeverMapsToAvailabilityMessage() {
+        assertEquals(null, healthAvailabilityMessageKind(HealthConnectAvailability.AVAILABLE))
+    }
+
+    @Test
+    fun messageKindTracksResolvedAvailability() {
+        assertEquals(
+            HealthAvailabilityMessageKind.PROFILE_UNSUPPORTED,
+            healthAvailabilityMessageKind(HealthConnectAvailability.PROFILE_UNSUPPORTED)
+        )
+        assertEquals(
+            HealthAvailabilityMessageKind.PROVIDER_UPDATE_REQUIRED,
+            healthAvailabilityMessageKind(HealthConnectAvailability.PROVIDER_UPDATE_REQUIRED)
+        )
+        assertEquals(
+            HealthAvailabilityMessageKind.SYSTEM_UNAVAILABLE,
+            healthAvailabilityMessageKind(HealthConnectAvailability.UNAVAILABLE)
+        )
+    }
+
+    @Test
+    fun profileUnsupportedWinsEvenWhenProviderUpdateWouldApply() {
+        assertEquals(
+            HealthConnectAvailability.PROFILE_UNSUPPORTED,
+            resolveHealthConnectAvailability(
+                isProfile = true,
+                sdkAvailable = false,
+                providerUpdateRequired = true
+            )
+        )
+        assertEquals(
+            HealthAvailabilityMessageKind.PROFILE_UNSUPPORTED,
+            healthAvailabilityMessageKind(
+                resolveHealthConnectAvailability(
+                    isProfile = true,
+                    sdkAvailable = false,
+                    providerUpdateRequired = true
+                )
+            )
+        )
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #209

## Root cause

On Android 14+ (Pixel 8 Pro, Pixel 10a, etc.), Health Connect is integrated into the system via `com.google.android.healthconnect.controller`, not the standalone `com.google.android.apps.healthdata` package. Fud AI was missing a `<queries>` entry for `android.health.connect.action.MANAGE_HEALTH_PERMISSIONS`, so `manageAccessIntent()` could not resolve on newer devices and availability checks failed with a misleading **"system service is unavailable"** dialog.

Additionally, `SettingsScreen.healthAvailabilityMessage()` incorrectly mapped `HealthConnectAvailability.AVAILABLE` to `settings_health_system_unavailable` — a copy-paste bug that could show the wrong message when opening Health Connect settings failed.

## Changes

- **AndroidManifest**: add `<queries>` intent for `MANAGE_HEALTH_PERMISSIONS` (keep existing `healthdata` package + rationale intent).
- **HealthConnectManager**: call `getSdkStatus(context, HEALTH_CONNECT_PROVIDER_PACKAGE)`; log raw `sdkStatus`, `isProfile`, and resolved enum (`Log.w`, no PII); add Play Store intents for provider install/update.
- **SettingsScreen**: fix message mapping so `AVAILABLE` never maps to system-unavailable; show contextual CTAs — **Get Health Connect** (Play Store) for provider update, **Manage Health Connect Access** + Play Store fallback for system unavailable.
- **Tests**: extend `HealthConnectAvailabilityTest` for message-kind mapping and profile-priority cases.

## Out of scope

Step counting / `StepsRecord` / `READ_STEPS` remains **#205** — Fud AI still syncs weight, body fat, nutrition, and active/total calories only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18f6238b-9267-448c-a577-14a4d3535ed2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18f6238b-9267-448c-a577-14a4d3535ed2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR improves Health Connect availability detection and recovery guidance across Android versions.
- Adds package visibility for the Android 14+ Health Connect permission-management intent.
- Distinguishes unsupported profiles, provider updates, and system-unavailable states.
- Adds contextual Manage Access and Play Store recovery actions.
- Extends unit coverage for availability and message mapping.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/src/main/AndroidManifest.xml | Adds package visibility for the Android 14+ Health Connect permission-management intent. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/services/health/HealthConnectManager.kt | Refines provider-specific availability detection, deduplicated diagnostic logging, and Play Store fallback intents. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt | Preserves availability in dialog state and provides contextual recovery actions; the previously reported unavailable-recovery issue is fixed. |
| android/app/src/main/res/values/strings.xml | Adds labels and guidance copy for Health Connect installation and access management. |
| android/app/src/test/java/com/apoorvdarshan/calorietracker/services/health/HealthConnectAvailabilityTest.kt | Extends tests for availability precedence and message-kind mapping. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User enables Health Connect] --> B{Availability}
    B -->|Available| C[Launch permission request]
    B -->|Profile unsupported| D[Show unsupported-profile guidance]
    B -->|Provider update required| E[Show Get Health Connect action]
    B -->|Unavailable| F[Show Manage Access and Play Store actions]
    F --> G{Manage Access launches?}
    G -->|Yes| H[Open Health Connect settings]
    G -->|No| F
    E --> I[Open Play Store with web fallback]
    F --> I
```

<sub>Reviews (3): Last reviewed commit: ["fix(android): stop flooding logs on Heal..."](https://github.com/apoorvdarshan/fud-ai/commit/4a6cc9515cda1d89127071c165eba16653813db7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62557530)</sub>

<!-- /greptile_comment -->