### PR TITLE
Show daily steps from Health Connect / Apple Health on Home (#205)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
     <uses-permission android:name="android.permission.health.READ_ACTIVE_CALORIES_BURNED" />
     <uses-permission android:name="android.permission.health.WRITE_ACTIVE_CALORIES_BURNED" />
     <uses-permission android:name="android.permission.health.READ_TOTAL_CALORIES_BURNED" />
+    <uses-permission android:name="android.permission.health.READ_STEPS" />
     <uses-permission android:name="android.permission.health.READ_HEALTH_DATA_IN_BACKGROUND" />
 
     <uses-feature

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/health/HealthConnectManager.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/health/HealthConnectManager.kt
@@ -14,6 +14,7 @@ import androidx.health.connect.client.records.ActiveCaloriesBurnedRecord
 import androidx.health.connect.client.records.BodyFatRecord
 import androidx.health.connect.client.records.MealType as HCMealType
 import androidx.health.connect.client.records.NutritionRecord
+import androidx.health.connect.client.records.StepsRecord
 import androidx.health.connect.client.records.TotalCaloriesBurnedRecord
 import androidx.health.connect.client.records.WeightRecord
 import androidx.health.connect.client.records.metadata.DataOrigin
@@ -160,11 +161,13 @@ class HealthConnectManager(
     private val activeEnergyRead = HealthPermission.getReadPermission(ActiveCaloriesBurnedRecord::class)
     private val activeEnergyWrite = HealthPermission.getWritePermission(ActiveCaloriesBurnedRecord::class)
     private val totalEnergyRead = HealthPermission.getReadPermission(TotalCaloriesBurnedRecord::class)
+    private val stepsRead = HealthPermission.getReadPermission(StepsRecord::class)
     private val backgroundRead = HealthPermission.PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND
 
     val permissions: Set<String> = setOf(
         weightRead, weightWrite, nutritionRead, nutritionWrite,
-        bodyFatRead, bodyFatWrite, activeEnergyRead, activeEnergyWrite, totalEnergyRead
+        bodyFatRead, bodyFatWrite, activeEnergyRead, activeEnergyWrite, totalEnergyRead,
+        stepsRead
     )
 
     /** Requested only when Daily Summary is enabled. Keeping it out of [permissions]
@@ -199,6 +202,7 @@ class HealthConnectManager(
     suspend fun hasActiveEnergyRead(): Boolean = activeEnergyRead in granted()
     suspend fun hasActiveEnergyWrite(): Boolean = activeEnergyWrite in granted()
     suspend fun hasEnergyRead(): Boolean = granted().let { activeEnergyRead in it && totalEnergyRead in it }
+    suspend fun hasStepsRead(): Boolean = stepsRead in granted()
     suspend fun hasBackgroundRead(): Boolean = backgroundRead in granted()
 
     /** One permission read snapshotting every capability — used by the read-sync coordinator. */
@@ -212,7 +216,8 @@ class HealthConnectManager(
             nutritionRead = nutritionRead in g,
             nutritionWrite = nutritionWrite in g,
             energyRead = activeEnergyRead in g && totalEnergyRead in g,
-            activeEnergyWrite = activeEnergyWrite in g
+            activeEnergyWrite = activeEnergyWrite in g,
+            stepsRead = stepsRead in g
         )
     }
 
@@ -689,6 +694,29 @@ class HealthConnectManager(
         )
     }
 
