### PR TITLE
Move Walk & Run toggle into Workout settings

### DIFF
--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt
@@ -888,12 +888,40 @@ fun SettingsScreen(container: AppContainer, nav: NavHostController, vm: Settings
                         icon = Icons.Outlined.TrackChanges
                     ) { sheet = SettingsSheet.FASTING_GOAL }
                 }
-                HorizontalDivider()
+            }
+            }
+
+            // Workout is permanently available. Keep its live preferences in the
+            // same compact Fud AI settings card.
+            if (selectedCategory == SettingsCategory.WORKOUT) {
+            SectionCard {
                 ToggleRow(
                     stringResource(R.string.settings_walk_run_quick_log),
                     ui.walkRunQuickLogEnabled,
                     icon = Icons.AutoMirrored.Outlined.DirectionsWalk,
                     onChange = vm::setWalkRunQuickLogEnabled
+                )
+                HorizontalDivider()
+                SettingRow(
+                    stringResource(R.string.settings_training_split),
+                    ui.workoutSplit.title,
+                    icon = Icons.Outlined.FitnessCenter,
+                    inlineMenu = true
+                ) { sheet = SettingsSheet.WORKOUT_SPLIT }
+                HorizontalDivider()
+                SettingRow(
+                    stringResource(R.string.settings_rpe_scale),
+                    ui.workoutRpeScale.title,
+                    icon = Icons.Outlined.Speed,
+                    inlineMenu = true
+                ) { sheet = SettingsSheet.WORKOUT_RPE }
+                HorizontalDivider()
+                Text(
+                    stringResource(R.string.settings_rpe_guide),
+                    fontSize = 12.sp,
+                    lineHeight = 18.sp,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f),
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp)
                 )
             }
             }
@@ -1221,34 +1249,6 @@ fun SettingsScreen(container: AppContainer, nav: NavHostController, vm: Settings
                 Text(
                     stringResource(R.string.settings_custom_instructions_footer),
                     fontSize = 12.sp,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f),
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp)
-                )
-            }
-            }
-
-            // Workout is permanently available. Keep its only two live
-            // preferences in the same compact Fud AI settings card.
-            if (selectedCategory == SettingsCategory.WORKOUT) {
-            SectionCard {
-                SettingRow(
-                    stringResource(R.string.settings_training_split),
-                    ui.workoutSplit.title,
-                    icon = Icons.Outlined.FitnessCenter,
-                    inlineMenu = true
-                ) { sheet = SettingsSheet.WORKOUT_SPLIT }
-                HorizontalDivider()
-                SettingRow(
-                    stringResource(R.string.settings_rpe_scale),
-                    ui.workoutRpeScale.title,
-                    icon = Icons.Outlined.Speed,
-                    inlineMenu = true
-                ) { sheet = SettingsSheet.WORKOUT_RPE }
-                HorizontalDivider()
-                Text(
-                    stringResource(R.string.settings_rpe_guide),
-                    fontSize = 12.sp,
-                    lineHeight = 18.sp,
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f),
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp)
                 )

--- a/ios/calorietracker/ContentView.swift
+++ b/ios/calorietracker/ContentView.swift
@@ -4035,7 +4035,6 @@ struct ProfileView: View {
     @AppStorage(WaterSettings.unitKey) private var waterUnitRaw = WaterUnit.defaultUnit.rawValue
     @AppStorage(FastingSettings.enabledKey) private var fastingTrackingEnabled = false
     @AppStorage(FastingSettings.defaultGoalMinutesKey) private var fastingDefaultGoalMinutes = FastingSettings.defaultGoalMinutes
-    @AppStorage(OutdoorActivitySettings.enabledKey) private var walkRunQuickLogEnabled = false
 
     private var waterUnit: WaterUnit { WaterUnit(rawValue: waterUnitRaw) ?? .defaultUnit }
 
@@ -4745,19 +4744,6 @@ struct ProfileView: View {
                                     notificationManager.cancelFastingGoal()
                                 }
                             }
