### PR TITLE
Fullscreen meal photos: pinch zoom, pan, and save to gallery (#191)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,9 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
 
     <uses-permission android:name="android.permission.health.READ_WEIGHT" />
     <uses-permission android:name="android.permission.health.WRITE_WEIGHT" />

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/FullScreenImageViewer.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/FullScreenImageViewer.kt
@@ -9,9 +9,10 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
-import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -46,8 +47,13 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.awaitPointerEvent
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -58,6 +64,7 @@ import androidx.compose.ui.window.DialogProperties
 import androidx.core.content.ContextCompat
 import com.apoorvdarshan.calorietracker.R
 import kotlin.math.abs
+import kotlin.math.max
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -134,20 +141,40 @@ fun FullScreenImageViewer(
                 .graphicsLayer { translationY = dragOffset }
                 .pointerInput(isCurrentPageZoomed) {
                     if (!isCurrentPageZoomed) {
-                        detectVerticalDragGestures(
-                            onVerticalDrag = { change, dragAmount ->
+                        awaitEachGesture {
+                            val down = awaitFirstDown(requireUnconsumed = false)
+                            val pointerId = down.id
+                            var tracking = false
+                            val touchSlop = viewConfiguration.touchSlop
+
+                            while (true) {
+                                val event = awaitPointerEvent()
+                                if (event.changes.count { it.pressed } > 1) {
+                                    if (tracking) dragOffset = 0f
+                                    return@awaitEachGesture
+                                }
+
+                                val change = event.changes.firstOrNull { it.id == pointerId }
+                                if (change == null || !change.pressed) {
+                                    if (tracking) {
+                                        if (abs(dragOffset) > dismissThresholdPx) {
+                                            onDismiss()
+                                        } else {
+                                            dragOffset = 0f
+                                        }
+                                    }
+                                    return@awaitEachGesture
+                                }
+
+                                val dragAmount = change.positionChange().y
+                                if (!tracking) {
+                                    if (abs(dragAmount) < touchSlop) continue
+                                    tracking = true
+                                }
                                 change.consume()
                                 dragOffset += dragAmount
-                            },
-                            onDragEnd = {
-                                if (abs(dragOffset) > dismissThresholdPx) {
-                                    onDismiss()
-                                } else {
-                                    dragOffset = 0f
-                                }
-                            },
-                            onDragCancel = { dragOffset = 0f }
-                        )
+                            }
+                        }
                     }
                 }
         ) {
@@ -246,6 +273,8 @@ private fun ZoomableMealPhotoPage(
     var scale by remember(pageIndex) { mutableFloatStateOf(1f) }
     var offsetX by remember(pageIndex) { mutableFloatStateOf(0f) }
     var offsetY by remember(pageIndex) { mutableFloatStateOf(0f) }
+    var containerSize by remember(pageIndex) { mutableStateOf(Offset.Zero) }
+    val isPageZoomed = scale > 1.01f
 
     LaunchedEffect(isActive) {
         if (!isActive) {
@@ -259,19 +288,37 @@ private fun ZoomableMealPhotoPage(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .pointerInput(pageIndex, isActive) {
-                detectTransformGestures { _, pan, zoom, _ ->
-                    if (!isActive) return@detectTransformGestures
-                    val updatedScale = (scale * zoom).coerceIn(1f, MAX_ZOOM)
-                    scale = updatedScale
-                    if (updatedScale > 1.01f) {
-                        offsetX += pan.x
-                        offsetY += pan.y
-                    } else {
-                        offsetX = 0f
-                        offsetY = 0f
+            .onSizeChanged { size ->
+                containerSize = Offset(size.width.toFloat(), size.height.toFloat())
+            }
+            .pointerInput(pageIndex, isActive, isPageZoomed) {
+                if (!isActive) return@pointerInput
+                if (isPageZoomed) {
+                    detectTransformGestures { _, pan, zoom, _ ->
+                        val updatedScale = (scale * zoom).coerceIn(1f, MAX_ZOOM)
+                        scale = updatedScale
+                        if (updatedScale > 1.01f) {
+                            offsetX += pan.x
+                            offsetY += pan.y
+                        } else {
+                            offsetX = 0f
+                            offsetY = 0f
+                        }
+                        onZoomChanged(updatedScale > 1.01f)
                     }
-                    onZoomChanged(updatedScale > 1.01f)
+                } else {
+                    detectPinchToZoomGestures { pan, zoom ->
+                        val updatedScale = (scale * zoom).coerceIn(1f, MAX_ZOOM)
+                        scale = updatedScale
+                        if (updatedScale > 1.01f) {
+                            offsetX += pan.x
+                            offsetY += pan.y
+                        } else {
+                            offsetX = 0f
+                            offsetY = 0f
+                        }
+                        onZoomChanged(updatedScale > 1.01f)
+                    }
                 }
             }
             .pointerInput(pageIndex, isActive) {
@@ -287,7 +334,7 @@ private fun ZoomableMealPhotoPage(
                             scale = DOUBLE_TAP_ZOOM
                             offsetX = 0f
                             offsetY = 0f
-                            centerPanForZoom(tapOffset, scale)?.let { (x, y) ->
+                            centerPanForZoom(tapOffset, containerSize, scale)?.let { (x, y) ->
                                 offsetX = x
                                 offsetY = y
                             }
@@ -313,9 +360,73 @@ private fun ZoomableMealPhotoPage(
     }
 }
 
-private fun centerPanForZoom(tapOffset: Offset, scale: Float): Pair<Float, Float>? {
-    if (scale <= 1.01f) return null
-    return (-(tapOffset.x * (scale - 1f))) to (-(tapOffset.y * (scale - 1f)))
+private fun centerPanForZoom(
+    tapOffset: Offset,
+    containerSize: Offset,
+    scale: Float
+): Pair<Float, Float>? {
+    if (scale <= 1.01f || containerSize == Offset.Zero) return null
+    val centerX = containerSize.x / 2f
+    val centerY = containerSize.y / 2f
+    return ((centerX - tapOffset.x) * (scale - 1f)) to ((centerY - tapOffset.y) * (scale - 1f))
+}
+
+private suspend fun PointerInputScope.detectPinchToZoomGestures(
+    onGesture: (pan: Offset, zoom: Float) -> Unit
+) {
+    awaitEachGesture {
+        awaitFirstDown(requireUnconsumed = false)
+        while (true) {
+            val event = awaitPointerEvent()
+            val pressed = event.changes.filter { it.pressed }
+            when {
+                pressed.isEmpty() -> return@awaitEachGesture
+                pressed.size >= 2 -> break
+            }
+        }
+
+        var previousCentroid = Offset.Zero
+        var previousSpan = 0f
+        var initialized = false
+
+        do {
+            val event = awaitPointerEvent()
+            val pressed = event.changes.filter { it.pressed }
+            if (pressed.size < 2) break
+
+            val centroid = pressed
+                .map { it.position }
+                .reduce { accumulated, position -> accumulated + position } / pressed.size.toFloat()
+            val span = computePointerSpan(pressed)
+
+            if (!initialized) {
+                previousCentroid = centroid
+                previousSpan = span
+                initialized = true
+            } else {
+                val zoom = if (previousSpan > 0f) span / previousSpan else 1f
+                val pan = centroid - previousCentroid
+                pressed.forEach { it.consume() }
+                onGesture(pan, zoom)
+                previousCentroid = centroid
+                previousSpan = span
+            }
+        } while (event.changes.any { it.pressed })
+    }
+}
+
+private fun computePointerSpan(changes: List<PointerInputChange>): Float {
+    if (changes.size < 2) return 0f
+    var maxDistance = 0f
+    for (first in changes.indices) {
+        for (second in first + 1 until changes.size) {
+            maxDistance = max(
+                maxDistance,
+                (changes[first].position - changes[second].position).getDistance()
+            )
+        }
+    }
+    return maxDistance
 }
 
 private suspend fun saveCurrentPhoto(
@@ -327,10 +438,14 @@ private suspend fun saveCurrentPhoto(
 ) {
     if (isSaving || page !in bitmaps.indices) return
     setSaving(true)
-    val result = withContext(Dispatchers.IO) {
-        saveMealPhotoToGallery(context, bitmaps[page])
+    val result = try {
+        withContext(Dispatchers.IO) {
+            runCatching { saveMealPhotoToGallery(context, bitmaps[page]) }
+                .getOrElse { MealPhotoSaveResult.Failed }
+        }
+    } finally {
+        setSaving(false)
     }
-    setSaving(false)
 
     val messageRes = when (result) {
         MealPhotoSaveResult.Saved -> R.string.photo_saved_to_gallery

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/FullScreenImageViewer.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/FullScreenImageViewer.kt
@@ -1,7 +1,16 @@
 package com.apoorvdarshan.calorietracker.ui.components
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.graphics.Bitmap
+import android.os.Build
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -14,33 +23,51 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.Download
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.core.content.ContextCompat
 import com.apoorvdarshan.calorietracker.R
 import kotlin.math.abs
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+private const val DOUBLE_TAP_ZOOM = 2.5f
+private const val MAX_ZOOM = 4f
 
 /**
- * Full-screen meal photo viewer. Supports horizontal paging for multi-photo entries,
- * a close button, and vertical drag-to-dismiss.
+ * Full-screen meal photo viewer. Supports pinch/double-tap zoom, pan while zoomed,
+ * horizontal paging when zoomed out, save to gallery, close, and vertical drag-to-dismiss.
  */
 @Composable
 fun FullScreenImageViewer(
@@ -50,13 +77,46 @@ fun FullScreenImageViewer(
 ) {
     if (bitmaps.isEmpty()) return
 
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     val startIndex = initialIndex.coerceIn(0, bitmaps.lastIndex)
     val pagerState = rememberPagerState(
         initialPage = startIndex,
         pageCount = { bitmaps.size }
     )
     var dragOffset by remember { mutableFloatStateOf(0f) }
+    var zoomedPage by remember { mutableIntStateOf(-1) }
+    var isSaving by remember { mutableStateOf(false) }
     val dismissThresholdPx = 180f
+    val isCurrentPageZoomed = zoomedPage == pagerState.currentPage
+
+    val storagePermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) {
+            scope.launch { saveCurrentPhoto(context, bitmaps, pagerState.currentPage, isSaving) { isSaving = it } }
+        } else {
+            Toast.makeText(
+                context,
+                context.getString(R.string.photo_save_permission_denied),
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+    }
+
+    fun requestSaveCurrentPhoto() {
+        if (isSaving) return
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE) !=
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            storagePermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            return
+        }
+        scope.launch {
+            saveCurrentPhoto(context, bitmaps, pagerState.currentPage, isSaving) { isSaving = it }
+        }
+    }
 
     Dialog(
         onDismissRequest = onDismiss,
@@ -72,32 +132,40 @@ fun FullScreenImageViewer(
                 .fillMaxSize()
                 .background(Color.Black.copy(alpha = (1f - (abs(dragOffset) / 500f)).coerceIn(0.35f, 1f)))
                 .graphicsLayer { translationY = dragOffset }
-                .pointerInput(Unit) {
-                    detectVerticalDragGestures(
-                        onVerticalDrag = { change, dragAmount ->
-                            change.consume()
-                            dragOffset += dragAmount
-                        },
-                        onDragEnd = {
-                            if (abs(dragOffset) > dismissThresholdPx) {
-                                onDismiss()
-                            } else {
-                                dragOffset = 0f
-                            }
-                        },
-                        onDragCancel = { dragOffset = 0f }
-                    )
+                .pointerInput(isCurrentPageZoomed) {
+                    if (!isCurrentPageZoomed) {
+                        detectVerticalDragGestures(
+                            onVerticalDrag = { change, dragAmount ->
+                                change.consume()
+                                dragOffset += dragAmount
+                            },
+                            onDragEnd = {
+                                if (abs(dragOffset) > dismissThresholdPx) {
+                                    onDismiss()
+                                } else {
+                                    dragOffset = 0f
+                                }
+                            },
+                            onDragCancel = { dragOffset = 0f }
+                        )
+                    }
                 }
         ) {
             HorizontalPager(
                 state = pagerState,
+                userScrollEnabled = !isCurrentPageZoomed,
                 modifier = Modifier.fillMaxSize()
             ) { page ->
-                androidx.compose.foundation.Image(
-                    bitmap = bitmaps[page].asImageBitmap(),
-                    contentDescription = stringResource(R.string.cd_meal_photo, page + 1),
-                    contentScale = ContentScale.Fit,
-                    modifier = Modifier.fillMaxSize()
+                ZoomableMealPhotoPage(
+                    bitmap = bitmaps[page],
+                    pageIndex = page,
+                    isActive = pagerState.currentPage == page,
+                    isZoomed = zoomedPage == page,
+                    onZoomChanged = { zoomed ->
+                        zoomedPage = if (zoomed) page else {
+                            if (zoomedPage == page) -1 else zoomedPage
+                        }
+                    }
                 )
             }
 
@@ -131,6 +199,143 @@ fun FullScreenImageViewer(
                     tint = Color.White
                 )
             }
+
+            Row(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 28.dp)
+                    .background(Color.White.copy(alpha = 0.22f), RoundedCornerShape(50))
+                    .clickable(enabled = !isSaving) { requestSaveCurrentPhoto() }
+                    .padding(horizontal = 18.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (isSaving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        color = Color.White,
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    Icon(
+                        Icons.Outlined.Download,
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = stringResource(R.string.action_save),
+                    color = Color.White,
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
         }
     }
+}
+
+@Composable
+private fun ZoomableMealPhotoPage(
+    bitmap: Bitmap,
+    pageIndex: Int,
+    isActive: Boolean,
+    isZoomed: Boolean,
+    onZoomChanged: (Boolean) -> Unit
+) {
+    var scale by remember(pageIndex) { mutableFloatStateOf(1f) }
+    var offsetX by remember(pageIndex) { mutableFloatStateOf(0f) }
+    var offsetY by remember(pageIndex) { mutableFloatStateOf(0f) }
+
+    LaunchedEffect(isActive) {
+        if (!isActive) {
+            scale = 1f
+            offsetX = 0f
+            offsetY = 0f
+            onZoomChanged(false)
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .pointerInput(pageIndex, isActive) {
+                detectTransformGestures { _, pan, zoom, _ ->
+                    if (!isActive) return@detectTransformGestures
+                    val updatedScale = (scale * zoom).coerceIn(1f, MAX_ZOOM)
+                    scale = updatedScale
+                    if (updatedScale > 1.01f) {
+                        offsetX += pan.x
+                        offsetY += pan.y
+                    } else {
+                        offsetX = 0f
+                        offsetY = 0f
+                    }
+                    onZoomChanged(updatedScale > 1.01f)
+                }
+            }
+            .pointerInput(pageIndex, isActive) {
+                detectTapGestures(
+                    onDoubleTap = { tapOffset ->
+                        if (!isActive) return@detectTapGestures
+                        if (scale > 1.01f) {
+                            scale = 1f
+                            offsetX = 0f
+                            offsetY = 0f
+                            onZoomChanged(false)
+                        } else {
+                            scale = DOUBLE_TAP_ZOOM
+                            offsetX = 0f
+                            offsetY = 0f
+                            centerPanForZoom(tapOffset, scale)?.let { (x, y) ->
+                                offsetX = x
+                                offsetY = y
+                            }
+                            onZoomChanged(true)
+                        }
+                    }
+                )
+            }
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+                translationX = offsetX
+                translationY = offsetY
+            },
+        contentAlignment = Alignment.Center
+    ) {
+        androidx.compose.foundation.Image(
+            bitmap = bitmap.asImageBitmap(),
+            contentDescription = stringResource(R.string.cd_meal_photo, pageIndex + 1),
+            contentScale = ContentScale.Fit,
+            modifier = Modifier.fillMaxSize()
+        )
+    }
+}
+
+private fun centerPanForZoom(tapOffset: Offset, scale: Float): Pair<Float, Float>? {
+    if (scale <= 1.01f) return null
+    return (-(tapOffset.x * (scale - 1f))) to (-(tapOffset.y * (scale - 1f)))
+}
+
+private suspend fun saveCurrentPhoto(
+    context: android.content.Context,
+    bitmaps: List<Bitmap>,
+    page: Int,
+    isSaving: Boolean,
+    setSaving: (Boolean) -> Unit
+) {
+    if (isSaving || page !in bitmaps.indices) return
+    setSaving(true)
+    val result = withContext(Dispatchers.IO) {
+        saveMealPhotoToGallery(context, bitmaps[page])
+    }
+    setSaving(false)
+
+    val messageRes = when (result) {
+        MealPhotoSaveResult.Saved -> R.string.photo_saved_to_gallery
+        MealPhotoSaveResult.PermissionDenied -> R.string.photo_save_permission_denied
+        MealPhotoSaveResult.Failed -> R.string.photo_save_failed
+    }
+    Toast.makeText(context, context.getString(messageRes), Toast.LENGTH_SHORT).show()
 }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/FullScreenImageViewer.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/FullScreenImageViewer.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.PointerInputScope
-import androidx.compose.ui.input.pointer.awaitPointerEvent
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.layout.ContentScale

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/MealPhotoGalleryExport.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/MealPhotoGalleryExport.kt
@@ -1,0 +1,105 @@
+package com.apoorvdarshan.calorietracker.ui.components
+
+import android.content.ContentValues
+import android.content.Context
+import android.graphics.Bitmap
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import com.apoorvdarshan.calorietracker.R
+import java.io.File
+import java.io.FileOutputStream
+
+enum class MealPhotoSaveResult {
+    Saved,
+    PermissionDenied,
+    Failed
+}
+
+fun saveMealPhotoToGallery(context: Context, bitmap: Bitmap): MealPhotoSaveResult {
+    val filename = "fud-ai-${System.currentTimeMillis()}.jpg"
+    val folderName = context.getString(R.string.gallery_folder_name)
+
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        saveViaMediaStore(context, bitmap, filename, folderName)
+    } else {
+        saveViaLegacyExternalStorage(context, bitmap, filename, folderName)
+    }
+}
+
+private fun saveViaMediaStore(
+    context: Context,
+    bitmap: Bitmap,
+    filename: String,
+    folderName: String
+): MealPhotoSaveResult {
+    val resolver = context.contentResolver
+    val contentValues = ContentValues().apply {
+        put(MediaStore.MediaColumns.DISPLAY_NAME, filename)
+        put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
+        put(
+            MediaStore.MediaColumns.RELATIVE_PATH,
+            "${Environment.DIRECTORY_PICTURES}/$folderName"
+        )
+        put(MediaStore.MediaColumns.IS_PENDING, 1)
+    }
+
+    val uri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
+        ?: return MealPhotoSaveResult.Failed
+
+    val wrote = runCatching {
+        resolver.openOutputStream(uri)?.use { output ->
+            if (!bitmap.compress(Bitmap.CompressFormat.JPEG, 95, output)) {
+                error("compress failed")
+            }
+        } ?: error("missing output stream")
+    }.isSuccess
+
+    if (!wrote) {
+        resolver.delete(uri, null, null)
+        return MealPhotoSaveResult.Failed
+    }
+
+    contentValues.clear()
+    contentValues.put(MediaStore.MediaColumns.IS_PENDING, 0)
+    resolver.update(uri, contentValues, null, null)
+    return MealPhotoSaveResult.Saved
+}
+
+private fun saveViaLegacyExternalStorage(
+    context: Context,
+    bitmap: Bitmap,
+    filename: String,
+    folderName: String
+): MealPhotoSaveResult {
+    val picturesRoot = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
+    val targetDir = File(picturesRoot, folderName)
+    if (!targetDir.exists() && !targetDir.mkdirs()) {
+        return MealPhotoSaveResult.Failed
+    }
+
+    val targetFile = File(targetDir, filename)
+    val wrote = runCatching {
+        FileOutputStream(targetFile).use { output ->
+            if (!bitmap.compress(Bitmap.CompressFormat.JPEG, 95, output)) {
+                error("compress failed")
+            }
+        }
+    }.isSuccess
+
+    if (!wrote) {
+        targetFile.delete()
+        return MealPhotoSaveResult.Failed
+    }
+
+    val resolver = context.contentResolver
+    val contentValues = ContentValues().apply {
+        put(MediaStore.MediaColumns.DISPLAY_NAME, filename)
+        put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
+        put(MediaStore.MediaColumns.DATA, targetFile.absolutePath)
+    }
+    resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
+        ?: return MealPhotoSaveResult.Failed
+
+    return MealPhotoSaveResult.Saved
+}

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/MealPhotoGalleryExport.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/MealPhotoGalleryExport.kt
@@ -33,37 +33,39 @@ private fun saveViaMediaStore(
     filename: String,
     folderName: String
 ): MealPhotoSaveResult {
-    val resolver = context.contentResolver
-    val contentValues = ContentValues().apply {
-        put(MediaStore.MediaColumns.DISPLAY_NAME, filename)
-        put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
-        put(
-            MediaStore.MediaColumns.RELATIVE_PATH,
-            "${Environment.DIRECTORY_PICTURES}/$folderName"
-        )
-        put(MediaStore.MediaColumns.IS_PENDING, 1)
-    }
+    return runCatching {
+        val resolver = context.contentResolver
+        val contentValues = ContentValues().apply {
+            put(MediaStore.MediaColumns.DISPLAY_NAME, filename)
+            put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
+            put(
+                MediaStore.MediaColumns.RELATIVE_PATH,
+                "${Environment.DIRECTORY_PICTURES}/$folderName"
+            )
+            put(MediaStore.MediaColumns.IS_PENDING, 1)
+        }
 
-    val uri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
-        ?: return MealPhotoSaveResult.Failed
+        val uri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
+            ?: return@runCatching MealPhotoSaveResult.Failed
 
-    val wrote = runCatching {
-        resolver.openOutputStream(uri)?.use { output ->
-            if (!bitmap.compress(Bitmap.CompressFormat.JPEG, 95, output)) {
-                error("compress failed")
-            }
-        } ?: error("missing output stream")
-    }.isSuccess
+        val wrote = runCatching {
+            resolver.openOutputStream(uri)?.use { output ->
+                if (!bitmap.compress(Bitmap.CompressFormat.JPEG, 95, output)) {
+                    error("compress failed")
+                }
+            } ?: error("missing output stream")
+        }.isSuccess
 
-    if (!wrote) {
-        resolver.delete(uri, null, null)
-        return MealPhotoSaveResult.Failed
-    }
+        if (!wrote) {
+            runCatching { resolver.delete(uri, null, null) }
+            return@runCatching MealPhotoSaveResult.Failed
+        }
 
-    contentValues.clear()
-    contentValues.put(MediaStore.MediaColumns.IS_PENDING, 0)
-    resolver.update(uri, contentValues, null, null)
-    return MealPhotoSaveResult.Saved
+        contentValues.clear()
+        contentValues.put(MediaStore.MediaColumns.IS_PENDING, 0)
+        resolver.update(uri, contentValues, null, null)
+        MealPhotoSaveResult.Saved
+    }.getOrElse { MealPhotoSaveResult.Failed }
 }
 
 private fun saveViaLegacyExternalStorage(
@@ -72,34 +74,36 @@ private fun saveViaLegacyExternalStorage(
     filename: String,
     folderName: String
 ): MealPhotoSaveResult {
-    val picturesRoot = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
-    val targetDir = File(picturesRoot, folderName)
-    if (!targetDir.exists() && !targetDir.mkdirs()) {
-        return MealPhotoSaveResult.Failed
-    }
-
-    val targetFile = File(targetDir, filename)
-    val wrote = runCatching {
-        FileOutputStream(targetFile).use { output ->
-            if (!bitmap.compress(Bitmap.CompressFormat.JPEG, 95, output)) {
-                error("compress failed")
-            }
+    return runCatching {
+        val picturesRoot = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
+        val targetDir = File(picturesRoot, folderName)
+        if (!targetDir.exists() && !targetDir.mkdirs()) {
+            return@runCatching MealPhotoSaveResult.Failed
         }
-    }.isSuccess
 
-    if (!wrote) {
-        targetFile.delete()
-        return MealPhotoSaveResult.Failed
-    }
+        val targetFile = File(targetDir, filename)
+        val wrote = runCatching {
+            FileOutputStream(targetFile).use { output ->
+                if (!bitmap.compress(Bitmap.CompressFormat.JPEG, 95, output)) {
+                    error("compress failed")
+                }
+            }
+        }.isSuccess
 
-    val resolver = context.contentResolver
-    val contentValues = ContentValues().apply {
-        put(MediaStore.MediaColumns.DISPLAY_NAME, filename)
-        put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
-        put(MediaStore.MediaColumns.DATA, targetFile.absolutePath)
-    }
-    resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
-        ?: return MealPhotoSaveResult.Failed
+        if (!wrote) {
+            targetFile.delete()
+            return@runCatching MealPhotoSaveResult.Failed
+        }
 
-    return MealPhotoSaveResult.Saved
+        val resolver = context.contentResolver
+        val contentValues = ContentValues().apply {
+            put(MediaStore.MediaColumns.DISPLAY_NAME, filename)
+            put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
+            put(MediaStore.MediaColumns.DATA, targetFile.absolutePath)
+        }
+        resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
+            ?: return@runCatching MealPhotoSaveResult.Failed
+
+        MealPhotoSaveResult.Saved
+    }.getOrElse { MealPhotoSaveResult.Failed }
 }

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -780,4 +780,9 @@
     <string name="about_whisper_notices">إشعارات الجهات الخارجية لـ Whisper Base</string>
     <string name="about_whisper_notices_load_error">تعذّر تحميل إشعارات الجهات الخارجية لـ Whisper Base.</string>
     <string name="cd_remove_image">إزالة الصورة</string>
+    <string name="cd_save_photo">حفظ الصورة</string>
+    <string name="gallery_folder_name">Fud AI</string>
+    <string name="photo_saved_to_gallery">تم حفظ الصورة</string>
+    <string name="photo_save_failed">تعذر حفظ الصورة</string>
+    <string name="photo_save_permission_denied">تم رفض الوصول إلى الصور</string>
 </resources>

--- a/android/app/src/main/res/values-az/strings.xml
+++ b/android/app/src/main/res/values-az/strings.xml
@@ -772,4 +772,9 @@
     <string name="about_whisper_notices">Whisper Base üçün üçüncü tərəf bildirişləri</string>
     <string name="about_whisper_notices_load_error">Whisper Base üçün üçüncü tərəf bildirişlərini yükləmək mümkün olmadı.</string>
     <string name="cd_remove_image">Şəkli sil</string>
+    <string name="cd_save_photo">Şəkli yadda saxla</string>
+    <string name="gallery_folder_name">Fud AI</string>
+    <string name="photo_saved_to_gallery">Şəkil yadda saxlanıldı</string>
+    <string name="photo_save_failed">Şəkil yadda saxlanmadı</string>
+    <string name="photo_save_permission_denied">Foto girişinə icazə verilmədi</string>
 </resources>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -772,4 +772,9 @@
     <string name="about_whisper_notices">Drittanbieterhinweise zu Whisper Base</string>
     <string name="about_whisper_notices_load_error">Die Drittanbieterhinweise zu Whisper Base konnten nicht geladen werden.</string>
     <string name="cd_remove_image">Bild entfernen</string>
+    <string name="cd_save_photo">Foto speichern</string>
+    <string name="gallery_folder_name">Fud AI</string>
+    <string name="photo_saved_to_gallery">Foto gespeichert</string>
+    <string name="photo_save_failed">Foto konnte nicht gespeichert werden</string>
+    <string name="photo_save_permission_denied">Fotozugriff verweigert</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -772,4 +772,9 @@
     <string name="about_whisper_notices">Avisos de terceros de Whisper Base</string>
     <string name="about_whisper_notices_load_error">No se pudieron cargar los avisos de terceros de Whisper Base.</string>
     <string name="cd_remove_image">Quitar imagen</string>
+    <string name="cd_save_photo">Guardar foto</string>
+    <string name="gallery_folder_name">Fud AI</string>
+    <string name="photo_saved_to_gallery">Foto guardada</string>
+    <string name="photo_save_failed">No se pudo guardar la foto</string>
+    <string name="photo_save_permission_denied">Acceso a fotos denegado</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -772,4 +772,9 @@
     <string name="about_whisper_notices">Mentions tierces de Whisper Base</string>
     <string name="about_whisper_notices_load_error">Impossible de charger les mentions tierces de Whisper Base.</string>
     <string name="cd_remove_image">Retirer l’image</string>
+    <string name="cd_save_photo">Enregistrer la photo</string>
+    <string name="gallery_folder_name">Fud AI</string>
+    <string name="photo_saved_to_gallery">Photo enregistrée</string>
+    <string name="photo_save_failed">Impossible d'enregistrer la photo</string>
+    <string name="photo_save_permission_denied">Accès aux photos refusé</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -775,6 +775,6 @@
     <string name="cd_save_photo">Enregistrer la photo</string>
     <string name="gallery_folder_name">Fud AI</string>
     <string name="photo_saved_to_gallery">Photo enregistrée</string>
-    <string name="photo_save_failed">Impossible d'enregistrer la photo</string>
+    <string name="photo_save_failed">Impossible d\u2019enregistrer la photo</string>
     <string name="photo_save_permission_denied">Accès aux photos refusé</string>
 </resources>

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -772,4 +772,9 @@
     <string name="about_whisper_notices">Whisper Base के तृतीय-पक्ष नोटिस</string>
     <string name="about_whisper_notices_load_error">Whisper Base के तृतीय-पक्ष नोटिस लोड नहीं किए जा सके।</string>
     <string name="cd_remove_image">चित्र हटाएँ</string>
+    <string name="cd_save_photo">फ़ोटो सहेजें</string>
+    <string name="gallery_folder_name">Fud AI</string>
+    <string name="photo_saved_to_gallery">फ़ोटो सहेजी गई</string>
+    <string name="photo_save_failed">फ़ोटो सहेजी नहीं जा सकी</string>
+    <string name="photo_save_permission_denied">फ़ोटो एक्सेस अस्वीकृत</string>
 </resources>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -772,4 +772,9 @@
     <string name="about_whisper_notices">Avvisi di terze parti di Whisper Base</string>
     <string name="about_whisper_notices_load_error">Impossibile caricare gli avvisi di terze parti di Whisper Base.</string>
     <string name="cd_remove_image">Rimuovi immagine</string>
+    <string name="cd_save_photo">Salva foto</string>
+    <string name="gallery_folder_name">Fud AI</string>
+    <string name="photo_saved_to_gallery">Foto salvata</string>
+    <string name="photo_save_failed">Impossibile salvare la foto</string>
+    <string name="photo_save_permission_denied">Accesso alle foto negato</string>
 </resources>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -772,4 +772,9 @@
     <string name="about_whisper_notices">Whisper Base のサードパーティ通知</string>
     <string name="about_whisper_notices_load_error">Whisper Base のサードパーティ通知を読み込めませんでした。</string>
     <string name="cd_remove_image">画像を削除</string>
+    <string name="cd_save_photo">写真を保存</string>
+    <string name="gallery_folder_name">Fud AI</string>
+    <string name="photo_saved_to_gallery">写真を保存しました</string>
+    <string name="photo_save_failed">写真を保存できませんでした</string>
+    <string name="photo_save_permission_denied">写真へのアクセスが拒否されました</string>
 </resources>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -772,4 +772,9 @@
     <string name="about_whisper_notices">Whisper Base 타사 고지</string>
     <string name="about_whisper_notices_load_error">Whisper Base 타사 고지를 불러올 수 없습니다.</string>
     <string name="cd_remove_image">이미지 제거</string>
+    <string name="cd_save_photo">사진 저장</string>
+    <string name="gallery_folder_name">Fud AI</string>
+    <string name="photo_saved_to_gallery">사진 저장됨</string>
+    <string name="photo_save_failed">사진을 저장할 수 없습니다</string>
+    <string name="photo_save_permission_denied">사진 접근이 거부되었습니다</string>
 </resources>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -772,4 +772,9 @@
     <string name="about_whisper_notices">Kennisgevingen van derden voor Whisper Base</string>
     <string name="about_whisper_notices_load_error">De kennisgevingen van derden voor Whisper Base konden niet worden geladen.</string>
     <string name="cd_remove_image">Afbeelding verwijderen</string>
+    <string name="cd_save_photo">Foto opslaan</string>
+    <string name="gallery_folder_name">Fud AI</string>
+    <string name="photo_saved_to_gallery">Foto opgeslagen</string>
+    <string name="photo_save_failed">Kon foto niet opslaan</string>
+    <string name="photo_save_permission_denied">Fototoegang geweigerd</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -776,4 +776,9 @@
     <string name="about_whisper_notices">Informacje zewnętrzne Whisper Base</string>
     <string name="about_whisper_notices_load_error">Nie udało się wczytać informacji zewnętrznych Whisper Base.</string>
     <string name="cd_remove_image">Usuń obraz</string>
+    <string name="cd_save_photo">Zapisz zdjęcie</string>
+    <string name="gallery_folder_name">Fud AI</string>
+    <string name="photo_saved_to_gallery">Zdjęcie zapisane</string>
+    <string name="photo_save_failed">Nie udało się zapisać zdjęcia</string>
+    <string name="photo_save_permission_denied">Odmowa dostępu do zdjęć</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -772,4 +772,9 @@
     <string name="about_whisper_notices">Avisos de terceiros do Whisper Base</string>
     <string name="about_whisper_notices_load_error">Não foi possível carregar os avisos de terceiros do Whisper Base.</string>
     <string name="cd_remove_image">Remover imagem</string>
+    <string name="cd_save_photo">Salvar foto</string>
+    <string name="gallery_folder_name">Fud AI</string>
+    <string name="photo_saved_to_gallery">Foto salva</string>
+    <string name="photo_save_failed">Não foi possível salvar a foto</string>
+    <string name="photo_save_permission_denied">Acesso às fotos negado</string>
 </resources>

--- a/android/app/src/main/res/values-ro/strings.xml
+++ b/android/app/src/main/res/values-ro/strings.xml
@@ -774,4 +774,9 @@
     <string name="about_whisper_notices">Notificări terțe Whisper Base</string>
     <string name="about_whisper_notices_load_error">Notificările terțe Whisper Base nu au putut fi încărcate.</string>
     <string name="cd_remove_image">Elimină imaginea</string>
+    <string name="cd_save_photo">Salvează fotografia</string>
+    <string name="gallery_folder_name">Fud AI</string>
+    <string name="photo_saved_to_gallery">Fotografie salvată</string>
+    <string name="photo_save_failed">Fotografia nu a putut fi salvată</string>
+    <string name="photo_save_permission_denied">Acces la fotografii refuzat</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -832,6 +832,11 @@
     <string name="cd_add_image">Добавить изображение</string>
     <string name="cd_open_camera">Открыть камеру</string>
     <string name="cd_close_camera">Закрыть камеру</string>
+        <string name="cd_save_photo">Сохранить фото</string>
+    <string name="gallery_folder_name">Fud AI</string>
+    <string name="photo_saved_to_gallery">Фото сохранено</string>
+    <string name="photo_save_failed">Не удалось сохранить фото</string>
+    <string name="photo_save_permission_denied">Доступ к фото запрещён</string>
     <!-- Localization pass: previously hardcoded UI strings -->
     <string name="unit_mcg">мкг</string>
     <string name="home_food_log">Журнал питания</string>

--- a/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -772,4 +772,9 @@
     <string name="about_whisper_notices">Whisper Base 第三方声明</string>
     <string name="about_whisper_notices_load_error">无法加载 Whisper Base 第三方声明。</string>
     <string name="cd_remove_image">移除图片</string>
+    <string name="cd_save_photo">保存照片</string>
+    <string name="gallery_folder_name">Fud AI</string>
+    <string name="photo_saved_to_gallery">照片已保存</string>
+    <string name="photo_save_failed">无法保存照片</string>
+    <string name="photo_save_permission_denied">照片访问被拒绝</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1031,6 +1031,11 @@
     <string name="cd_add_image">Add image</string>
     <string name="cd_open_camera">Open camera</string>
     <string name="cd_close_camera">Close camera</string>
+    <string name="cd_save_photo">Save photo</string>
+    <string name="gallery_folder_name">Fud AI</string>
+    <string name="photo_saved_to_gallery">Photo saved</string>
+    <string name="photo_save_failed">Couldn\u2019t save photo</string>
+    <string name="photo_save_permission_denied">Photo access denied</string>
 
     <!-- Localization pass: previously hardcoded UI strings -->
     <string name="unit_mcg">mcg</string>

--- a/ios/calorietracker.xcodeproj/project.pbxproj
+++ b/ios/calorietracker.xcodeproj/project.pbxproj
@@ -703,6 +703,7 @@
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Read your weight, height, body composition, nutrition, and Fud AI workout calories to keep your history in sync.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "Write, update, or remove your nutrition, body measurements, and calculated workout calories when you change your logs.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Fud AI needs microphone access so you can log food by voice.";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Fud AI saves meal photos to your photo library when you tap Save.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Fud AI uses speech recognition to convert your voice into text for food logging.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -755,6 +756,7 @@
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Read your weight, height, body composition, nutrition, and Fud AI workout calories to keep your history in sync.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "Write, update, or remove your nutrition, body measurements, and calculated workout calories when you change your logs.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Fud AI needs microphone access so you can log food by voice.";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Fud AI saves meal photos to your photo library when you tap Save.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Fud AI uses speech recognition to convert your voice into text for food logging.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/ios/calorietracker/InfoPlist.xcstrings
+++ b/ios/calorietracker/InfoPlist.xcstrings
@@ -101,6 +101,107 @@
           }
         }
       }
+    },
+    "NSPhotoLibraryAddUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يحفظ Fud AI صور الوجبات في مكتبة الصور عند النقر على حفظ."
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fud AI \"Yadda saxla\" düyməsinə toxunanda yemək şəkillərini foto kitabxananıza yadda saxlayır."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fud AI speichert Mahlzeitfotos in deiner Fotomediathek, wenn du auf Speichern tippst."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fud AI saves meal photos to your photo library when you tap Save."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fud AI guarda fotos de comidas en tu biblioteca de fotos cuando tocas Guardar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fud AI enregistre les photos de repas dans votre photothèque lorsque vous touchez Enregistrer."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जब आप सहेजें पर टैप करते हैं, तो Fud AI भोजन की तस्वीरें आपकी फोटो लाइब्रेरी में सहेजता है।"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fud AI salva le foto dei pasti nella libreria foto quando tocchi Salva."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fud AIは「保存」をタップすると、食事の写真をフォトライブラリに保存します。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fud AI는 저장을 탭하면 식사 사진을 사진 보관함에 저장합니다."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fud AI slaat maaltijdfoto's op in je fotobibliotheek wanneer je op Opslaan tikt."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fud AI zapisuje zdjęcia posiłków w bibliotece zdjęć po dotknięciu Zapisz."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Fud AI salva fotos de refeições na sua biblioteca de fotos quando você toca em Salvar."
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fud AI salvează fotografiile meselor în biblioteca foto când atingi Salvează."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fud AI сохраняет фото блюд в медиатеку, когда вы нажимаете «Сохранить»."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当你点按“保存”时，Fud AI 会将餐食照片保存到照片图库。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/ios/calorietracker/Localizable.xcstrings
+++ b/ios/calorietracker/Localizable.xcstrings
@@ -48594,7 +48594,107 @@
     },
     "%@ burned · %@ deficit": {},
     "%@ burned · %@ surplus": {},
-    "%@ burned · balanced": {}
+    "%@ burned · balanced": {},
+    "Couldn't save photo": {
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "تعذر حفظ الصورة" } },
+        "az": { "stringUnit": { "state": "translated", "value": "Şəkil yadda saxlanmadı" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Foto konnte nicht gespeichert werden" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Couldn't save photo" } },
+        "es": { "stringUnit": { "state": "translated", "value": "No se pudo guardar la foto" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Impossible d'enregistrer la photo" } },
+        "hi": { "stringUnit": { "state": "translated", "value": "फ़ोटो सहेजी नहीं जा सकी" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Impossibile salvare la foto" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "写真を保存できませんでした" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "사진을 저장할 수 없습니다" } },
+        "nl": { "stringUnit": { "state": "translated", "value": "Kon foto niet opslaan" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Nie udało się zapisać zdjęcia" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Não foi possível salvar a foto" } },
+        "ro": { "stringUnit": { "state": "translated", "value": "Fotografia nu a putut fi salvată" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Не удалось сохранить фото" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "无法保存照片" } }
+      }
+    },
+    "Photo access denied": {
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "تم رفض الوصول إلى الصور" } },
+        "az": { "stringUnit": { "state": "translated", "value": "Foto girişinə icazə verilmədi" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Fotozugriff verweigert" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Photo access denied" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Acceso a fotos denegado" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Accès aux photos refusé" } },
+        "hi": { "stringUnit": { "state": "translated", "value": "फ़ोटो एक्सेस अस्वीकृत" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Accesso alle foto negato" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "写真へのアクセスが拒否されました" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "사진 접근이 거부되었습니다" } },
+        "nl": { "stringUnit": { "state": "translated", "value": "Fototoegang geweigerd" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Odmowa dostępu do zdjęć" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Acesso às fotos negado" } },
+        "ro": { "stringUnit": { "state": "translated", "value": "Acces la fotografii refuzat" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Доступ к фото запрещён" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "照片访问被拒绝" } }
+      }
+    },
+    "Photo saved": {
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "تم حفظ الصورة" } },
+        "az": { "stringUnit": { "state": "translated", "value": "Şəkil yadda saxlanıldı" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Foto gespeichert" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Photo saved" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Foto guardada" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Photo enregistrée" } },
+        "hi": { "stringUnit": { "state": "translated", "value": "फ़ोटो सहेजी गई" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Foto salvata" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "写真を保存しました" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "사진 저장됨" } },
+        "nl": { "stringUnit": { "state": "translated", "value": "Foto opgeslagen" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Zdjęcie zapisane" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Foto salva" } },
+        "ro": { "stringUnit": { "state": "translated", "value": "Fotografie salvată" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Фото сохранено" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "照片已保存" } }
+      }
+    },
+    "Save photo": {
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "حفظ الصورة" } },
+        "az": { "stringUnit": { "state": "translated", "value": "Şəkli yadda saxla" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Foto speichern" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Save photo" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Guardar foto" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Enregistrer la photo" } },
+        "hi": { "stringUnit": { "state": "translated", "value": "फ़ोटो सहेजें" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Salva foto" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "写真を保存" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "사진 저장" } },
+        "nl": { "stringUnit": { "state": "translated", "value": "Foto opslaan" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Zapisz zdjęcie" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Salvar foto" } },
+        "ro": { "stringUnit": { "state": "translated", "value": "Salvează fotografia" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Сохранить фото" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "保存照片" } }
+      }
+    },
+    "Save Photo": {
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "حفظ الصورة" } },
+        "az": { "stringUnit": { "state": "translated", "value": "Şəkli yadda saxla" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Foto speichern" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Save Photo" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Guardar foto" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Enregistrer la photo" } },
+        "hi": { "stringUnit": { "state": "translated", "value": "फ़ोटो सहेजें" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Salva foto" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "写真を保存" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "사진 저장" } },
+        "nl": { "stringUnit": { "state": "translated", "value": "Foto opslaan" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Zapisz zdjęcie" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Salvar foto" } },
+        "ro": { "stringUnit": { "state": "translated", "value": "Salvează fotografia" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Сохранить фото" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "保存照片" } }
+      }
+    }
   },
   "version": "1.1"
 }

--- a/ios/calorietracker/Views/FullScreenImageViewer.swift
+++ b/ios/calorietracker/Views/FullScreenImageViewer.swift
@@ -304,13 +304,22 @@ private struct ZoomableMealPhotoScrollView: UIViewRepresentable {
             isZoomed = false
         }
 
-        context.coordinator.layoutImage(in: scrollView)
+        let isAtMinZoom = scrollView.zoomScale <= scrollView.minimumZoomScale + 0.01
+        let boundsChanged = scrollView.bounds.size != context.coordinator.lastLayoutBounds
+        let imageChanged = context.coordinator.lastLayoutImage !== image
+        if isAtMinZoom && (boundsChanged || imageChanged) {
+            context.coordinator.layoutImage(in: scrollView)
+            context.coordinator.lastLayoutBounds = scrollView.bounds.size
+            context.coordinator.lastLayoutImage = image
+        }
     }
 
     final class Coordinator: NSObject, UIScrollViewDelegate {
         var parent: ZoomableMealPhotoScrollView
         weak var scrollView: UIScrollView?
         weak var imageView: UIImageView?
+        var lastLayoutBounds: CGSize = .zero
+        var lastLayoutImage: UIImage?
 
         init(parent: ZoomableMealPhotoScrollView) {
             self.parent = parent

--- a/ios/calorietracker/Views/FullScreenImageViewer.swift
+++ b/ios/calorietracker/Views/FullScreenImageViewer.swift
@@ -1,4 +1,6 @@
+import Photos
 import SwiftUI
+import UIKit
 
 /// Session payload for presenting one or more meal photos full-screen.
 struct FullScreenImagePreview: Identifiable {
@@ -12,7 +14,13 @@ struct FullScreenImagePreview: Identifiable {
     }
 }
 
-/// Full-screen meal photo viewer with page swipe (multi-photo), close button, and swipe-down dismiss.
+private enum MealPhotoSaveOutcome {
+    case saved
+    case permissionDenied
+    case failed
+}
+
+/// Full-screen meal photo viewer with pinch/double-tap zoom, page swipe, save, close, and swipe-down dismiss.
 struct FullScreenImageViewer: View {
     let images: [UIImage]
     let initialIndex: Int
@@ -22,11 +30,20 @@ struct FullScreenImageViewer: View {
     @State private var dragOffset: CGFloat = 0
     @State private var backdropOpacity: Double = 1
     @State private var verticalDismissCommitted = false
+    @State private var zoomedPages: Set<Int> = []
+    @State private var isSaving = false
+    @State private var saveBanner: String?
+
+    private let doubleTapZoomScale: CGFloat = 2.5
 
     init(images: [UIImage], initialIndex: Int = 0) {
         self.images = images
         self.initialIndex = initialIndex
         _currentIndex = State(initialValue: min(max(0, initialIndex), max(images.count - 1, 0)))
+    }
+
+    private var isCurrentPageZoomed: Bool {
+        zoomedPages.contains(currentIndex)
     }
 
     var body: some View {
@@ -37,15 +54,27 @@ struct FullScreenImageViewer: View {
 
             TabView(selection: $currentIndex) {
                 ForEach(Array(images.enumerated()), id: \.offset) { index, image in
-                    Image(uiImage: image)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .tag(index)
-                        .accessibilityLabel("Photo \(index + 1)")
+                    ZoomableMealPhotoPage(
+                        image: image,
+                        doubleTapZoomScale: doubleTapZoomScale,
+                        isActive: currentIndex == index,
+                        isZoomed: Binding(
+                            get: { zoomedPages.contains(index) },
+                            set: { zoomed in
+                                if zoomed {
+                                    zoomedPages.insert(index)
+                                } else {
+                                    zoomedPages.remove(index)
+                                }
+                            }
+                        )
+                    )
+                    .tag(index)
+                    .accessibilityLabel(String(localized: "Photo \(index + 1)"))
                 }
             }
             .tabViewStyle(.page(indexDisplayMode: images.count > 1 ? .automatic : .never))
+            .scrollDisabled(isCurrentPageZoomed)
             .offset(y: dragOffset)
 
             VStack {
@@ -71,20 +100,62 @@ struct FullScreenImageViewer: View {
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
-                    .accessibilityLabel("Close")
+                    .accessibilityLabel(String(localized: "Close"))
                 }
                 .padding(.horizontal, 16)
                 .padding(.top, 8)
+
                 Spacer()
+
+                Button {
+                    Task { await saveCurrentPhoto() }
+                } label: {
+                    HStack(spacing: 8) {
+                        if isSaving {
+                            ProgressView()
+                                .tint(.white)
+                        } else {
+                            Image(systemName: "square.and.arrow.down")
+                                .font(.system(size: 15, weight: .semibold))
+                        }
+                        Text("Save Photo", comment: "Save the current meal photo to the device photo library")
+                            .font(.subheadline.weight(.semibold))
+                    }
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 10)
+                    .background(.white.opacity(0.22), in: Capsule())
+                }
+                .buttonStyle(.plain)
+                .disabled(isSaving)
+                .accessibilityLabel(String(localized: "Save photo"))
+                .padding(.bottom, 28)
+            }
+
+            if let saveBanner {
+                VStack {
+                    Spacer()
+                    Text(saveBanner)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                        .background(.black.opacity(0.72), in: Capsule())
+                        .padding(.bottom, 96)
+                }
+                .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }
         .statusBarHidden(true)
         .simultaneousGesture(
             DragGesture(minimumDistance: 24)
                 .onChanged { value in
+                    guard !isCurrentPageZoomed else {
+                        verticalDismissCommitted = false
+                        return
+                    }
                     let vertical = value.translation.height
                     let horizontal = abs(value.translation.width)
-                    // Prefer vertical dismiss; ignore mostly-horizontal page swipes.
                     guard abs(vertical) > horizontal else {
                         verticalDismissCommitted = false
                         return
@@ -94,6 +165,14 @@ struct FullScreenImageViewer: View {
                     backdropOpacity = Double(max(0.35, 1 - abs(vertical) / 420))
                 }
                 .onEnded { value in
+                    guard !isCurrentPageZoomed else {
+                        verticalDismissCommitted = false
+                        withAnimation(.spring(response: 0.32, dampingFraction: 0.86)) {
+                            dragOffset = 0
+                            backdropOpacity = 1
+                        }
+                        return
+                    }
                     let vertical = value.translation.height
                     let horizontal = abs(value.translation.width)
                     guard verticalDismissCommitted, abs(vertical) > horizontal else {
@@ -117,6 +196,194 @@ struct FullScreenImageViewer: View {
                     }
                 }
         )
+    }
+
+    @MainActor
+    private func saveCurrentPhoto() async {
+        guard images.indices.contains(currentIndex), !isSaving else { return }
+        isSaving = true
+        defer { isSaving = false }
+
+        let outcome = await saveImageToPhotoLibrary(images[currentIndex])
+        let message: String
+        switch outcome {
+        case .saved:
+            message = String(localized: "Photo saved")
+        case .permissionDenied:
+            message = String(localized: "Photo access denied")
+        case .failed:
+            message = String(localized: "Couldn't save photo")
+        }
+
+        withAnimation(.easeInOut(duration: 0.2)) {
+            saveBanner = message
+        }
+        try? await Task.sleep(for: .seconds(2))
+        withAnimation(.easeInOut(duration: 0.2)) {
+            saveBanner = nil
+        }
+    }
+
+    private func saveImageToPhotoLibrary(_ image: UIImage) async -> MealPhotoSaveOutcome {
+        let status = await PHPhotoLibrary.requestAuthorization(for: .addOnly)
+        guard status == .authorized || status == .limited else {
+            return .permissionDenied
+        }
+
+        return await withCheckedContinuation { continuation in
+            PHPhotoLibrary.shared().performChanges({
+                PHAssetCreationRequest.creationRequestForAsset(from: image)
+            }) { success, _ in
+                continuation.resume(returning: success ? .saved : .failed)
+            }
+        }
+    }
+}
+
+private struct ZoomableMealPhotoPage: View {
+    let image: UIImage
+    let doubleTapZoomScale: CGFloat
+    let isActive: Bool
+    @Binding var isZoomed: Bool
+
+    var body: some View {
+        ZoomableMealPhotoScrollView(
+            image: image,
+            doubleTapZoomScale: doubleTapZoomScale,
+            isActive: isActive,
+            isZoomed: $isZoomed
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+private struct ZoomableMealPhotoScrollView: UIViewRepresentable {
+    let image: UIImage
+    let doubleTapZoomScale: CGFloat
+    let isActive: Bool
+    @Binding var isZoomed: Bool
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeUIView(context: Context) -> UIScrollView {
+        let scrollView = UIScrollView()
+        scrollView.delegate = context.coordinator
+        scrollView.minimumZoomScale = 1
+        scrollView.maximumZoomScale = max(doubleTapZoomScale, 4)
+        scrollView.bouncesZoom = true
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.backgroundColor = .clear
+        scrollView.contentInsetAdjustmentBehavior = .never
+
+        let imageView = UIImageView(image: image)
+        imageView.contentMode = .scaleAspectFit
+        imageView.isUserInteractionEnabled = true
+        scrollView.addSubview(imageView)
+        context.coordinator.imageView = imageView
+        context.coordinator.scrollView = scrollView
+
+        let doubleTap = UITapGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handleDoubleTap(_:))
+        )
+        doubleTap.numberOfTapsRequired = 2
+        scrollView.addGestureRecognizer(doubleTap)
+
+        return scrollView
+    }
+
+    func updateUIView(_ scrollView: UIScrollView, context: Context) {
+        context.coordinator.parent = self
+        context.coordinator.imageView?.image = image
+
+        if !isActive, scrollView.zoomScale > scrollView.minimumZoomScale + 0.01 {
+            scrollView.setZoomScale(scrollView.minimumZoomScale, animated: false)
+            isZoomed = false
+        }
+
+        context.coordinator.layoutImage(in: scrollView)
+    }
+
+    final class Coordinator: NSObject, UIScrollViewDelegate {
+        var parent: ZoomableMealPhotoScrollView
+        weak var scrollView: UIScrollView?
+        weak var imageView: UIImageView?
+
+        init(parent: ZoomableMealPhotoScrollView) {
+            self.parent = parent
+        }
+
+        func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+            imageView
+        }
+
+        func scrollViewDidZoom(_ scrollView: UIScrollView) {
+            centerImage(in: scrollView)
+            parent.isZoomed = scrollView.zoomScale > scrollView.minimumZoomScale + 0.01
+        }
+
+        func scrollViewDidEndZooming(_ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat) {
+            parent.isZoomed = scale > scrollView.minimumZoomScale + 0.01
+        }
+
+        @objc func handleDoubleTap(_ recognizer: UITapGestureRecognizer) {
+            guard let scrollView, let imageView else { return }
+
+            if scrollView.zoomScale > scrollView.minimumZoomScale + 0.01 {
+                scrollView.setZoomScale(scrollView.minimumZoomScale, animated: true)
+                return
+            }
+
+            let targetScale = min(parent.doubleTapZoomScale, scrollView.maximumZoomScale)
+            let point = recognizer.location(in: imageView)
+            let zoomRect = zoomRect(for: targetScale, center: point, in: scrollView)
+            scrollView.zoom(to: zoomRect, animated: true)
+        }
+
+        func layoutImage(in scrollView: UIScrollView) {
+            guard let imageView, let image = imageView.image else { return }
+            let bounds = scrollView.bounds
+            guard bounds.width > 0, bounds.height > 0 else { return }
+
+            let imageSize = image.size
+            guard imageSize.width > 0, imageSize.height > 0 else { return }
+
+            let widthScale = bounds.width / imageSize.width
+            let heightScale = bounds.height / imageSize.height
+            let fitScale = min(widthScale, heightScale)
+            let fittedSize = CGSize(width: imageSize.width * fitScale, height: imageSize.height * fitScale)
+
+            imageView.frame = CGRect(origin: .zero, size: fittedSize)
+            scrollView.contentSize = fittedSize
+            centerImage(in: scrollView)
+        }
+
+        private func centerImage(in scrollView: UIScrollView) {
+            guard let imageView else { return }
+            let boundsSize = scrollView.bounds.size
+            var frame = imageView.frame
+
+            frame.origin.x = frame.size.width < boundsSize.width
+                ? (boundsSize.width - frame.size.width) / 2
+                : frame.origin.x
+            frame.origin.y = frame.size.height < boundsSize.height
+                ? (boundsSize.height - frame.size.height) / 2
+                : frame.origin.y
+
+            imageView.frame = frame
+        }
+
+        private func zoomRect(for scale: CGFloat, center: CGPoint, in scrollView: UIScrollView) -> CGRect {
+            let size = scrollView.bounds.size
+            let width = size.width / scale
+            let height = size.height / scale
+            let originX = center.x - width / 2
+            let originY = center.y - height / 2
+            return CGRect(x: originX, y: originY, width: width, height: height)
+        }
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes remaining work for #191 on top of the basic fullscreen viewer shipped in #211 / PR #245.

## Changes
- **iOS** (`FullScreenImageViewer.swift`): UIScrollView-backed pinch/double-tap zoom (~2.5×), pan while zoomed, `scrollDisabled` paging at 1×, swipe-down dismiss only when not zoomed, Save button via `PHPhotoLibrary` add-only access.
- **Android** (`FullScreenImageViewer.kt` + `MealPhotoGalleryExport.kt`): pinch/double-tap zoom with pager scroll disabled while zoomed, vertical dismiss only at 1×, Save to `Pictures/Fud AI` via MediaStore (API 29+ no prompt; API 26–28 uses `WRITE_EXTERNAL_STORAGE` + legacy file write).
- **Permissions / strings**: Android manifest storage permission (maxSdk 28), iOS `NSPhotoLibraryAddUsageDescription`, localized save/status strings on both platforms.

Existing behavior preserved: ✕ close, Android back, swipe-down dismiss, page counter, multi-photo paging.

## Test plan
- [ ] **Open viewer** from Edit Entry and Food Result on both platforms; confirm starts on tapped photo and shows `N/M` counter for multi-photo meals.
- [ ] **Pinch** to zoom in/out; **double-tap** toggles fit ↔ ~2.5×.
- [ ] While zoomed, **drag** pans the photo; horizontal **paging is disabled**.
- [ ] Zoom back to 1×; **swipe left/right** pages between photos again.
- [ ] **Swipe down** (iOS) / vertical drag (Android) dismisses only at 1×; ✕ and Android back still dismiss.
- [ ] Tap **Save** on current photo:
  - iOS: grant add-only Photos permission if prompted → photo appears in Photos library.
  - Android API 29+: photo appears in Gallery under `Pictures/Fud AI` without storage prompt.
  - Android API 26–28: grant storage permission if prompted → photo saved under `Pictures/Fud AI`.
- [ ] Deny permission → shows permission-denied message; simulate save failure if possible → shows failure toast/banner.

Fixes #191
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e58878ed-d8ce-457f-a266-9a01fa135f02?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e58878ed-d8ce-457f-a266-9a01fa135f02&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pinch-to-zoom, double-tap zoom, and panning for meal photos in the full-screen viewer.
  * Added an option to save the currently viewed photo to the device gallery.
  * Added success, failure, and permission feedback when saving photos.
* **Localization**
  * Added translated photo-saving labels and messages across supported languages.
* **Permissions**
  * Added the required photo-library and storage permission prompts for supported Android and iOS versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds zoomable fullscreen meal photos and gallery export on Android and iOS.
- Adds pinch, double-tap zoom, and panning while disabling paging and dismissal when zoomed.
- Adds Android MediaStore and legacy external-storage export paths.
- Adds iOS photo-library saving with add-only authorization.
- Adds the required permissions and localized save-status text.
- The changes since the previous review only remove an unnecessary Android import and correct escaping in a French string resource.

<h3>Confidence Score: 0/5</h3>

The PR does not appear safe to merge because multiple previously reported gesture and gallery-export failures remain unresolved.

Android pinch handling still keys `pointerInput` on the live zoom threshold and can restart the handler as zoom begins. Vertical dismissal still compares each individual pointer event against touch slop rather than accumulating movement. Double-tap centering was corrected relative to the viewport center, but its translation remains unclamped to the scaled image bounds. The Android MediaStore path still reports success without checking whether publishing the pending row updated anything and does not remove that row when finalization fails; the legacy path still leaves the written file behind when registration fails. The iOS representable still records zero bounds after a failed initial layout without a layout-driven retry, so an initially zero-sized single-photo viewer can remain blank.

**Files Needing Attention:** android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/FullScreenImageViewer.kt, android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/MealPhotoGalleryExport.kt, ios/calorietracker/Views/FullScreenImageViewer.swift

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/FullScreenImageViewer.kt | Adds zoom, pan, dismissal coordination, and save controls; several previously reported gesture defects remain outstanding. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/MealPhotoGalleryExport.kt | Adds modern and legacy gallery export paths; previously reported finalization and cleanup failures remain outstanding. |
| ios/calorietracker/Views/FullScreenImageViewer.swift | Adds UIScrollView-backed zooming and photo-library export; the previously reported zero-bounds initial-layout issue remains. |
| android/app/src/main/res/values-fr/strings.xml | Correctly escapes the apostrophe in the localized photo-save failure message. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Fullscreen meal photo] --> B{User action}
    B -->|Pinch or double-tap| C[Zoom and pan]
    C --> D{At minimum zoom?}
    D -->|Yes| E[Enable paging and dismiss gesture]
    D -->|No| F[Disable paging and dismiss gesture]
    B -->|Save| G{Platform}
    G -->|iOS| H[Request add-only Photos access]
    H --> I[Write image to photo library]
    G -->|Android 10+| J[Insert pending MediaStore row]
    J --> K[Write JPEG]
    K --> L[Publish MediaStore row]
    G -->|Android 8–9| M[Request storage permission]
    M --> N[Write JPEG and register with MediaStore]
```

<sub>Reviews (2): Last reviewed commit: ["fix(android): unblock PR #258 CI compile..."](https://github.com/apoorvdarshan/fud-ai/commit/e32b20205a586b26d5947a07501c667493712827) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62934930)</sub>

<!-- /greptile_comment -->