+    /** Daily step total for one local calendar day from Health Connect aggregates. */
+    suspend fun readStepsForDay(date: LocalDate): Int? {
+        if (!hasStepsRead()) return null
+        val zone = ZoneId.systemDefault()
+        val start = date.atStartOfDay(zone).toInstant()
+        val end = minOf(date.plusDays(1).atStartOfDay(zone).toInstant(), Instant.now())
+        if (!end.isAfter(start)) return null
+        return readDailySteps(start, end)
+    }
+
+    private suspend fun readDailySteps(start: Instant, end: Instant): Int? {
+        val c = client ?: return null
+        val result = runCatching {
+            c.aggregate(
+                AggregateRequest(
+                    metrics = setOf(StepsRecord.COUNT_TOTAL),
+                    timeRangeFilter = TimeRangeFilter.between(start, end)
+                )
+            )
+        }.getOrNull() ?: return null
+        return result[StepsRecord.COUNT_TOTAL]?.toLong()?.toInt()?.takeIf { it >= 0 }
+    }
+
     private suspend fun readDailyEnergy(start: Instant, end: Instant): DailyEnergy? {
         val c = client ?: return null
         val result = runCatching {
@@ -866,8 +894,9 @@ class HealthConnectManager(
          *  v2 = added BodyFatRecord read+write permissions.
          *  v3 = added energy burn read permissions.
          *  v4 = added NutritionRecord read permission (food-log restore).
-         *  v5 = added ActiveCaloriesBurnedRecord write permission (workout burn sync). */
-        const val CURRENT_TYPES_VERSION = 5
+         *  v5 = added ActiveCaloriesBurnedRecord write permission (workout burn sync).
+         *  v6 = added StepsRecord read permission (daily steps on Home). */
+        const val CURRENT_TYPES_VERSION = 6
     }
 }
 
@@ -896,7 +925,8 @@ data class HealthCapabilities(
     val nutritionRead: Boolean,
     val nutritionWrite: Boolean,
     val energyRead: Boolean,
-    val activeEnergyWrite: Boolean
+    val activeEnergyWrite: Boolean,
+    val stepsRead: Boolean
 )
 
 data class WorkoutBurnIdentity(

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
@@ -12,7 +12,11 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.apoorvdarshan.calorietracker.services.FoodImageDecoder
 import com.apoorvdarshan.calorietracker.ui.navigation.LocalLaunchFillEpoch
 import androidx.compose.foundation.BorderStroke
@@ -209,6 +213,16 @@ fun HomeScreen(
 ) {
     val vm: HomeViewModel = viewModel(factory = HomeViewModel.Factory(container))
     val ui by vm.ui.collectAsState()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                vm.refreshDailySteps()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
     val shareScope = rememberCoroutineScope()
     val ctx = LocalContext.current
     val weekStartsOnMonday by container.prefs.weekStartsOnMonday.collectAsState(initial = true)

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.DirectionsWalk
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AddAPhoto
 import androidx.compose.material.icons.filled.Bookmark
@@ -494,6 +495,10 @@ fun HomeScreen(
                 ) {
                     Spacer(Modifier.height(32.dp))
                     CalorieHero(current = ui.caloriesToday, goal = ui.profile?.effectiveCalories ?: 2000)
+                    ui.dailySteps?.let { steps ->
+                        Spacer(Modifier.height(8.dp))
+                        DailyStepsRow(steps = steps)
+                    }
                     Spacer(Modifier.height(12.dp))
                     Row(
                         Modifier
@@ -1508,6 +1513,31 @@ private fun shortDay(dow: DayOfWeek): String = when (dow) {
  *   }
  *   .padding(.vertical, 20)
  */
+@Composable
+private fun DailyStepsRow(steps: Int) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Outlined.DirectionsWalk,
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.width(6.dp))
+        Text(
+            text = pluralStringResource(R.plurals.home_daily_steps, steps, steps.formattedWholeNumber()),
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
 @Composable
 private fun CalorieHero(current: Int, goal: Int) {
     val ratio = if (goal > 0) (current.toFloat() / goal).coerceIn(0f, 1f) else 0f

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt
@@ -211,9 +211,9 @@ class HomeViewModel(private val container: AppContainer) : ViewModel() {
                 container.prefs.healthConnectEnabled,
                 _selectedDate,
                 _stepsRefreshEpoch
-            ) { enabled, date, _ -> enabled to date }
+            ) { enabled, date, epoch -> Triple(enabled, date, epoch) }
                 .distinctUntilChanged()
-                .collect { (enabled, date) ->
+                .collect { (enabled, date, _) ->
                     if (!enabled || !container.health.hasStepsRead()) {
                         _ui.value = _ui.value.copy(dailySteps = null)
                         return@collect

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -81,7 +82,9 @@ data class HomeUiState(
     val fastingOverlap: Boolean = false,
     val error: String? = null,
     /** When true, the error dialog's primary action opens the food camera instead of retrying. */
-    val errorOffersScanLabel: Boolean = false
+    val errorOffersScanLabel: Boolean = false,
+    /** Daily step total from Health Connect for [date]; null when health is off, unreadable, or loading. */
+    val dailySteps: Int? = null
 ) {
     val caloriesToday: Int get() = todayEntries.sumOf { it.calories }
     val proteinToday: Double get() = todayEntries.sumOf { it.protein }
@@ -200,6 +203,24 @@ class HomeViewModel(private val container: AppContainer) : ViewModel() {
 
         viewModelScope.launch {
             container.prefs.pendingFoodAnalysisDraft.first()?.let { restorePendingDraft(it) }
+        }
+
+        viewModelScope.launch {
+            combine(
+                container.prefs.healthConnectEnabled,
+                _selectedDate
+            ) { enabled, date -> enabled to date }
+                .distinctUntilChanged()
+                .collect { (enabled, date) ->
+                    if (!enabled || !container.health.hasStepsRead()) {
+                        _ui.value = _ui.value.copy(dailySteps = null)
+                        return@collect
+                    }
+                    val steps = container.health.readStepsForDay(date)
+                    if (_selectedDate.value == date) {
+                        _ui.value = _ui.value.copy(dailySteps = steps)
+                    }
+                }
         }
     }
 

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt
@@ -112,6 +112,7 @@ class HomeViewModel(private val container: AppContainer) : ViewModel() {
     private val _ui = MutableStateFlow(HomeUiState())
     val ui: StateFlow<HomeUiState> = _ui.asStateFlow()
     private val _selectedDate = MutableStateFlow(LocalDate.now())
+    private val _stepsRefreshEpoch = MutableStateFlow(0)
     private var retryAction: (() -> Unit)? = null
     private val foodSubmissionGate = FoodSubmissionGate()
 
@@ -208,8 +209,9 @@ class HomeViewModel(private val container: AppContainer) : ViewModel() {
         viewModelScope.launch {
             combine(
                 container.prefs.healthConnectEnabled,
-                _selectedDate
-            ) { enabled, date -> enabled to date }
+                _selectedDate,
+                _stepsRefreshEpoch
+            ) { enabled, date, _ -> enabled to date }
                 .distinctUntilChanged()
                 .collect { (enabled, date) ->
                     if (!enabled || !container.health.hasStepsRead()) {
@@ -222,6 +224,10 @@ class HomeViewModel(private val container: AppContainer) : ViewModel() {
                     }
                 }
         }
+    }
+
+    fun refreshDailySteps() {
+        _stepsRefreshEpoch.value += 1
     }
 
     fun setSelectedDate(date: LocalDate) {

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/onboarding/OnboardingScreen.kt
@@ -1089,6 +1089,7 @@ private fun HealthConnectStep(container: AppContainer, enabled: Boolean, onToggl
             HealthFeatureRow(icon = Icons.Outlined.Restaurant, label = stringResource(R.string.onboarding_health_feature_nutrition))
             HealthFeatureRow(icon = Icons.Outlined.MonitorWeight, label = stringResource(R.string.onboarding_health_feature_weight))
             HealthFeatureRow(icon = Icons.Outlined.Accessibility, label = stringResource(R.string.onboarding_health_feature_body))
+            HealthFeatureRow(icon = Icons.AutoMirrored.Outlined.DirectionsWalk, label = stringResource(R.string.onboarding_health_feature_steps))
         }
         Spacer(Modifier.height(24.dp))
         Box(

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModel.kt
@@ -1082,11 +1082,12 @@ class SettingsViewModel(val container: AppContainer) : ViewModel() {
         }
 
         val workoutWriteGranted = container.health.hasActiveEnergyWrite()
+        val stepsReadGranted = container.health.hasStepsRead()
         if (granted && (!stored || version < HealthConnectManager.CURRENT_TYPES_VERSION)) {
             backfillHealthConnect()
-            // v5 adds workout Active Energy write. Do not mark v5 complete for
-            // an existing user until that newly added permission is granted.
-            if (workoutWriteGranted) {
+            // v5 adds workout Active Energy write; v6 adds steps read. Do not mark
+            // complete until every permission added in those versions is granted.
+            if (workoutWriteGranted && stepsReadGranted) {
                 container.prefs.setHealthPermissionsVersion(HealthConnectManager.CURRENT_TYPES_VERSION)
             }
         }
@@ -1115,7 +1116,7 @@ class SettingsViewModel(val container: AppContainer) : ViewModel() {
                     return@launch
                 }
                 container.prefs.setHealthConnectEnabled(true)
-                if (container.health.hasActiveEnergyWrite()) {
+                if (container.health.hasActiveEnergyWrite() && container.health.hasStepsRead()) {
                     container.prefs.setHealthPermissionsVersion(HealthConnectManager.CURRENT_TYPES_VERSION)
                 }
                 if (container.health.readRecentEnergySummary(days = 14) == null) {

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModel.kt
@@ -1035,7 +1035,7 @@ class SettingsViewModel(val container: AppContainer) : ViewModel() {
             if (enabled) {
                 backfillHealthConnect()
                 container.syncHealthConnectReads()
-                if (container.health.hasActiveEnergyWrite()) {
+                if (container.health.hasActiveEnergyWrite() && container.health.hasStepsRead()) {
                     container.prefs.setHealthPermissionsVersion(HealthConnectManager.CURRENT_TYPES_VERSION)
                 }
             }

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -244,9 +244,10 @@
     <string name="onboarding_notifications_change_anytime">يمكنك تغيير هذا في أي وقت من الإعدادات.</string>
 
     <string name="onboarding_health_title">الاتصال بـ\nHealth Connect</string>
-    <string name="onboarding_health_subtitle">حافظ على مزامنة تغذيتك ومقاييس\nجسمك تلقائيًا.</string>
+    <string name="onboarding_health_subtitle">حافظ على تزامن التغذية والخطوات\nوقياسات الجسم تلقائيًا.</string>
     <string name="onboarding_health_feature_nutrition">بيانات التغذية</string>
     <string name="onboarding_health_feature_weight">مزامنة الوزن</string>
+    <string name="onboarding_health_feature_steps">الخطوات اليومية</string>
     <string name="onboarding_health_feature_body">مقاييس الجسم</string>
     <string name="onboarding_health_unavailable">Health Connect غير متاح</string>
     <string name="onboarding_health_connected">متصل</string>
@@ -285,6 +286,11 @@
 
 
     <!-- Home -->
+    <plurals name="home_daily_steps">
+        <item quantity="one">خطوة واحدة (%1$s)</item>
+        <item quantity="other">%1$s خطوة</item>
+    </plurals>
+
     <string name="home_add_food">إضافة طعام</string>
     <string name="home_menu_camera">الكاميرا</string>
     <string name="home_menu_camera_note">كاميرا + ملاحظة</string>

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -287,7 +287,11 @@
 
     <!-- Home -->
     <plurals name="home_daily_steps">
+        <item quantity="zero">لا خطوات (%1$s)</item>
         <item quantity="one">خطوة واحدة (%1$s)</item>
+        <item quantity="two">خطوتان (%1$s)</item>
+        <item quantity="few">%1$s خطوات</item>
+        <item quantity="many">%1$s خطوة</item>
         <item quantity="other">%1$s خطوة</item>
     </plurals>
 

--- a/android/app/src/main/res/values-az/strings.xml
+++ b/android/app/src/main/res/values-az/strings.xml
@@ -244,9 +244,10 @@
     <string name="onboarding_notifications_change_anytime">Bunu istənilən vaxt Parametrlərdə dəyişə bilərsiniz.</string>
 
     <string name="onboarding_health_title">Health Connect-ə\nqoşulun</string>
-    <string name="onboarding_health_subtitle">Qidalanma və bədən ölçülərinizi\navtomatik olaraq sinxronlaşdırın.</string>
+    <string name="onboarding_health_subtitle">Qidalanma, addımlar və bədən\nölçülərini avtomatik sinxron saxlayın.</string>
     <string name="onboarding_health_feature_nutrition">Qidalanma Məlumatları</string>
     <string name="onboarding_health_feature_weight">Çəki Sinxronizasiyası</string>
+    <string name="onboarding_health_feature_steps">Gündəlik addımlar</string>
     <string name="onboarding_health_feature_body">Bədən Ölçüləri</string>
     <string name="onboarding_health_unavailable">Health Connect əlçatan deyil</string>
     <string name="onboarding_health_connected">Qoşuldu</string>
@@ -285,6 +286,11 @@
 
 
     <!-- Home -->
+    <plurals name="home_daily_steps">
+        <item quantity="one">%1$s addım</item>
+        <item quantity="other">%1$s addım</item>
+    </plurals>
+
     <string name="home_add_food">Yemək əlavə et</string>
     <string name="home_menu_camera">Kamera</string>
     <string name="home_menu_camera_note">Kamera + Qeyd</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -244,9 +244,10 @@
     <string name="onboarding_notifications_change_anytime">Du kannst dies jederzeit in den Einstellungen ändern.</string>
 
     <string name="onboarding_health_title">Mit Health Connect\nverbinden</string>
-    <string name="onboarding_health_subtitle">Halte deine Ernährungs- und Körpermessdaten\nautomatisch synchron.</string>
+    <string name="onboarding_health_subtitle">Halte Ernährung, Schritte und Körper-\nmaße automatisch synchron.</string>
     <string name="onboarding_health_feature_nutrition">Ernährungsdaten</string>
     <string name="onboarding_health_feature_weight">Gewichts-Sync</string>
+    <string name="onboarding_health_feature_steps">Tägliche Schritte</string>
     <string name="onboarding_health_feature_body">Körpermessungen</string>
     <string name="onboarding_health_unavailable">Health Connect nicht verfügbar</string>
     <string name="onboarding_health_connected">Verbunden</string>
@@ -285,6 +286,11 @@
 
 
     <!-- Home -->
+    <plurals name="home_daily_steps">
+        <item quantity="one">%1$s Schritt</item>
+        <item quantity="other">%1$s Schritte</item>
+    </plurals>
+
     <string name="home_add_food">Essen hinzufügen</string>
     <string name="home_menu_camera">Kamera</string>
     <string name="home_menu_camera_note">Kamera + Notiz</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -244,9 +244,10 @@
     <string name="onboarding_notifications_change_anytime">Puedes cambiarlo cuando quieras en Ajustes.</string>
 
     <string name="onboarding_health_title">Conectar a\nHealth Connect</string>
-    <string name="onboarding_health_subtitle">Mantén tu nutrición y medidas\ncorporales sincronizadas automáticamente.</string>
+    <string name="onboarding_health_subtitle">Mantén tu nutrición, pasos y medidas\ncorporales sincronizados automáticamente.</string>
     <string name="onboarding_health_feature_nutrition">Datos de nutrición</string>
     <string name="onboarding_health_feature_weight">Sincronización de peso</string>
+    <string name="onboarding_health_feature_steps">Pasos diarios</string>
     <string name="onboarding_health_feature_body">Medidas corporales</string>
     <string name="onboarding_health_unavailable">Health Connect no disponible</string>
     <string name="onboarding_health_connected">Conectado</string>
@@ -285,6 +286,11 @@
 
 
     <!-- Home -->
+    <plurals name="home_daily_steps">
+        <item quantity="one">%1$s paso</item>
+        <item quantity="other">%1$s pasos</item>
+    </plurals>
+
     <string name="home_add_food">Añadir comida</string>
     <string name="home_menu_camera">Cámara</string>
     <string name="home_menu_camera_note">Cámara + nota</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -244,9 +244,10 @@
     <string name="onboarding_notifications_change_anytime">Vous pouvez changer cela à tout moment dans Réglages.</string>
 
     <string name="onboarding_health_title">Connectez-vous à\nHealth Connect</string>
-    <string name="onboarding_health_subtitle">Synchronisez automatiquement votre nutrition\net vos mesures corporelles.</string>
+    <string name="onboarding_health_subtitle">Gardez votre nutrition, vos pas et vos mesures\ncorporelles synchronisés automatiquement.</string>
     <string name="onboarding_health_feature_nutrition">Données nutritionnelles</string>
     <string name="onboarding_health_feature_weight">Synchronisation du poids</string>
+    <string name="onboarding_health_feature_steps">Pas quotidiens</string>
     <string name="onboarding_health_feature_body">Mesures corporelles</string>
     <string name="onboarding_health_unavailable">Health Connect indisponible</string>
     <string name="onboarding_health_connected">Connecté</string>
@@ -285,6 +286,11 @@
 
 
     <!-- Home -->
+    <plurals name="home_daily_steps">
+        <item quantity="one">%1$s pas</item>
+        <item quantity="other">%1$s pas</item>
+    </plurals>
+
     <string name="home_add_food">Ajouter un aliment</string>
     <string name="home_menu_camera">Appareil photo</string>
     <string name="home_menu_camera_note">Appareil photo + note</string>

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -244,9 +244,10 @@
     <string name="onboarding_notifications_change_anytime">आप इसे सेटिंग्स में कभी भी बदल सकते हैं।</string>
 
     <string name="onboarding_health_title">Health Connect से\nजुड़ें</string>
-    <string name="onboarding_health_subtitle">अपने पोषण और शरीर के मापों को\nस्वतः सिंक रखें।</string>
+    <string name="onboarding_health_subtitle">अपने पोषण, कदम और शरीर के\nमाप को अपने आप सिंक रखें।</string>
     <string name="onboarding_health_feature_nutrition">पोषण डेटा</string>
     <string name="onboarding_health_feature_weight">वज़न सिंक</string>
+    <string name="onboarding_health_feature_steps">दैनिक कदम</string>
     <string name="onboarding_health_feature_body">शरीर के माप</string>
     <string name="onboarding_health_unavailable">Health Connect अनुपलब्ध</string>
     <string name="onboarding_health_connected">कनेक्ट किया गया</string>
@@ -285,6 +286,11 @@
 
 
     <!-- Home -->
+    <plurals name="home_daily_steps">
+        <item quantity="one">%1$s कदम</item>
+        <item quantity="other">%1$s कदम</item>
+    </plurals>
+
     <string name="home_add_food">भोजन जोड़ें</string>
     <string name="home_menu_camera">कैमरा</string>
     <string name="home_menu_camera_note">कैमरा + नोट</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -244,9 +244,10 @@
     <string name="onboarding_notifications_change_anytime">Puoi modificarlo in qualsiasi momento dalle Impostazioni.</string>
 
     <string name="onboarding_health_title">Connetti a\nHealth Connect</string>
-    <string name="onboarding_health_subtitle">Mantieni nutrizione e misure corporee\nsincronizzate automaticamente.</string>
+    <string name="onboarding_health_subtitle">Tieni sincronizzati automaticamente nutrizione, passi\ne misure corporee.</string>
     <string name="onboarding_health_feature_nutrition">Dati nutrizionali</string>
     <string name="onboarding_health_feature_weight">Sincronizzazione peso</string>
+    <string name="onboarding_health_feature_steps">Passi giornalieri</string>
     <string name="onboarding_health_feature_body">Misure corporee</string>
     <string name="onboarding_health_unavailable">Health Connect non disponibile</string>
     <string name="onboarding_health_connected">Connesso</string>
@@ -285,6 +286,11 @@
 
 
     <!-- Home -->
+    <plurals name="home_daily_steps">
+        <item quantity="one">%1$s passo</item>
+        <item quantity="other">%1$s passi</item>
+    </plurals>
+
     <string name="home_add_food">Aggiungi cibo</string>
     <string name="home_menu_camera">Fotocamera</string>
     <string name="home_menu_camera_note">Fotocamera + Nota</string>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -244,9 +244,10 @@
     <string name="onboarding_notifications_change_anytime">設定からいつでも変更できます。</string>
 
     <string name="onboarding_health_title">Health Connectに\n接続</string>
-    <string name="onboarding_health_subtitle">栄養と身体測定値を\n自動で同期します。</string>
+    <string name="onboarding_health_subtitle">栄養、歩数、身体測定を\n自動的に同期します。</string>
     <string name="onboarding_health_feature_nutrition">栄養データ</string>
     <string name="onboarding_health_feature_weight">体重の同期</string>
+    <string name="onboarding_health_feature_steps">1日の歩数</string>
     <string name="onboarding_health_feature_body">身体測定値</string>
     <string name="onboarding_health_unavailable">Health Connectは利用できません</string>
     <string name="onboarding_health_connected">接続済み</string>
@@ -285,6 +286,11 @@
 
 
     <!-- Home -->
+    <plurals name="home_daily_steps">
+        <item quantity="one">%1$s 歩</item>
+        <item quantity="other">%1$s 歩</item>
+    </plurals>
+
     <string name="home_add_food">食事を追加</string>
     <string name="home_menu_camera">カメラ</string>
     <string name="home_menu_camera_note">カメラ + メモ</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -244,9 +244,10 @@
     <string name="onboarding_notifications_change_anytime">설정에서 언제든지 변경할 수 있어요.</string>
 
     <string name="onboarding_health_title">Health Connect\n연결</string>
-    <string name="onboarding_health_subtitle">영양 정보와 신체 측정을\n자동으로 동기화하세요.</string>
+    <string name="onboarding_health_subtitle">영양, 걸음 수, 신체 측정을\n자동으로 동기화하세요.</string>
     <string name="onboarding_health_feature_nutrition">영양 데이터</string>
     <string name="onboarding_health_feature_weight">체중 동기화</string>
+    <string name="onboarding_health_feature_steps">일일 걸음 수</string>
     <string name="onboarding_health_feature_body">신체 측정</string>
     <string name="onboarding_health_unavailable">Health Connect 사용 불가</string>
     <string name="onboarding_health_connected">연결됨</string>
@@ -285,6 +286,11 @@
 
 
     <!-- Home -->
+    <plurals name="home_daily_steps">
+        <item quantity="one">%1$s걸음</item>
+        <item quantity="other">%1$s걸음</item>
+    </plurals>
+
     <string name="home_add_food">음식 추가</string>
     <string name="home_menu_camera">카메라</string>
     <string name="home_menu_camera_note">카메라 + 메모</string>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -244,9 +244,10 @@
     <string name="onboarding_notifications_change_anytime">Je kunt dit altijd wijzigen in Instellingen.</string>
 
     <string name="onboarding_health_title">Verbinden met\nHealth Connect</string>
-    <string name="onboarding_health_subtitle">Houd je voeding en lichaams-\nmetingen automatisch synchroon.</string>
+    <string name="onboarding_health_subtitle">Houd je voeding, stappen en lichaams-\nmetingen automatisch gesynchroniseerd.</string>
     <string name="onboarding_health_feature_nutrition">Voedingsgegevens</string>
     <string name="onboarding_health_feature_weight">Gewichtssync</string>
+    <string name="onboarding_health_feature_steps">Dagelijkse stappen</string>
     <string name="onboarding_health_feature_body">Lichaamsmetingen</string>
     <string name="onboarding_health_unavailable">Health Connect niet beschikbaar</string>
     <string name="onboarding_health_connected">Verbonden</string>
@@ -285,6 +286,11 @@
 
 
     <!-- Home -->
+    <plurals name="home_daily_steps">
+        <item quantity="one">%1$s stap</item>
+        <item quantity="other">%1$s stappen</item>
+    </plurals>
+
     <string name="home_add_food">Eten toevoegen</string>
     <string name="home_menu_camera">Camera</string>
     <string name="home_menu_camera_note">Camera + notitie</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -288,7 +288,9 @@
     <!-- Home -->
     <plurals name="home_daily_steps">
         <item quantity="one">%1$s krok</item>
-        <item quantity="other">%1$s kroki</item>
+        <item quantity="few">%1$s kroki</item>
+        <item quantity="many">%1$s kroków</item>
+        <item quantity="other">%1$s kroków</item>
     </plurals>
 
     <string name="home_add_food">Dodaj jedzenie</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -244,9 +244,10 @@
     <string name="onboarding_notifications_change_anytime">Możesz to zmienić w każdej chwili w Ustawieniach.</string>
 
     <string name="onboarding_health_title">Połącz z\nHealth Connect</string>
-    <string name="onboarding_health_subtitle">Automatycznie synchronizuj odżywianie\ni pomiary ciała.</string>
+    <string name="onboarding_health_subtitle">Synchronizuj automatycznie odżywianie, kroki\ni pomiary ciała.</string>
     <string name="onboarding_health_feature_nutrition">Dane żywieniowe</string>
     <string name="onboarding_health_feature_weight">Synchronizacja wagi</string>
+    <string name="onboarding_health_feature_steps">Dzienne kroki</string>
     <string name="onboarding_health_feature_body">Pomiary ciała</string>
     <string name="onboarding_health_unavailable">Health Connect niedostępny</string>
     <string name="onboarding_health_connected">Połączono</string>
@@ -285,6 +286,11 @@
 
 
     <!-- Home -->
+    <plurals name="home_daily_steps">
+        <item quantity="one">%1$s krok</item>
+        <item quantity="other">%1$s kroki</item>
+    </plurals>
+
     <string name="home_add_food">Dodaj jedzenie</string>
     <string name="home_menu_camera">Aparat</string>
     <string name="home_menu_camera_note">Aparat + notatka</string>

--- a/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -244,9 +244,10 @@
     <string name="onboarding_notifications_change_anytime">Você pode mudar isso a qualquer momento em Ajustes.</string>
 
     <string name="onboarding_health_title">Conectar ao\nHealth Connect</string>
-    <string name="onboarding_health_subtitle">Mantenha sua nutrição e medidas\ncorporais sincronizadas automaticamente.</string>
+    <string name="onboarding_health_subtitle">Mantenha nutrição, passos e medidas\ncorporais sincronizados automaticamente.</string>
     <string name="onboarding_health_feature_nutrition">Dados nutricionais</string>
     <string name="onboarding_health_feature_weight">Sincronização de peso</string>
+    <string name="onboarding_health_feature_steps">Passos diários</string>
     <string name="onboarding_health_feature_body">Medidas corporais</string>
     <string name="onboarding_health_unavailable">Health Connect indisponível</string>
     <string name="onboarding_health_connected">Conectado</string>
@@ -285,6 +286,11 @@
 
 
     <!-- Home -->
+    <plurals name="home_daily_steps">
+        <item quantity="one">%1$s passo</item>
+        <item quantity="other">%1$s passos</item>
+    </plurals>
+
     <string name="home_add_food">Adicionar alimento</string>
     <string name="home_menu_camera">Câmera</string>
     <string name="home_menu_camera_note">Câmera + nota</string>

--- a/android/app/src/main/res/values-ro/strings.xml
+++ b/android/app/src/main/res/values-ro/strings.xml
@@ -244,9 +244,10 @@
     <string name="onboarding_notifications_change_anytime">Poți schimba asta oricând în Setări.</string>
 
     <string name="onboarding_health_title">Conectează-te la\nHealth Connect</string>
-    <string name="onboarding_health_subtitle">Sincronizează automat nutriția și\nmăsurătorile corporale.</string>
+    <string name="onboarding_health_subtitle">Păstrează sincronizate automat nutriția, pașii\nși măsurătorile corporale.</string>
     <string name="onboarding_health_feature_nutrition">Date nutriționale</string>
     <string name="onboarding_health_feature_weight">Sincronizare greutate</string>
+    <string name="onboarding_health_feature_steps">Pași zilnici</string>
     <string name="onboarding_health_feature_body">Măsurători corporale</string>
     <string name="onboarding_health_unavailable">Health Connect indisponibil</string>
     <string name="onboarding_health_connected">Conectat</string>
@@ -285,6 +286,11 @@
 
 
     <!-- Home -->
+    <plurals name="home_daily_steps">
+        <item quantity="one">%1$s pas</item>
+        <item quantity="other">%1$s pași</item>
+    </plurals>
+
     <string name="home_add_food">Adaugă aliment</string>
     <string name="home_menu_camera">Cameră</string>
     <string name="home_menu_camera_note">Cameră + notă</string>

--- a/android/app/src/main/res/values-ro/strings.xml
+++ b/android/app/src/main/res/values-ro/strings.xml
@@ -288,7 +288,8 @@
     <!-- Home -->
     <plurals name="home_daily_steps">
         <item quantity="one">%1$s pas</item>
-        <item quantity="other">%1$s pași</item>
+        <item quantity="few">%1$s pași</item>
+        <item quantity="other">%1$s de pași</item>
     </plurals>
 
     <string name="home_add_food">Adaugă aliment</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -244,9 +244,10 @@
     <string name="onboarding_notifications_change_anytime">Вы можете изменить это в любое время в Настройках.</string>
 
     <string name="onboarding_health_title">Подключиться к\nHealth Connect</string>
-    <string name="onboarding_health_subtitle">Поддерживайте автоматическую синхронизацию\nпитания и измерений тела.</string>
+    <string name="onboarding_health_subtitle">Синхронизируйте питание, шаги и измерения\nтела автоматически.</string>
     <string name="onboarding_health_feature_nutrition">Данные о питании</string>
     <string name="onboarding_health_feature_weight">Синхронизация веса</string>
+    <string name="onboarding_health_feature_steps">Шаги за день</string>
     <string name="onboarding_health_feature_body">Измерения тела</string>
     <string name="onboarding_health_unavailable">Health Connect недоступен</string>
     <string name="onboarding_health_connected">Подключено</string>
@@ -285,6 +286,11 @@
 
 
     <!-- Home -->
+    <plurals name="home_daily_steps">
+        <item quantity="one">%1$s шаг</item>
+        <item quantity="other">%1$s шагов</item>
+    </plurals>
+
     <string name="home_add_food">Добавить еду</string>
     <string name="home_menu_camera">Камера</string>
     <string name="home_menu_camera_note">Камера + заметка</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -288,6 +288,8 @@
     <!-- Home -->
     <plurals name="home_daily_steps">
         <item quantity="one">%1$s шаг</item>
+        <item quantity="few">%1$s шага</item>
+        <item quantity="many">%1$s шагов</item>
         <item quantity="other">%1$s шагов</item>
     </plurals>
 

--- a/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -244,9 +244,10 @@
     <string name="onboarding_notifications_change_anytime">你可以随时在设置中更改。</string>
 
     <string name="onboarding_health_title">连接到\nHealth Connect</string>
-    <string name="onboarding_health_subtitle">让你的营养和身体测量数据\n自动保持同步。</string>
+    <string name="onboarding_health_subtitle">自动同步营养、步数和身体\n测量数据。</string>
     <string name="onboarding_health_feature_nutrition">营养数据</string>
     <string name="onboarding_health_feature_weight">体重同步</string>
+    <string name="onboarding_health_feature_steps">每日步数</string>
     <string name="onboarding_health_feature_body">身体测量</string>
     <string name="onboarding_health_unavailable">Health Connect 不可用</string>
     <string name="onboarding_health_connected">已连接</string>
@@ -285,6 +286,11 @@
 
 
     <!-- Home -->
+    <plurals name="home_daily_steps">
+        <item quantity="one">%1$s 步</item>
+        <item quantity="other">%1$s 步</item>
+    </plurals>
+
     <string name="home_add_food">添加食物</string>
     <string name="home_menu_camera">相机</string>
     <string name="home_menu_camera_note">相机 + 备注</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -295,10 +295,11 @@
     <string name="onboarding_notifications_change_anytime">You can change this anytime in Settings.</string>
 
     <string name="onboarding_health_title">Connect to\nHealth Connect</string>
-    <string name="onboarding_health_subtitle">Keep your nutrition and body\nmeasurements in sync automatically.</string>
+    <string name="onboarding_health_subtitle">Keep your nutrition, steps, and body\nmeasurements in sync automatically.</string>
     <string name="onboarding_health_feature_nutrition">Nutrition Data</string>
     <string name="onboarding_health_feature_weight">Weight Sync</string>
     <string name="onboarding_health_feature_body">Body Measurements</string>
+    <string name="onboarding_health_feature_steps">Daily Steps</string>
     <string name="onboarding_health_unavailable">Health Connect unavailable</string>
     <string name="onboarding_health_connected">Connected</string>
     <string name="onboarding_health_connect">Connect</string>
@@ -336,6 +337,11 @@
 
 
     <!-- Home -->
+    <plurals name="home_daily_steps">
+        <item quantity="one">%1$s step</item>
+        <item quantity="other">%1$s steps</item>
+    </plurals>
+
     <string name="home_add_food">Add food</string>
     <string name="home_menu_camera">Camera</string>
     <string name="home_menu_barcode">Barcode</string>

--- a/ios/calorietracker.xcodeproj/project.pbxproj
+++ b/ios/calorietracker.xcodeproj/project.pbxproj
@@ -700,7 +700,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_DISPLAY_NAME)";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
 				INFOPLIST_KEY_NSCameraUsageDescription = "Fud AI uses the camera to scan food and barcodes.";
-				INFOPLIST_KEY_NSHealthShareUsageDescription = "Read your weight, height, body composition, nutrition, and Fud AI workout calories to keep your history in sync.";
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "Read your weight, height, body composition, nutrition, daily steps, and Fud AI workout calories to keep your history in sync.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "Write, update, or remove your nutrition, body measurements, and calculated workout calories when you change your logs.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Fud AI needs microphone access so you can log food by voice.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Fud AI uses speech recognition to convert your voice into text for food logging.";
@@ -752,7 +752,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_DISPLAY_NAME)";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
 				INFOPLIST_KEY_NSCameraUsageDescription = "Fud AI uses the camera to scan food and barcodes.";
-				INFOPLIST_KEY_NSHealthShareUsageDescription = "Read your weight, height, body composition, nutrition, and Fud AI workout calories to keep your history in sync.";
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "Read your weight, height, body composition, nutrition, daily steps, and Fud AI workout calories to keep your history in sync.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "Write, update, or remove your nutrition, body measurements, and calculated workout calories when you change your logs.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Fud AI needs microphone access so you can log food by voice.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Fud AI uses speech recognition to convert your voice into text for food logging.";

--- a/ios/calorietracker/ContentView.swift
+++ b/ios/calorietracker/ContentView.swift
@@ -623,7 +623,10 @@ struct HomeView: View {
     @Environment(WaterStore.self) private var waterStore
     @Environment(FastingStore.self) private var fastingStore
     @Environment(NotificationManager.self) private var notificationManager
+    @Environment(HealthKitManager.self) private var healthKitManager
     @Environment(\.scenePhase) private var scenePhase
+    @AppStorage("healthKitEnabled") private var healthKitEnabled = false
+    @State private var dailySteps: Int?
     @State private var showCamera = false
     @State private var showBarcodeScanner = false
     @State private var capturedImage: UIImage?
@@ -831,6 +834,18 @@ struct HomeView: View {
         selectedDate = newDate
     }
 
+    private var dailyStepsTaskKey: String {
+        "\(selectedDate.timeIntervalSince1970)-\(healthKitEnabled)"
+    }
+
+    private func refreshDailySteps() async {
+        guard healthKitEnabled else {
+            dailySteps = nil
+            return
+        }
+        dailySteps = await healthKitManager.fetchStepsForDay(selectedDate)
+    }
+
     private func logDate(on day: Date, now: Date = .now) -> Date {
         let calendar = Calendar.current
         if calendar.isDateInToday(day) { return now }
@@ -983,6 +998,12 @@ struct HomeView: View {
                         .simultaneousGesture(daySwipeGesture)
                         .listRowBackground(Color.clear)
                         .listRowSeparator(.hidden)
+
+                    if let dailySteps {
+                        DailyStepsRow(steps: dailySteps)
+                            .listRowBackground(Color.clear)
+                            .listRowSeparator(.hidden)
+                    }
 
                     HStack(alignment: .top, spacing: 4) {
                         ForEach(displayedHomeNutrients) { nutrient in
@@ -1198,6 +1219,9 @@ struct HomeView: View {
             .scrollContentBackground(.hidden)
             .background(AppColors.appBackground)
             .animation(.snappy, value: selectedDate)
+            .task(id: dailyStepsTaskKey) {
+                await refreshDailySteps()
+            }
             .contentMargins(.bottom, isFoodSelectionMode ? 8 : 96, for: .scrollContent)
             .sensoryFeedback(.selection, trigger: selectedFoodIDs) { _, selection in
                 !selection.isEmpty

--- a/ios/calorietracker/ContentView.swift
+++ b/ios/calorietracker/ContentView.swift
@@ -843,7 +843,12 @@ struct HomeView: View {
             dailySteps = nil
             return
         }
-        dailySteps = await healthKitManager.fetchStepsForDay(selectedDate)
+        let requestedDate = selectedDate
+        guard !Task.isCancelled else { return }
+        let steps = await healthKitManager.fetchStepsForDay(requestedDate)
+        guard !Task.isCancelled, healthKitEnabled else { return }
+        guard Calendar.current.isDate(selectedDate, inSameDayAs: requestedDate) else { return }
+        dailySteps = steps
     }
 
     private func logDate(on day: Date, now: Date = .now) -> Date {
@@ -1804,6 +1809,7 @@ struct HomeView: View {
             .onChange(of: scenePhase) { _, newPhase in
                 if newPhase == .active {
                     checkAndConsumeSharedImage()
+                    Task { await refreshDailySteps() }
                     // Returned to the foreground -> replay the fill-from-zero reveal.
                     // Gated on wasBackgrounded so transient .inactive blips (control
                     // center, app switcher) don't retrigger it.

--- a/ios/calorietracker/ContentView.swift
+++ b/ios/calorietracker/ContentView.swift
@@ -627,6 +627,7 @@ struct HomeView: View {
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage("healthKitEnabled") private var healthKitEnabled = false
     @State private var dailySteps: Int?
+    @State private var dailyStepsFetchGeneration = 0
     @State private var showCamera = false
     @State private var showBarcodeScanner = false
     @State private var capturedImage: UIImage?
@@ -844,9 +845,12 @@ struct HomeView: View {
             return
         }
         let requestedDate = selectedDate
+        dailyStepsFetchGeneration += 1
+        let generation = dailyStepsFetchGeneration
         guard !Task.isCancelled else { return }
         let steps = await healthKitManager.fetchStepsForDay(requestedDate)
         guard !Task.isCancelled, healthKitEnabled else { return }
+        guard generation == dailyStepsFetchGeneration else { return }
         guard Calendar.current.isDate(selectedDate, inSameDayAs: requestedDate) else { return }
         dailySteps = steps
     }

--- a/ios/calorietracker/Localizable.xcstrings
+++ b/ios/calorietracker/Localizable.xcstrings
@@ -48780,96 +48780,350 @@
         }
       }
     },
-    "%@ steps": {
+    "%lld steps": {
+      "comment": "Plural-aware daily step count on Home.",
+      "extractionState": "manual",
       "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ Schritte"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ pasos"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ pas"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ कदम"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ passi"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ 歩"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@걸음"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ stappen"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ kroki"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ passos"
-          }
-        },
-        "ro": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ pași"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ шагов"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ 步"
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld step"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld steps"
+                }
+              }
+            }
           }
         },
         "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ خطوة"
+          "variations": {
+            "plural": {
+              "zero": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "لا خطوات (%lld)"
+                }
+              },
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "خطوة واحدة (%lld)"
+                }
+              },
+              "two": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "خطوتان (%lld)"
+                }
+              },
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld خطوات"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld خطوة"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld خطوة"
+                }
+              }
+            }
           }
         },
         "az": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ addım"
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld addım"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld addım"
+                }
+              }
+            }
+          }
+        },
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Schritt"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Schritte"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld paso"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld pasos"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld pas"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld pas"
+                }
+              }
+            }
+          }
+        },
+        "hi": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld कदम"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld कदम"
+                }
+              }
+            }
+          }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld passo"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld passi"
+                }
+              }
+            }
+          }
+        },
+        "ja": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 歩"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 歩"
+                }
+              }
+            }
+          }
+        },
+        "ko": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld걸음"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld걸음"
+                }
+              }
+            }
+          }
+        },
+        "nl": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld stap"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld stappen"
+                }
+              }
+            }
+          }
+        },
+        "pl": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld krok"
+                }
+              },
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld kroki"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld kroków"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld kroków"
+                }
+              }
+            }
+          }
+        },
+        "pt-BR": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld passo"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld passos"
+                }
+              }
+            }
+          }
+        },
+        "ro": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld pas"
+                }
+              },
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld pași"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld de pași"
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld шаг"
+                }
+              },
+              "few": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld шага"
+                }
+              },
+              "many": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld шагов"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld шагов"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 步"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 步"
+                }
+              }
+            }
           }
         }
       }

