### PR TITLE
fix(ios): HealthKit workout import compile error

### DIFF
--- a/ios/calorietracker/Stores/HealthKitManager.swift
+++ b/ios/calorietracker/Stores/HealthKitManager.swift
@@ -1480,7 +1480,7 @@ class HealthKitManager {
         let predicate = HKQuery.predicateForSamples(withStart: start, end: nil, options: .strictStartDate)
         let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)
 
-        return await withCheckedContinuation { continuation in
+        return await withCheckedContinuation { (continuation: CheckedContinuation<[ImportedHealthWorkout]?, Never>) in
             let query = HKSampleQuery(
                 sampleType: type,
                 predicate: predicate,


### PR DESCRIPTION
## Summary
- Fixes Release build failure: `nil` not compatible with `[ImportedHealthWorkout]` in workout fetch continuation.

## Test plan
- [x] iOS Release build


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes an iOS Release-build type-inference failure by explicitly declaring the workout-fetch continuation’s optional result type.
- Aligns the continuation with `fetchImportedWorkouts`’s `[ImportedHealthWorkout]?` return type.
- Preserves existing behavior for failed queries and successful workout results.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the annotation matches the function contract and preserves all existing result paths.

No actionable failures were found; query errors still return nil, successful queries still return mapped arrays, and the caller handles both outcomes as intended.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ios/calorietracker/Stores/HealthKitManager.swift | Adds a type-consistent continuation annotation to resolve the Release compilation error without changing runtime behavior. |

<sub>Reviews (1): Last reviewed commit: ["Fix HealthKit workout import compile err..."](https://github.com/apoorvdarshan/fud-ai/commit/5113b78dd8901e998f030210f0454e2311ff0e7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62935271)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Clarified internal type annotations for improved code readability.
  - No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->