### PR TITLE
Move Walk/Run quick log to Workouts + menu

### DIFF
--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
@@ -248,7 +248,6 @@ DisposableEffect(lifecycleOwner, vm) {
     val selectionMode = selectedFoodIds.isNotEmpty()
     var showNutritionDetail by remember { mutableStateOf(false) }
     var showCustomWaterLog by remember { mutableStateOf(false) }
-    var outdoorActivitySheet by remember { mutableStateOf<OutdoorActivityKind?>(null) }
     var showFastingStart by remember { mutableStateOf(false) }
     var editingFast by remember { mutableStateOf<FastingSession?>(null) }
     var pendingDiaryDeletion by remember { mutableStateOf<HomeDiaryItem?>(null) }
@@ -723,18 +722,6 @@ CalorieHero(
                                 SheetGlassDropdownMenuItem(label = stringResource(R.string.fasting), leadingIcon = Icons.Filled.Timer, trailingIcon = Icons.Filled.ChevronRight) { addMenuGroup = AddMenuGroup.Fasting }
                             }
                         }
-                        if (ui.walkRunQuickLogEnabled) {
-                            SheetGlassDropdownMenuItem(label = stringResource(R.string.outdoor_activity_walking), leadingIcon = Icons.AutoMirrored.Outlined.DirectionsWalk) {
-                                showAddMenu = false
-                                addMenuGroup = null
-                                outdoorActivitySheet = OutdoorActivityKind.WALKING
-                            }
-                            SheetGlassDropdownMenuItem(label = stringResource(R.string.outdoor_activity_running), leadingIcon = Icons.AutoMirrored.Filled.DirectionsRun) {
-                                showAddMenu = false
-                                addMenuGroup = null
-                                outdoorActivitySheet = OutdoorActivityKind.RUNNING
-                            }
-                        }
                     }
 
                     AddMenuGroup.PhotoAndScan -> {
@@ -805,14 +792,6 @@ CalorieHero(
             unit = ui.waterUnit,
             onDismiss = { showCustomWaterLog = false },
             onAdd = vm::addWater
-        )
-    }
-
-    outdoorActivitySheet?.let { activity ->
-        OutdoorActivityDurationSheet(
-            activity = activity,
-            onDismiss = { outdoorActivitySheet = null },
-            onLog = { minutes -> vm.logQuickOutdoorActivity(activity, minutes) }
         )
     }
 

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt
@@ -13,11 +13,8 @@ import com.apoorvdarshan.calorietracker.models.MealType
 import com.apoorvdarshan.calorietracker.models.OptionalNutrientGoals
 import com.apoorvdarshan.calorietracker.models.PendingFoodAnalysisDraft
 import com.apoorvdarshan.calorietracker.models.UserProfile
-import com.apoorvdarshan.calorietracker.data.ExerciseRepository
-import com.apoorvdarshan.calorietracker.models.OutdoorActivitySettings
 import com.apoorvdarshan.calorietracker.models.WaterEntry
 import com.apoorvdarshan.calorietracker.models.WaterUnit
-import com.apoorvdarshan.calorietracker.models.WorkoutWeightUnit
 import com.apoorvdarshan.calorietracker.services.CalorieBalanceDirection
 import com.apoorvdarshan.calorietracker.services.DailySummaryPolicy
 import com.apoorvdarshan.calorietracker.services.OpenFoodFactsService