--- a/ios/calorietracker/Localizable.xcstrings
+++ b/ios/calorietracker/Localizable.xcstrings
@@ -48591,6 +48591,288 @@
           }
         }
       }
+    },
+    "Keep your nutrition, steps, and body\nmeasurements in sync automatically.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Halte Ernährung, Schritte und Körper-\nmaße automatisch synchron."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantén tu nutrición, pasos y medidas\ncorporales sincronizados automáticamente."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gardez votre nutrition, vos pas et vos mesures\ncorporelles synchronisés automatiquement."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अपने पोषण, कदम और शरीर के\nमाप को अपने आप सिंक रखें।"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tieni sincronizzati automaticamente nutrizione, passi\ne misure corporee."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "栄養、歩数、身体測定を\n自動的に同期します。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "영양, 걸음 수, 신체 측정을\n자동으로 동기화하세요."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Houd je voeding, stappen en lichaams-\nmetingen automatisch gesynchroniseerd."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synchronizuj automatycznie odżywianie, kroki\ni pomiary ciała."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantenha nutrição, passos e medidas\ncorporais sincronizados automaticamente."
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Păstrează sincronizate automat nutriția, pașii\nși măsurătorile corporale."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Синхронизируйте питание, шаги и измерения\nтела автоматически."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动同步营养、步数和身体\n测量数据。"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حافظ على تزامن التغذية والخطوات\nوقياسات الجسم تلقائيًا."
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Qidalanma, addımlar və bədən\nölçülərini avtomatik sinxron saxlayın."
+          }
+        }
+      }
+    },
+    "Daily Steps": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tägliche Schritte"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pasos diarios"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas quotidiens"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "दैनिक कदम"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passi giornalieri"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1日の歩数"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일일 걸음 수"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dagelijkse stappen"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dzienne kroki"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passos diários"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pași zilnici"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Шаги за день"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每日步数"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الخطوات اليومية"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gündəlik addımlar"
+          }
+        }
+      }
+    },
+    "%@ steps": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ Schritte"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ pasos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ pas"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ कदम"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ passi"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 歩"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@걸음"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ stappen"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ kroki"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ passos"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ pași"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ шагов"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 步"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ خطوة"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ addım"
+          }
+        }
+      }
     }
   },
   "version": "1.1"

