### PR TITLE
fix(ios): HKWorkout compactMap compile error

### DIFF
--- a/ios/calorietracker/Stores/HealthKitManager.swift
+++ b/ios/calorietracker/Stores/HealthKitManager.swift
@@ -1491,7 +1491,7 @@ class HealthKitManager {
                     continuation.resume(returning: nil)
                     return
                 }
-                let mapped = samples.compactMap(ImportedHealthWorkout.from)
+                let mapped = samples.compactMap { ImportedHealthWorkout.from($0) }
                 continuation.resume(returning: mapped)
             }
             healthStore.execute(query)


### PR DESCRIPTION
Fixes Release build: method reference with default Calendar arg.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the iOS Release build by replacing a Swift method reference whose declaration has a default `Calendar` argument with an explicit closure.
- Preserves compact-map filtering and workout conversion behavior.
- Correctly allows Swift to apply the method’s default argument at the call site.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the closure preserves the intended workout conversion behavior while resolving the compilation failure.

The changed closure accepts the existing `HKWorkout` element type, calls the only matching conversion method, applies its default calendar argument, and retains `compactMap` filtering semantics.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ios/calorietracker/Stores/HealthKitManager.swift | Replaces the incompatible `compactMap` method reference with an equivalent explicit closure. |

<sub>Reviews (1): Last reviewed commit: ["Fix HKWorkout compactMap method referenc..."](https://github.com/apoorvdarshan/fud-ai/commit/5da4daeb72f6b3996cd676f55c8859f53260f779) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62935553)</sub>

<!-- /greptile_comment -->