### PR TITLE
fix: address #248 bot review (meal share + allergens)

### DIFF
--- a/android/app/src/androidTest/java/com/apoorvdarshan/calorietracker/services/MealShareTest.kt
+++ b/android/app/src/androidTest/java/com/apoorvdarshan/calorietracker/services/MealShareTest.kt
@@ -33,16 +33,15 @@ class MealShareTest {
         assertFalse(MealShare.shareText(entries, result).contains("?d="))
     }
 
-    @Test fun retriesOnceOnRateLimit() = runBlocking {
-        val short = "https://www.fud-ai.app/m/abcdefghijklmnopqrstuv"
+    @Test fun rateLimitFallsBackWithoutRetry() = runBlocking {
+        val fallback = MealShare.link(entries)
         var attempts = 0
         val result = MealShare.preferredLink(entries) {
             attempts += 1
-            if (attempts == 1) throw MealShare.RateLimited()
-            short
+            null
         }
-        assertEquals(2, attempts)
-        assertEquals(short, result)
+        assertEquals(1, attempts)
+        assertEquals(fallback, result)
     }
 
     @Test fun failuresPreserveLongLink() = runBlocking {

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/MealShare.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/MealShare.kt
@@ -57,7 +57,7 @@ object MealShare {
         return "https://$WEB_HOST$WEB_PATH?d=$b64"
     }
 
-    /** Failed/offline creation preserves the existing self-contained link. */
+    /** Failed/offline/rate-limited creation preserves the existing self-contained link. */
     internal suspend fun preferredLink(
         entries: List<FoodEntry>,
         create: suspend (String) -> String? = ::createShortLink
@@ -65,25 +65,15 @@ object MealShare {
         val fallback = link(entries)
         val payload = String(Base64.getUrlDecoder().decode(fallback.substringAfter("?d=")), Charsets.UTF_8)
         val pattern = Regex("https://www\\.fud-ai\\.app/m/[A-Za-z0-9_-]{22}")
-        for (attempt in 0 until 2) {
-            val short = try {
-                create(payload)
-            } catch (_: RateLimited) {
-                if (attempt == 0) continue
-                return fallback
-            } catch (_: IOException) {
-                return fallback
-            }
-            if (short?.matches(pattern) == true) return short
-            // Injectable create may return null to simulate rate limit in tests.
-            if (attempt == 0 && short == null) continue
-            break
+        // One attempt only: the Worker rate-limits for 60s, so an immediate 429 retry
+        // still fails and would burn quota / delay the share sheet for no gain.
+        val short = try {
+            create(payload)
+        } catch (_: IOException) {
+            null
         }
-        return fallback
+        return short?.takeIf { it.matches(pattern) } ?: fallback
     }
-
-    /** Thrown by [createShortLink] on HTTP 429 so [preferredLink] can retry once. */
-    internal class RateLimited : IOException("meal share rate limited")
 
     private suspend fun createShortLink(payload: String): String? = withContext(Dispatchers.IO) {
         val request = Request.Builder().url("https://$WEB_HOST/api/meal-shares")
@@ -91,7 +81,6 @@ object MealShare {
             .header("User-Agent", SHARE_USER_AGENT)
             .build()
         shareClient.newCall(request).execute().use { response ->
-            if (response.code == 429) throw RateLimited()
             if (response.code != 201) return@withContext null
             try { JSONObject(response.body?.string().orEmpty()).optString("url").takeIf { it.isNotEmpty() } }
             catch (_: org.json.JSONException) { null }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/AllergenSensitivitiesScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/AllergenSensitivitiesScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableFloatStateOf
@@ -104,6 +105,12 @@ fun AllergenSensitivitiesScreen(
     var importError by remember { mutableStateOf<String?>(null) }
     var pendingImport by remember { mutableStateOf<List<String>?>(null) }
     var selectedImport by remember { mutableStateOf<Set<String>>(emptySet()) }
+
+    // Profile may load after this route opens; keep local list in sync. Edits call
+    // persist() immediately, so there is no unsaved draft to preserve across refreshes.
+    LaunchedEffect(current) {
+        if (allergens != current) allergens = current
+    }
 
     fun persist(next: List<String>) {
         allergens = next

--- a/ios/calorietracker/Services/MealShare.swift
+++ b/ios/calorietracker/Services/MealShare.swift
@@ -55,23 +55,21 @@ enum MealShare {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(shareUserAgent, forHTTPHeaderField: "User-Agent")
         request.httpBody = payload
+        // One attempt only: Worker 429s use Retry-After: 60, so an immediate retry
+        // still fails and only delays the share sheet.
         do {
-            for attempt in 0..<2 {
-                let (data, response) = try await send(request)
-                let status = (response as? HTTPURLResponse)?.statusCode ?? 0
-                if status == 429, attempt == 0 { continue }
-                guard status == 201,
-                      let result = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-                      let value = result["url"] as? String,
-                      let url = URL(string: value),
-                      url.scheme == "https", url.host == webHost,
-                      url.user == nil, url.password == nil, url.port == nil,
-                      url.query == nil, url.fragment == nil,
-                      url.path.range(of: "^/m/[A-Za-z0-9_-]{22}$", options: .regularExpression) != nil
-                else { return fallback }
-                return url
-            }
-            return fallback
+            let (data, response) = try await send(request)
+            let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+            guard status == 201,
+                  let result = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let value = result["url"] as? String,
+                  let url = URL(string: value),
+                  url.scheme == "https", url.host == webHost,
+                  url.user == nil, url.password == nil, url.port == nil,
+                  url.query == nil, url.fragment == nil,
+                  url.path.range(of: "^/m/[A-Za-z0-9_-]{22}$", options: .regularExpression) != nil
+            else { return fallback }
+            return url
         } catch { return fallback }
     }
 

--- a/ios/calorietrackerTests/MealShareTests.swift
+++ b/ios/calorietrackerTests/MealShareTests.swift
@@ -37,17 +37,14 @@ struct MealShareTests {
         #expect(!text.contains("?d="))
     }
 
-    @Test func retriesOnceOnRateLimit() async throws {
-        let short = "https://www.fud-ai.app/m/abcdefghijklmnopqrstuv"
+    @Test func rateLimitFallsBackWithoutRetry() async throws {
         var attempts = 0
         let result = await MealShare.preferredLink(for: entries) { request in
             attempts += 1
-            let status = attempts == 1 ? 429 : 201
-            let body = attempts == 1 ? "{}" : "{\"url\":\"\(short)\"}"
-            return (Data(body.utf8), HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!)
+            return (Data("{}".utf8), HTTPURLResponse(url: request.url!, statusCode: 429, httpVersion: nil, headerFields: nil)!)
         }
-        #expect(attempts == 2)
-        #expect(result?.absoluteString == short)
+        #expect(attempts == 1)
+        #expect(result?.path == MealShare.webPath)
     }
 
     @Test func failuresKeepTheLongLink() async {

--- a/web/MEAL_SHARES.md
+++ b/web/MEAL_SHARES.md
@@ -50,7 +50,9 @@ No account resources are created by the tests or dry-run.
 
 Both mobile share sheets attempt creation with a five-second timeout, send
 `Content-Type: application/json` and a `FudAI/1.0 (...; MealShare)` User-Agent,
-retry once on HTTP 429, and retain the long link on offline, repeated rate-limit,
-service, or invalid-response failures. Deploy
+and retain the long link on offline, rate-limit (HTTP 429), service, or
+invalid-response failures. They do not immediately retry 429s: the Worker returns
+`Retry-After: 60`, so a second request in the same window would still fail and
+only delay the share sheet. Deploy
 the Worker before releasing the mobile changes. Verify creation, messenger previews,
 expiry, and iOS/Android import on a simulator/emulator or test device separately.


### PR DESCRIPTION
## Summary
- **Greptile / Qodo (meal share):** Stop retrying on null or immediate 429. The Worker returns `Retry-After: 60`, so a second POST in the same window still fails, burns quota, and delays the share sheet. Fall back to the long link on first failure instead. Waiting 60s before sharing is not worth it.
- **Qodo (allergens):** Sync `AllergenSensitivitiesScreen` local list when `current` updates after profile load, so later edits do not overwrite a fresher profile list.

## Test plan
- [ ] Share a meal online → short `/m/...` link
- [ ] Share offline / with API failure → long `/add-meal?d=...` fallback (single attempt)
- [ ] Open allergen sensitivities after cold start; confirm list matches profile; add one and confirm it merges correctly


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes immediate meal-share retries on Android and iOS, updates associated tests and documentation, and synchronizes Android allergen UI state with asynchronously loaded profile data.
- Meal-share creation now falls back to the self-contained long link after the first failed, invalid, or rate-limited request.
- Android allergen state now follows current profile emissions, but this can overwrite newer edits while saves are in flight.

<h3>Confidence Score: 4/5</h3>

The allergen synchronization race should be fixed before merging because a delayed profile update can erase a newer user edit.

The new LaunchedEffect unconditionally adopts asynchronous current values, while saves are launched independently, allowing an earlier profile emission to replace a newer local allergen list.

**Files Needing Attention:** android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/AllergenSensitivitiesScreen.kt

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/AllergenSensitivitiesScreen.kt | Adds profile-to-local synchronization that can revert newer local allergen edits when asynchronous updates emit out of order. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/services/MealShare.kt | Removes retry behavior while retaining validated short-link handling and long-link fallback. |
| ios/calorietracker/Services/MealShare.swift | Replaces the two-attempt loop with one request and preserves strict response validation and fallback behavior. |
| android/app/src/androidTest/java/com/apoorvdarshan/calorietracker/services/MealShareTest.kt | Updates Android coverage to assert one creation attempt and long-link fallback. |
| ios/calorietrackerTests/MealShareTests.swift | Updates iOS coverage to assert immediate fallback after a 429 response. |
| web/MEAL_SHARES.md | Documents the single-attempt mobile sharing behavior and rationale. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor User
    participant Screen as Allergen Screen
    participant VM as SettingsViewModel
    participant Repo as Profile Repository
    User->>Screen: Add allergen A
    Screen->>VM: updateProfile([A])
    VM->>Repo: async save [A]
    User->>Screen: Add allergen B
    Screen->>VM: updateProfile([A, B])
    Repo-->>VM: first save completes
    VM-->>Screen: "current = [A]"
    Screen->>Screen: LaunchedEffect replaces [A, B] with [A]
    Note over User,Screen: Allergen B disappears
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20apoorvdarshan%2Ffud-ai%20PR%20%23252%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=252&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fsettings%2FAllergenSensitivitiesScreen.kt%3A111-113%0A**Profile%20emissions%20overwrite%20newer%20edits**%0A%0AWhen%20a%20user%20makes%20successive%20allergen%20edits%20before%20asynchronous%20profile%20saves%20complete%2C%20%60LaunchedEffect%28current%29%60%20adopts%20an%20earlier%20emitted%20profile%20value%20and%20replaces%20the%20newer%20local%20list%2C%20causing%20the%20latest%20addition%20or%20removal%20to%20disappear%20and%20allowing%20subsequent%20edits%20to%20persist%20the%20reverted%20list.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=252&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22apoorvdarshan%2Ffud-ai%22%20on%20the%20existing%20branch%20%22fix%2F248-meal-share-bot-review%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F248-meal-share-bot-review%22.%0A%0A%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fsettings%2FAllergenSensitivitiesScreen.kt%3A111-113%0A**Profile%20emissions%20overwrite%20newer%20edits**%0A%0AWhen%20a%20user%20makes%20successive%20allergen%20edits%20before%20asynchronous%20profile%20saves%20complete%2C%20%60LaunchedEffect%28current%29%60%20adopts%20an%20earlier%20emitted%20profile%20value%20and%20replaces%20the%20newer%20local%20list%2C%20causing%20the%20latest%20addition%20or%20removal%20to%20disappear%20and%20allowing%20subsequent%20edits%20to%20persist%20the%20reverted%20list.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=252&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fsettings%2FAllergenSensitivitiesScreen.kt%3A111-113%0A**Profile%20emissions%20overwrite%20newer%20edits**%0A%0AWhen%20a%20user%20makes%20successive%20allergen%20edits%20before%20asynchronous%20profile%20saves%20complete%2C%20%60LaunchedEffect%28current%29%60%20adopts%20an%20earlier%20emitted%20profile%20value%20and%20replaces%20the%20newer%20local%20list%2C%20causing%20the%20latest%20addition%20or%20removal%20to%20disappear%20and%20allowing%20subsequent%20edits%20to%20persist%20the%20reverted%20list.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=252&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/AllergenSensitivitiesScreen.kt:111-113
**Profile emissions overwrite newer edits**

When a user makes successive allergen edits before asynchronous profile saves complete, `LaunchedEffect(current)` adopts an earlier emitted profile value and replaces the newer local list, causing the latest addition or removal to disappear and allowing subsequent edits to persist the reverted list.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: address #248 bot review on meal sha..."](https://github.com/apoorvdarshan/fud-ai/commit/c70b03102ebb9df277fb0bf5c854a4da670983c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62574202)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Allergen sensitivity settings now update automatically when profile information finishes loading, while preserving edits made during the session.

- **Bug Fixes**
  - Meal sharing now falls back immediately to a self-contained long link when short-link creation is unavailable, rate-limited, offline, or returns an invalid response.
  - Share link creation no longer retries after a rate-limit response, reducing delays and avoiding unnecessary requests across mobile and web.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->