--- a/ios/calorietracker/Stores/HealthKitManager.swift
+++ b/ios/calorietracker/Stores/HealthKitManager.swift
@@ -1073,8 +1073,16 @@ class HealthKitManager {
                 quantityType: type,
                 quantitySamplePredicate: predicate,
                 options: .cumulativeSum
-            ) { _, statistics, _ in
-                let count = statistics?.sumQuantity()?.doubleValue(for: .count()) ?? 0
+            ) { _, statistics, error in
+                if error != nil {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                guard let statistics else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                let count = statistics.sumQuantity()?.doubleValue(for: .count()) ?? 0
                 continuation.resume(returning: count >= 0 ? Int(count.rounded()) : nil)
             }
             healthStore.execute(query)

--- a/ios/calorietracker/Stores/HealthKitManager.swift
+++ b/ios/calorietracker/Stores/HealthKitManager.swift
@@ -119,7 +119,8 @@ class HealthKitManager {
     /// the weight/body-fat backfills, which now restore own samples too.
     /// v6: active energy joined the write set so calculated workout calories can
     /// stay synchronized with Apple Health.
-    private let typesVersion = 7
+    /// v8: stepCount joined the read set for daily steps on Home.
+    private let typesVersion = 8
     private let typesVersionKey = "healthKitTypesVersion"
 
     /// Active-energy samples written for the workout diary are deliberately
@@ -226,6 +227,7 @@ class HealthKitManager {
             HKQuantityType(.bodyFatPercentage),
             HKQuantityType(.activeEnergyBurned),
             HKQuantityType(.basalEnergyBurned),
+            HKQuantityType(.stepCount),
             HKCharacteristicType(.dateOfBirth),
             HKCharacteristicType(.biologicalSex),
         ]
@@ -1048,6 +1050,35 @@ class HealthKitManager {
             daysUsed: activeDays.count,
             requestedDays: requestedDays
         )
+    }
+
+    /// Daily step total for one local calendar day. Read-only — watches and phones
+    /// write steps to HealthKit; Fud AI surfaces the aggregate on Home.
+    func fetchStepsForDay(_ date: Date) async -> Int? {
+        guard UserDefaults.standard.bool(forKey: "healthKitEnabled") else { return nil }
+        let calendar = Calendar.current
+        let start = calendar.startOfDay(for: date)
+        guard let end = calendar.date(byAdding: .day, value: 1, to: start) else { return nil }
+        let endBound = min(end, Date())
+        guard endBound > start else { return nil }
+
+        let type = HKQuantityType(.stepCount)
+        return await withCheckedContinuation { continuation in
+            let predicate = HKQuery.predicateForSamples(
+                withStart: start,
+                end: endBound,
+                options: .strictStartDate
+            )
+            let query = HKStatisticsQuery(
+                quantityType: type,
+                quantitySamplePredicate: predicate,
+                options: .cumulativeSum
+            ) { _, statistics, _ in
+                let count = statistics?.sumQuantity()?.doubleValue(for: .count()) ?? 0
+                continuation.resume(returning: count >= 0 ? Int(count.rounded()) : nil)
+            }
+            healthStore.execute(query)
+        }
     }
 
     /// Dated measured energy for adaptive-goal evidence. This uses the same active-energy

--- a/ios/calorietracker/Views/HomeComponents.swift
+++ b/ios/calorietracker/Views/HomeComponents.swift
@@ -769,6 +769,6 @@ struct DailyStepsRow: View {
     }
 
     private var stepsLabel: String {
-        String(format: String(localized: "%@ steps"), steps.formatted())
+        String(localized: "\(steps) steps")
     }
 }