-                    }
-
-                    HStack {
-                        Label {
-                            Text("Walk & Run")
-                        } icon: {
-                            Image(systemName: "figure.walk")
-                                .foregroundStyle(AppColors.calorie)
-                        }
-                        Spacer()
-                        Toggle("Walk & Run", isOn: $walkRunQuickLogEnabled)
-                            .labelsHidden()
-                            .tint(AppColors.calorie)
                     }
 
                     if fastingTrackingEnabled {

--- a/ios/calorietracker/Views/WorkoutLoggingSettingsView.swift
+++ b/ios/calorietracker/Views/WorkoutLoggingSettingsView.swift
@@ -3,12 +3,26 @@ import SwiftUI
 /// Workout preferences embedded directly in Fud AI's main Settings list.
 struct WorkoutLoggingSettingsSection: View {
     @Environment(StrengthWorkoutStore.self) private var workoutStore
+    @AppStorage(OutdoorActivitySettings.enabledKey) private var walkRunQuickLogEnabled = false
 
     @State private var draft = StrengthWorkoutPreferences()
     @State private var hasLoaded = false
 
     var body: some View {
         Section {
+            HStack {
+                Label {
+                    Text("Walk & Run")
+                } icon: {
+                    Image(systemName: "figure.walk")
+                        .foregroundStyle(AppColors.calorie)
+                }
+                Spacer()
+                Toggle("Walk & Run", isOn: $walkRunQuickLogEnabled)
+                    .labelsHidden()
+                    .tint(AppColors.calorie)
+            }
+
             WorkoutSplitPickerRow(
                 title: "Training Split",
                 systemImage: "square.grid.2x2.fill",
@@ -24,6 +38,8 @@ struct WorkoutLoggingSettingsSection: View {
             rpeScaleGuide
         } header: {
             Text("Workout")
+        } footer: {
+            Text("When on, Walking and Running appear in the Home + menu for quick outdoor logs.")
         }
         .listRowBackground(AppColors.appCard)
         .onAppear(perform: loadPreferences)


### PR DESCRIPTION
## Summary
- Moves the Walk & Run opt-in from Tracking & Reminders into Settings → Workout on iOS and Android.
- Home + menu behavior unchanged (still off by default).

## Test plan
- [ ] Settings → Workout shows Walk & Run toggle
- [ ] Tracking & Reminders no longer shows it
- [ ] Enabling still adds Walking/Running to Home +

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR consistently relocates the Walk & Run preference from Tracking & Reminders into Workout settings on both platforms while preserving its existing storage and Home + behavior.
- Android moves the toggle into the existing Workout settings card.
- iOS moves the same AppStorage-backed toggle into the Workout section and adds explanatory footer text.
- No actionable correctness, security, or repository-rule issues were identified.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the setting is reachable in its new location on both platforms and continues to control the existing Home + behavior.

The relocation preserves the Android view-model binding and the iOS AppStorage key and default, while cleanly removing the old controls without disrupting adjacent settings.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt | Moves the Walk & Run toggle into the independently rendered Workout settings card without changing its view-model binding. |
| ios/calorietracker/ContentView.swift | Removes the Walk & Run preference and its now-unused AppStorage binding from Tracking & Reminders. |
| ios/calorietracker/Views/WorkoutLoggingSettingsView.swift | Adds the existing AppStorage-backed Walk & Run toggle and explanatory footer to Workout settings. |

<sub>Reviews (1): Last reviewed commit: ["Move Walk &amp; Run toggle into Workout sett..."](https://github.com/apoorvdarshan/fud-ai/commit/0b696473e7208c057786d5361da2e32f56154a97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62955766)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Walk & Run quick-log toggle to Workout settings on Android and iOS.
  - Added guidance explaining that enabling the toggle makes Walking and Running available from the Home quick-log menu.
- **Improvements**
  - Consolidated workout-related controls, including training split, RPE guidance, and Walk & Run quick logging, in the Workout settings area.
  - Removed the duplicate Walk & Run toggle from iOS Tracking & Reminders settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->