@@ -75,7 +72,6 @@ data class HomeUiState(
     val waterTodayMl: Int = 0,
     val waterEntriesToday: List<WaterEntry> = emptyList(),
     val fastingTrackingEnabled: Boolean = false,
-    val walkRunQuickLogEnabled: Boolean = false,
     val fastingDefaultGoalMinutes: Int = 16 * 60,
     val fastingSessions: List<FastingSession> = emptyList(),
     val pendingAnalysis: FoodAnalysis? = null,
@@ -202,10 +198,6 @@ private val _stepsRefreshEpoch = MutableStateFlow(0)
             .onEach { enabled -> _ui.value = _ui.value.copy(fastingTrackingEnabled = enabled) }
             .launchIn(viewModelScope)
 
-        container.prefs.walkRunQuickLogEnabled
-            .onEach { enabled -> _ui.value = _ui.value.copy(walkRunQuickLogEnabled = enabled) }
-            .launchIn(viewModelScope)
-
         container.prefs.fastingDefaultGoalMinutes
             .onEach { goal -> _ui.value = _ui.value.copy(fastingDefaultGoalMinutes = goal) }
             .launchIn(viewModelScope)
@@ -314,27 +306,6 @@ viewModelScope.launch {
             container.waterRepository.add(
                 WaterEntry(date = timestampForSelectedDay(), milliliters = milliliters)
             )
-        }
-    }
-
-    fun logQuickOutdoorActivity(kind: OutdoorActivityKind, minutes: Int) {
-        if (minutes <= 0) return
-        val date = _selectedDate.value
-        viewModelScope.launch {
-            val exerciseId = when (kind) {
-                OutdoorActivityKind.WALKING -> OutdoorActivitySettings.WALKING_EXERCISE_ID
-                OutdoorActivityKind.RUNNING -> OutdoorActivitySettings.RUNNING_EXERCISE_ID
-            }
-            val item = ExerciseRepository.get(container.appContext).exercises.firstOrNull { it.id == exerciseId } ?: return@launch
-            container.workoutRepository.logQuickCardio(item, minutes, date)
-            val profile = _ui.value.profile
-            val weightUnit = if (_ui.value.weightMetric) WorkoutWeightUnit.KG else WorkoutWeightUnit.LBS
-            container.workoutRepository.calculateBurn(
-                date = date,
-                bodyWeightKg = profile?.weightKg ?: 70.0,
-                weightUnit = weightUnit
-            )
-            bumpBurnRefresh()
         }
     }
 

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt
@@ -888,13 +888,6 @@ fun SettingsScreen(container: AppContainer, nav: NavHostController, vm: Settings
                         icon = Icons.Outlined.TrackChanges
                     ) { sheet = SettingsSheet.FASTING_GOAL }
                 }
-                HorizontalDivider()
-                ToggleRow(
-                    stringResource(R.string.settings_walk_run_quick_log),
-                    ui.walkRunQuickLogEnabled,
-                    icon = Icons.AutoMirrored.Outlined.DirectionsWalk,
-                    onChange = vm::setWalkRunQuickLogEnabled
-                )
             }
             }
 
@@ -1247,6 +1240,20 @@ fun SettingsScreen(container: AppContainer, nav: NavHostController, vm: Settings
                 HorizontalDivider()
                 Text(
                     stringResource(R.string.settings_rpe_guide),
+                    fontSize = 12.sp,
+                    lineHeight = 18.sp,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f),
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp)
+                )
+                HorizontalDivider()
+                ToggleRow(
+                    stringResource(R.string.settings_walk_run_quick_log),
+                    ui.walkRunQuickLogEnabled,
+                    icon = Icons.AutoMirrored.Outlined.DirectionsWalk,
+                    onChange = vm::setWalkRunQuickLogEnabled
+                )
+                Text(
+                    stringResource(R.string.settings_walk_run_quick_log_footer),
                     fontSize = 12.sp,
                     lineHeight = 18.sp,
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f),

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutDiaryScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutDiaryScreen.kt
@@ -42,6 +42,8 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.filled.DirectionsRun
+import androidx.compose.material.icons.automirrored.outlined.DirectionsWalk
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Bookmark
@@ -66,6 +68,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.key
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateMapOf
@@ -118,6 +121,8 @@ import com.apoorvdarshan.calorietracker.models.WorkoutWeightUnit
 import com.apoorvdarshan.calorietracker.ui.components.FudGlassDialog
 import com.apoorvdarshan.calorietracker.ui.components.FudGlassSurface
 import com.apoorvdarshan.calorietracker.ui.components.FudGlassTextButton