--- a/ios/calorietracker/Views/HomeComponents.swift
+++ b/ios/calorietracker/Views/HomeComponents.swift
@@ -750,3 +750,25 @@ struct MacroVerticalBar: View {
         }
     }
 }
+
+// MARK: - Daily Steps (HealthKit)
+
+struct DailyStepsRow: View {
+    let steps: Int
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "figure.walk")
+                .font(.system(size: 16, weight: .medium))
+            Text(stepsLabel)
+                .font(.system(.body, design: .rounded, weight: .medium))
+        }
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity)
+        .padding(.bottom, 4)
+    }
+
+    private var stepsLabel: String {
+        String(format: String(localized: "%@ steps"), steps.formatted())
+    }
+}

--- a/ios/calorietracker/Views/OnboardingView.swift
+++ b/ios/calorietracker/Views/OnboardingView.swift
@@ -727,7 +727,7 @@ struct OnboardingView: View {
                         .font(.system(size: 28, weight: .bold, design: .rounded))
                         .multilineTextAlignment(.center)
 
-                    Text("Keep your nutrition and body\nmeasurements in sync automatically.")
+                    Text("Keep your nutrition, steps, and body\nmeasurements in sync automatically.")
                         .font(.system(.callout, design: .rounded))
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
@@ -738,6 +738,7 @@ struct OnboardingView: View {
                     healthFeatureRow(icon: "fork.knife", label: "Nutrition Data")
                     healthFeatureRow(icon: "scalemass.fill", label: "Weight Sync")
                     healthFeatureRow(icon: "figure.stand", label: "Body Measurements")
+                    healthFeatureRow(icon: "figure.walk", label: "Daily Steps")
                 }
                 .padding(.horizontal, 40)
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #205

## Summary

Users who enabled Health Connect or Apple Health saw no step count because Fud AI only synced nutrition, weight, body metrics, and energy burn. This PR reads **daily aggregated steps** from the platform health stores and surfaces them on the **Home dashboard** for the selected day.

## Android

- **`HealthConnectManager`**: `StepsRecord` read permission, `readStepsForDay()` via the same aggregate API used for energy burn, `hasStepsRead()`, types version bumped to **v6** (re-auth for existing users).
- **`AndroidManifest`**: `READ_STEPS` permission.
- **`HomeViewModel` / `HomeScreen`**: Loads steps when Health Connect is on + steps read granted; shows a compact row under the calorie hero (hidden when health is off or unreadable).
- **Onboarding / strings**: Health Connect copy mentions steps; localized in all existing locale catalogs.

## iOS

- **`HealthKitManager`**: `HKQuantityType.stepCount` added to read types, `fetchStepsForDay()` via cumulative statistics query, types version bumped to **v8**.
- **`HomeView` / `HomeComponents`**: `DailyStepsRow` under the calorie gauge when Apple Health is enabled.
- **Info.plist usage string**, onboarding feature list, and **`Localizable.xcstrings`** updated.

## Behavior

- Uses OS aggregators (watch/phone → Health Connect / HealthKit → Fud AI). No Wear OS app.
- Respects existing health toggles and permission flows; steps read is included in the standard authorization set.
- When health is off or steps cannot be read, the row is hidden — no extra prompts beyond existing health UX.
- Local-first: reads from on-device health stores only.

## Out of scope (unchanged)

- Wear OS companion app
- Using steps for Adaptive Goals / activity level
- Manual step entry
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d4ac3a9-e7fd-48da-a44e-283c14340585?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d4ac3a9-e7fd-48da-a44e-283c14340585&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added daily step tracking through Health Connect on Android and HealthKit on iOS.
  - Daily step totals now appear on the home screen for the selected date and refresh when the app becomes active.
  - Added step tracking to health-data onboarding and permissions.

- **Localization**
  - Added translated daily-step labels and onboarding content across supported languages.
  - Updated iOS health-data usage messaging to include steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds daily Health Connect and Apple Health step totals to the Home dashboard, including platform permissions, lifecycle refreshes, onboarding copy, and localization.
- Adds daily aggregated step reads on Android and iOS.
- Displays step totals for the selected day when health integration and permission are available.
- Updates health authorization versions, manifests, usage descriptions, and localized copy.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because users missing only steps permission can remain connected without the direct in-app action needed to grant that permission.

The version-stamping checks now require steps access, but Settings still considers active-energy write access sufficient to hide the full permission request, leaving Home steps unavailable for partial-grant users.

**Files Needing Attention:** android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModel.kt and android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/src/main/java/com/apoorvdarshan/calorietracker/services/health/HealthConnectManager.kt | Adds steps permission, capability detection, daily aggregation, and the v6 permission-type version. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModel.kt | Correctly requires steps access before stamping v6, but reconciliation still hides the direct reauthorization action when active-energy access remains granted. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt | Loads permission-gated steps and preserves refresh epochs through flow deduplication. |
| ios/calorietracker/ContentView.swift | Adds selected-day steps loading with cancellation, date, enabled-state, and request-generation guards. |
| ios/calorietracker/Stores/HealthKitManager.swift | Adds HealthKit step authorization and cumulative daily statistics queries. |


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. `android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModel.kt`, line 313-319 ([link](https://github.com/apoorvdarshan/fud-ai/blob/db743ec04607e2a95c6d68170e6e9c7d92adc7e5/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModel.kt#L313-L319)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Steps reauthorization remains hidden**

   When a connected user retains active-energy write access but declines or revokes steps-read access, reconciliation still sets `workoutHealthWriteGranted` to true and hides the permission action that requests steps. Home therefore continues hiding daily steps until the user discovers the system management screen or disconnects and reconnects Health Connect.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModel.kt
   Line: 313-319

   Comment:
   **Steps reauthorization remains hidden**

   When a connected user retains active-energy write access but declines or revokes steps-read access, reconciliation still sets `workoutHealthWriteGranted` to true and hides the permission action that requests steps. Home therefore continues hiding daily steps until the user discovers the system management screen or disconnects and reconnects Health Connect.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20android%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fsettings%2FSettingsViewModel.kt%0ALine%3A%20313-319%0A%0AComment%3A%0A**Steps%20reauthorization%20remains%20hidden**%0A%0AWhen%20a%20connected%20user%20retains%20active-energy%20write%20access%20but%20declines%20or%20revokes%20steps-read%20access%2C%20reconciliation%20still%20sets%20%60workoutHealthWriteGranted%60%20to%20true%20and%20hides%20the%20permission%20action%20that%20requests%20steps.%20Home%20therefore%20continues%20hiding%20daily%20steps%20until%20the%20user%20discovers%20the%20system%20management%20screen%20or%20disconnects%20and%20reconnects%20Health%20Connect.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=253&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22apoorvdarshan%2Ffud-ai%22%20on%20the%20existing%20branch%20%22cursor%2Ffeature-205-health-steps-on-home-8ad9%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Ffeature-205-health-steps-on-home-8ad9%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20android%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fsettings%2FSettingsViewModel.kt%0ALine%3A%20313-319%0A%0AComment%3A%0A**Steps%20reauthorization%20remains%20hidden**%0A%0AWhen%20a%20connected%20user%20retains%20active-energy%20write%20access%20but%20declines%20or%20revokes%20steps-read%20access%2C%20reconciliation%20still%20sets%20%60workoutHealthWriteGranted%60%20to%20true%20and%20hides%20the%20permission%20action%20that%20requests%20steps.%20Home%20therefore%20continues%20hiding%20daily%20steps%20until%20the%20user%20discovers%20the%20system%20management%20screen%20or%20disconnects%20and%20reconnects%20Health%20Connect.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=253&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20android%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fsettings%2FSettingsViewModel.kt%0ALine%3A%20313-319%0A%0AComment%3A%0A**Steps%20reauthorization%20remains%20hidden**%0A%0AWhen%20a%20connected%20user%20retains%20active-energy%20write%20access%20but%20declines%20or%20revokes%20steps-read%20access%2C%20reconciliation%20still%20sets%20%60workoutHealthWriteGranted%60%20to%20true%20and%20hides%20the%20permission%20action%20that%20requests%20steps.%20Home%20therefore%20continues%20hiding%20daily%20steps%20until%20the%20user%20discovers%20the%20system%20management%20screen%20or%20disconnects%20and%20reconnects%20Health%20Connect.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=253&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20apoorvdarshan%2Ffud-ai%20PR%20%23253%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=253&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fsettings%2FSettingsViewModel.kt%3A313-319%0A**Steps%20reauthorization%20remains%20hidden**%0A%0AWhen%20a%20connected%20user%20retains%20active-energy%20write%20access%20but%20declines%20or%20revokes%20steps-read%20access%2C%20reconciliation%20still%20sets%20%60workoutHealthWriteGranted%60%20to%20true%20and%20hides%20the%20permission%20action%20that%20requests%20steps.%20Home%20therefore%20continues%20hiding%20daily%20steps%20until%20the%20user%20discovers%20the%20system%20management%20screen%20or%20disconnects%20and%20reconnects%20Health%20Connect.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=253&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22apoorvdarshan%2Ffud-ai%22%20on%20the%20existing%20branch%20%22cursor%2Ffeature-205-health-steps-on-home-8ad9%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Ffeature-205-health-steps-on-home-8ad9%22.%0A%0A%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fsettings%2FSettingsViewModel.kt%3A313-319%0A**Steps%20reauthorization%20remains%20hidden**%0A%0AWhen%20a%20connected%20user%20retains%20active-energy%20write%20access%20but%20declines%20or%20revokes%20steps-read%20access%2C%20reconciliation%20still%20sets%20%60workoutHealthWriteGranted%60%20to%20true%20and%20hides%20the%20permission%20action%20that%20requests%20steps.%20Home%20therefore%20continues%20hiding%20daily%20steps%20until%20the%20user%20discovers%20the%20system%20management%20screen%20or%20disconnects%20and%20reconnects%20Health%20Connect.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=253&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fsettings%2FSettingsViewModel.kt%3A313-319%0A**Steps%20reauthorization%20remains%20hidden**%0A%0AWhen%20a%20connected%20user%20retains%20active-energy%20write%20access%20but%20declines%20or%20revokes%20steps-read%20access%2C%20reconciliation%20still%20sets%20%60workoutHealthWriteGranted%60%20to%20true%20and%20hides%20the%20permission%20action%20that%20requests%20steps.%20Home%20therefore%20continues%20hiding%20daily%20steps%20until%20the%20user%20discovers%20the%20system%20management%20screen%20or%20disconnects%20and%20reconnects%20Health%20Connect.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=253&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsViewModel.kt:313-319
**Steps reauthorization remains hidden**

When a connected user retains active-energy write access but declines or revokes steps-read access, reconciliation still sets `workoutHealthWriteGranted` to true and hides the permission action that requests steps. Home therefore continues hiding daily steps until the user discovers the system management screen or disconnects and reconnects Health Connect.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["Merge origin/main into steps feature bra..."](https://github.com/apoorvdarshan/fud-ai/commit/db743ec04607e2a95c6d68170e6e9c7d92adc7e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62594753)</sub>

<!-- /greptile_comment -->