+import com.apoorvdarshan.calorietracker.ui.home.OutdoorActivityDurationSheet
+import com.apoorvdarshan.calorietracker.ui.home.OutdoorActivityKind
 import com.apoorvdarshan.calorietracker.ui.home.SheetGlassDropdownMenu
 import com.apoorvdarshan.calorietracker.ui.home.SheetGlassDropdownMenuItem
 import com.apoorvdarshan.calorietracker.ui.navigation.BottomNavScrollPadding
@@ -157,6 +162,8 @@ internal fun WorkoutDiaryScreen(
     var workoutTranscript by androidx.compose.runtime.saveable.rememberSaveable { mutableStateOf("") }
     var copySheetVisible by remember { mutableStateOf(false) }
     var addMenuExpanded by remember { mutableStateOf(false) }
+    var outdoorActivitySheet by remember { mutableStateOf<OutdoorActivityKind?>(null) }
+    val walkRunQuickLogEnabled by container.prefs.walkRunQuickLogEnabled.collectAsState(initial = false)
     val listState = rememberLazyListState()
     val focusManager = LocalFocusManager.current
     val keyboard = LocalSoftwareKeyboardController.current
@@ -393,6 +400,24 @@ internal fun WorkoutDiaryScreen(
                         pickerRequest = WorkoutPickerRequest.saved()
                     }
                 )
+                if (walkRunQuickLogEnabled) {
+                    SheetGlassDropdownMenuItem(
+                        label = stringResource(R.string.outdoor_activity_walking),
+                        leadingIcon = Icons.AutoMirrored.Outlined.DirectionsWalk,
+                        onClick = {
+                            addMenuExpanded = false
+                            outdoorActivitySheet = OutdoorActivityKind.WALKING
+                        }
+                    )
+                    SheetGlassDropdownMenuItem(
+                        label = stringResource(R.string.outdoor_activity_running),
+                        leadingIcon = Icons.AutoMirrored.Filled.DirectionsRun,
+                        onClick = {
+                            addMenuExpanded = false
+                            outdoorActivitySheet = OutdoorActivityKind.RUNNING
+                        }
+                    )
+                }
                 HorizontalDivider(color = workoutsColors().hairline.copy(alpha = 0.45f))
                 SheetGlassDropdownMenuItem(label = stringResource(R.string.workout_text_voice), leadingIcon = Icons.Filled.Mic, onClick = {
                     addMenuExpanded = false
@@ -451,6 +476,16 @@ internal fun WorkoutDiaryScreen(
             onToggleExercise = viewModel::toggleExercise,
             onToggleSaved = viewModel::toggleSaved,
             onDismiss = { pickerRequest = null }
+        )
+    }
+
+    outdoorActivitySheet?.let { activity ->
+        OutdoorActivityDurationSheet(
+            activity = activity,
+            onDismiss = { outdoorActivitySheet = null },
+            onLog = { minutes ->
+                viewModel.logQuickOutdoorActivity(activity, minutes)
+            }
         )
     }
 

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutsViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutsViewModel.kt
@@ -20,7 +20,9 @@ import com.apoorvdarshan.calorietracker.models.WorkoutPersistedState
 import com.apoorvdarshan.calorietracker.models.WorkoutPreferences
 import com.apoorvdarshan.calorietracker.models.WorkoutSplitGroup
 import com.apoorvdarshan.calorietracker.models.WorkoutTabMode
+import com.apoorvdarshan.calorietracker.models.OutdoorActivitySettings
 import com.apoorvdarshan.calorietracker.models.WorkoutWeightUnit
+import com.apoorvdarshan.calorietracker.ui.home.OutdoorActivityKind
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
@@ -310,6 +312,25 @@ class WorkoutsViewModel(app: Application) : AndroidViewModel(app) {
     fun copyPlan(sourceDate: LocalDate, includeSetDetails: Boolean = false) {
         val targetDate = diaryUiState.selectedDate
         viewModelScope.launch { workoutRepository?.copyPlan(sourceDate, targetDate, includeSetDetails) }
+    }
+
+    fun logQuickOutdoorActivity(kind: OutdoorActivityKind, minutes: Int) {
+        if (minutes <= 0) return
+        val repository = workoutRepository ?: return
+        val date = diaryUiState.selectedDate
+        viewModelScope.launch {
+            val exerciseId = when (kind) {
+                OutdoorActivityKind.WALKING -> OutdoorActivitySettings.WALKING_EXERCISE_ID
+                OutdoorActivityKind.RUNNING -> OutdoorActivitySettings.RUNNING_EXERCISE_ID
+            }
+            val item = exerciseRepository.exercises.firstOrNull { it.id == exerciseId } ?: return@launch
+            repository.logQuickCardio(item, minutes, date)
+            repository.calculateBurn(
+                date = date,
+                bodyWeightKg = bodyWeightKg,
+                weightUnit = workoutWeightUnit
+            )
+        }
     }
 
     fun calculateBurn() {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -712,6 +712,7 @@
     <string name="settings_water_unit_fl_oz">Fluid Ounces (fl oz)</string>
     <string name="settings_fasting_tracking">Fasting Tracking</string>
     <string name="settings_walk_run_quick_log">Walk &amp; Run</string>
+    <string name="settings_walk_run_quick_log_footer">Off by default. When enabled, Walking and Running appear in the Workouts + menu for quick outdoor logging.</string>
     <string name="outdoor_activity_walking">Walking</string>
     <string name="outdoor_activity_running">Running</string>
     <string name="outdoor_activity_how_long">How long?</string>

--- a/ios/calorietracker/ContentView.swift
+++ b/ios/calorietracker/ContentView.swift
@@ -622,7 +622,6 @@ struct HomeView: View {
     @Environment(FoodStore.self) private var foodStore
     @Environment(WaterStore.self) private var waterStore
     @Environment(FastingStore.self) private var fastingStore
-    @Environment(StrengthWorkoutStore.self) private var strengthWorkoutStore
     @Environment(NotificationManager.self) private var notificationManager
     @Environment(HealthKitManager.self) private var healthKitManager
     @Environment(\.scenePhase) private var scenePhase
@@ -762,7 +761,6 @@ struct HomeView: View {
     @State private var currentFoodSource: FoodSource = .snapFood
     @State private var showNutritionDetail = false
     @State private var showCustomWaterLog = false
-    @State private var outdoorActivitySheet: OutdoorActivityDurationSheet.ActivityKind?
     @State private var showFastingStart = false
     @State private var editingFastingSession: FastingSession?
     @State private var showFastingQuickActionDisabled = false
@@ -784,7 +782,6 @@ struct HomeView: View {
     @AppStorage(FastingSettings.enabledKey) private var fastingTrackingEnabled = false
     @AppStorage(FastingSettings.defaultGoalMinutesKey) private var fastingDefaultGoalMinutes = FastingSettings.defaultGoalMinutes
     @AppStorage(FastingSettings.notificationEnabledKey) private var fastingGoalNotificationEnabled = true
-    @AppStorage(OutdoorActivitySettings.enabledKey) private var walkRunQuickLogEnabled = false
     @AppStorage("notificationsEnabled") private var notificationsEnabled = false
     @Environment(ProfileStore.self) private var profileStore
     @State private var homeBurnLine: String?
@@ -1008,31 +1005,6 @@ private var dailyStepsTaskKey: String {
             _ = AVCaptureDevice.authorizationStatus(for: .video)
             _ = SFSpeechRecognizer.authorizationStatus()
         }
-    }
-
-    private func logQuickOutdoorActivity(_ activity: OutdoorActivityDurationSheet.ActivityKind, minutes: Int) {
-        guard minutes > 0 else { return }
-        let exerciseID = activity == .walking
-            ? OutdoorActivitySettings.walkingExerciseID
-            : OutdoorActivitySettings.runningExerciseID
-        guard let item = ExerciseLibraryService.shared.exercises.first(where: { $0.id == exerciseID }) else { return }
-
-        strengthWorkoutStore.logQuickCardio(item, minutes: minutes, on: selectedDate)
-        let weightUnit: WeightUnit = weightUnitRaw == "kg" ? .kg : .lbs
-        if let estimate = StrengthWorkoutBurnEstimator.estimate(
-            exercises: strengthWorkoutStore.exercises(for: selectedDate),
-            bodyWeightKg: userProfile.weightKg,
-            defaultWeightUnit: weightUnit,
-            defaultRPEScale: strengthWorkoutStore.preferences.rpeScale
-        ) {
-            _ = strengthWorkoutStore.upsertCalculatedWorkout(
-                on: selectedDate,
-                caloriesBurned: estimate.calories,
-                weightUnit: weightUnit
-            )
-        }
-        homeBurnRefreshGeneration += 1
-        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
     }
 
     @ViewBuilder
@@ -1394,18 +1366,6 @@ private var dailyStepsTaskKey: String {
                             waterQuickMenuItems
                         } label: {
                             Label("Water", systemImage: "drop.fill")
-                        }
-                    }
-                    if walkRunQuickLogEnabled {
-                        Button {
-                            outdoorActivitySheet = .walking
-                        } label: {
-                            Label("Walking", systemImage: "figure.walk")
-                        }
-                        Button {
-                            outdoorActivitySheet = .running
-                        } label: {
-                            Label("Running", systemImage: "figure.run")
                         }
                     }
                     if fastingStore.activeSession == nil {
@@ -1894,11 +1854,6 @@ private var dailyStepsTaskKey: String {
             .sheet(isPresented: $showCustomWaterLog) {
                 WaterCustomAmountSheet(unit: waterUnit, onAdd: logWater)
             }
-            .sheet(item: $outdoorActivitySheet) { activity in
-                OutdoorActivityDurationSheet(activity: activity) { minutes in
-                    logQuickOutdoorActivity(activity, minutes: minutes)
-                }
-            }
             .onOpenURL { url in
                 if url.scheme == "fudai", url.host == "import-share-image" {
                     checkAndConsumeSharedImage()
@@ -1980,7 +1935,6 @@ private var dailyStepsTaskKey: String {
         showCopyFromDaySheet = false
         showNutritionDetail = false
         showCustomWaterLog = false
-        outdoorActivitySheet = nil
         showError = false
         showFastingStart = false
         editingFastingSession = nil
@@ -4035,7 +3989,6 @@ struct ProfileView: View {
     @AppStorage(WaterSettings.unitKey) private var waterUnitRaw = WaterUnit.defaultUnit.rawValue
     @AppStorage(FastingSettings.enabledKey) private var fastingTrackingEnabled = false
     @AppStorage(FastingSettings.defaultGoalMinutesKey) private var fastingDefaultGoalMinutes = FastingSettings.defaultGoalMinutes
-    @AppStorage(OutdoorActivitySettings.enabledKey) private var walkRunQuickLogEnabled = false
 
     private var waterUnit: WaterUnit { WaterUnit(rawValue: waterUnitRaw) ?? .defaultUnit }
 
@@ -4745,19 +4698,6 @@ struct ProfileView: View {
                                     notificationManager.cancelFastingGoal()
                                 }
                             }
-                    }
-
-                    HStack {
-                        Label {
-                            Text("Walk & Run")
-                        } icon: {
-                            Image(systemName: "figure.walk")
-                                .foregroundStyle(AppColors.calorie)
-                        }
-                        Spacer()
-                        Toggle("Walk & Run", isOn: $walkRunQuickLogEnabled)
-                            .labelsHidden()
-                            .tint(AppColors.calorie)
                     }
 
                     if fastingTrackingEnabled {

--- a/ios/calorietracker/Views/WorkoutLogView.swift
+++ b/ios/calorietracker/Views/WorkoutLogView.swift
@@ -71,8 +71,10 @@ struct WorkoutLogView: View {
     @Environment(ProfileStore.self) private var profileStore
     @AppStorage(WeightUnit.storageKey) private var weightUnitRaw = WeightUnit.lbs.rawValue
     @AppStorage(AppThemeColor.storageKey) private var appThemeColorRaw = AppThemeColor.defaultColor.rawValue
+    @AppStorage(OutdoorActivitySettings.enabledKey) private var walkRunQuickLogEnabled = false
 
     @State private var pickerRequest: WorkoutLogPickerRequest?
+    @State private var outdoorActivitySheet: OutdoorActivityDurationSheet.ActivityKind?
     @State private var isCopySheetPresented = false
     @State private var isTextSheetPresented = false
     @State private var workoutInputUsesVoice = false
@@ -450,6 +452,11 @@ struct WorkoutLogView: View {
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
             }
+            .sheet(item: $outdoorActivitySheet) { activity in
+                OutdoorActivityDurationSheet(activity: activity) { minutes in
+                    logQuickOutdoorActivity(activity, minutes: minutes)
+                }
+            }
         }
 
     private var addExerciseMenu: some View {
@@ -471,6 +478,19 @@ struct WorkoutLogView: View {
                     isCopySheetPresented = true
                 } label: {
                     Label("Copy from day", systemImage: "calendar.badge.plus")
+                }
+
+                if walkRunQuickLogEnabled {
+                    Button {
+                        outdoorActivitySheet = .walking
+                    } label: {
+                        Label("Walking", systemImage: "figure.walk")
+                    }
+                    Button {
+                        outdoorActivitySheet = .running
+                    } label: {
+                        Label("Running", systemImage: "figure.run")
+                    }
                 }
 
                 if splitGroups.isEmpty {
@@ -522,6 +542,29 @@ struct WorkoutLogView: View {
               session.moveSelectedDay(by: delta)
         else { return }
         UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    }
+
+    private func logQuickOutdoorActivity(_ activity: OutdoorActivityDurationSheet.ActivityKind, minutes: Int) {
+        guard minutes > 0 else { return }
+        let exerciseID = activity == .walking
+            ? OutdoorActivitySettings.walkingExerciseID
+            : OutdoorActivitySettings.runningExerciseID
+        guard let item = library.exercises.first(where: { $0.id == exerciseID }) else { return }
+
+        workoutStore.logQuickCardio(item, minutes: minutes, on: selectedDate)
+        if let estimate = StrengthWorkoutBurnEstimator.estimate(
+            exercises: workoutStore.exercises(for: selectedDate),
+            bodyWeightKg: currentBodyWeightKg,
+            defaultWeightUnit: weightUnit,
+            defaultRPEScale: workoutStore.preferences.rpeScale
+        ) {
+            _ = workoutStore.upsertCalculatedWorkout(
+                on: selectedDate,
+                caloriesBurned: estimate.calories,
+                weightUnit: weightUnit
+            )
+        }
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
     }
 
     private func calculateBurn() {

--- a/ios/calorietracker/Views/WorkoutLoggingSettingsView.swift
+++ b/ios/calorietracker/Views/WorkoutLoggingSettingsView.swift
@@ -36,19 +36,6 @@ struct WorkoutLoggingSettingsSection: View {
             )
 
             rpeScaleGuide
-
-            HStack {
-                Label {
-                    Text("Walk & Run")
-                } icon: {
-                    Image(systemName: "figure.walk")
-                        .foregroundStyle(AppColors.calorie)
-                }
-                Spacer()
-                Toggle("Walk & Run", isOn: $walkRunQuickLogEnabled)
-                    .labelsHidden()
-                    .tint(AppColors.calorie)
-            }
         } header: {
             Text("Workout")
         } footer: {

--- a/ios/calorietracker/Views/WorkoutLoggingSettingsView.swift
+++ b/ios/calorietracker/Views/WorkoutLoggingSettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Workout preferences embedded directly in Fud AI's main Settings list.
 struct WorkoutLoggingSettingsSection: View {
     @Environment(StrengthWorkoutStore.self) private var workoutStore
+    @AppStorage(OutdoorActivitySettings.enabledKey) private var walkRunQuickLogEnabled = false
 
     @State private var draft = StrengthWorkoutPreferences()
     @State private var hasLoaded = false
@@ -22,8 +23,23 @@ struct WorkoutLoggingSettingsSection: View {
             )
 
             rpeScaleGuide
+
+            HStack {
+                Label {
+                    Text("Walk & Run")
+                } icon: {
+                    Image(systemName: "figure.walk")
+                        .foregroundStyle(AppColors.calorie)
+                }
+                Spacer()
+                Toggle("Walk & Run", isOn: $walkRunQuickLogEnabled)
+                    .labelsHidden()
+                    .tint(AppColors.calorie)
+            }
         } header: {
             Text("Workout")
+        } footer: {
+            Text("Off by default. When enabled, Walking and Running appear in the Workouts + menu for quick outdoor logging.")
         }
         .listRowBackground(AppColors.appCard)
         .onAppear(perform: loadPreferences)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #187

Walk & Run quick log was mistakenly placed on the **Home food + menu** (alongside Water/Fasting). It belongs on the **Workouts diary + menu** — the same + menu used for Copy from day, Saved, library picks, and text/voice workout adds.

## Changes

### Entry points (iOS + Android)
- **Removed** Walking/Running from the Home + menu entirely
- **Added** Walking/Running to the Workouts + menu, gated by `walkRunQuickLogEnabled` (still off by default)
- Reuses existing `OutdoorActivityDurationSheet`, outdoor exercise IDs, `logQuickCardio`, duration validation, and double-tap guards — only the entry points moved

### Settings
- Toggle stays under **Settings → Workout** (moved out of Tracking & Reminders)
- Footer/copy updated from "Home + menu" → "Workouts + menu"

## Platforms
- **iOS:** `ContentView.swift` (Home cleanup), `WorkoutLogView.swift` (menu + sheet), `WorkoutLoggingSettingsView.swift` (toggle + footer)
- **Android:** `HomeScreen.kt` / `HomeViewModel.kt` (cleanup), `WorkoutDiaryScreen.kt` / `WorkoutsViewModel.kt` (menu + sheet), `SettingsScreen.kt` + strings (toggle + footer)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c21103e-f775-4bd6-9bc8-3d531a4294c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c21103e-f775-4bd6-9bc8-3d531a4294c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional Walk & Run quick logging to the Workouts + menu on Android and iOS.
  - Users can select Walking or Running, enter a duration, and save the activity quickly.
  - Added explanatory guidance for the Walk & Run setting.
  - Meal photos are now automatically saved when completing eligible meal entries.

- **Changes**
  - Removed Walk & Run quick logging from the Home screen.
  - Improved AI fallback model handling when provider configurations overlap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moves the opt-in Walking and Running quick-log actions from the Home add menu to the Workouts add menu on both platforms.
- Removes the Home entry points and their associated logging state.
- Reuses the existing duration sheet, exercise identifiers, validation, and logging behavior from the Workouts diary.
- Keeps the feature disabled by default and updates its settings placement and explanatory copy.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the relocated quick-log flow preserves its gating, validation, logging, burn calculation, and platform-specific refresh behavior.

No actionable new failures remain, and the previously reported duplicate iOS settings toggle is resolved in the current code.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutDiaryScreen.kt | Adds preference-gated Walking and Running actions to the Workouts menu and presents the shared duration sheet. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutsViewModel.kt | Logs the selected outdoor activity on the workout diary date and recalculates daily burn. |
| ios/calorietracker/Views/WorkoutLogView.swift | Adds the gated Workouts-menu entry points and moves quick outdoor logging into the workout view. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt | Removes Walking and Running from the Home add menu and removes the associated sheet state. |
| ios/calorietracker/ContentView.swift | Removes the outdoor quick-log controls, state, and logging implementation from Home. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt | Keeps a single Walk & Run toggle in Workout settings and adds explanatory footer text. |
| ios/calorietracker/Views/WorkoutLoggingSettingsView.swift | Updates the feature footer to identify the Workouts add menu as the new entry point. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    S[Workout settings] -->|Enable Walk & Run| M[Workouts + menu]
    M --> W[Walking]
    M --> R[Running]
    W --> D[Duration sheet]
    R --> D
    D --> L[Quick cardio log]
    L --> B[Recalculate daily burn]
    B --> U[Refresh workout diary]
```

<sub>Reviews (4): Last reviewed commit: ["Merge origin/main into Walk/Run Workouts..."](https://github.com/apoorvdarshan/fud-ai/commit/6136b7af155a62d2f1837419b6ef2068a05ef0ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62974518)</sub>

<!-- /greptile_comment -->