### PR TITLE
Add visual separators between + Menu groups

### DIFF
--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
@@ -727,6 +727,13 @@ CalorieHero(
                 when (val destination = addMenuDestination) {
                     null -> {
                         var insertedFoodBlock = false
+                        @Composable
+                        fun maybeFoodBoundaryHairline() {
+                            if (insertedFoodBlock) {
+                                SheetHairline()
+                                insertedFoodBlock = false
+                            }
+                        }
                         if (ui.activeFast == null) {
                             val addMenuConfig = ui.addMenuConfig
                             if (addMenuConfig.usesFlatLayout) {
@@ -752,7 +759,7 @@ CalorieHero(
                             }
                         }
                         if (ui.waterTrackingEnabled) {
-                            if (insertedFoodBlock) SheetHairline()
+                            maybeFoodBoundaryHairline()
                             SheetGlassDropdownMenuItem(
                                 label = stringResource(R.string.water),
                                 leadingIcon = Icons.Filled.WaterDrop,
@@ -760,6 +767,7 @@ CalorieHero(
                             ) { addMenuDestination = AddMenuDestination.Water }
                         }
                         if (ui.fastingTrackingEnabled) {
+                            maybeFoodBoundaryHairline()
                             if (ui.activeFast == null) {
                                 SheetGlassDropdownMenuItem(label = stringResource(R.string.fasting_start), leadingIcon = Icons.Filled.Timer) {
                                     showAddMenu = false

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
@@ -727,26 +727,33 @@ CalorieHero(
             ) {
                 when (val destination = addMenuDestination) {
                     null -> {
+                        var insertedFoodBlock = false
                         if (ui.activeFast == null) {
                             val addMenuConfig = ui.addMenuConfig
                             if (addMenuConfig.usesFlatLayout) {
-                                addMenuConfig.resolvedFlatMethods().forEach { method ->
+                                val methods = addMenuConfig.resolvedFlatMethods()
+                                methods.forEach { method ->
                                     SheetGlassDropdownMenuItem(
                                         label = stringResource(method.titleRes),
                                         leadingIcon = method.icon
                                     ) { performFoodLogMethod(method) }
                                 }
+                                insertedFoodBlock = methods.isNotEmpty()
                             } else {
-                                addMenuConfig.resolvedGroups().forEachIndexed { index, group ->
+                                val groups = addMenuConfig.resolvedGroups()
+                                groups.forEachIndexed { index, group ->
+                                    if (index > 0) SheetHairline()
                                     SheetGlassDropdownMenuItem(
                                         label = group.displayName(),
                                         leadingIcon = group.methods.firstOrNull()?.icon ?: FoodLogMethodDefaultGroupIcon,
                                         trailingIcon = Icons.Filled.ChevronRight
                                     ) { addMenuDestination = AddMenuDestination.FoodGroup(index) }
                                 }
+                                insertedFoodBlock = groups.isNotEmpty()
                             }
                         }
                         if (ui.waterTrackingEnabled) {
+                            if (insertedFoodBlock) SheetHairline()
                             SheetGlassDropdownMenuItem(
                                 label = stringResource(R.string.water),
                                 leadingIcon = Icons.Filled.WaterDrop,

--- a/android/app/src/test/java/com/apoorvdarshan/calorietracker/models/WorkoutModelsTest.kt
+++ b/android/app/src/test/java/com/apoorvdarshan/calorietracker/models/WorkoutModelsTest.kt
@@ -2,6 +2,7 @@ package com.apoorvdarshan.calorietracker.models
 
 import com.apoorvdarshan.calorietracker.data.ExerciseItem
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test

--- a/ios/calorietracker/ContentView.swift
+++ b/ios/calorietracker/ContentView.swift
@@ -1379,49 +1379,55 @@ private var dailyStepsTaskKey: String {
             .overlay(alignment: .bottomTrailing) {
                 Menu {
                     if fastingTrackingEnabled {
-                        if fastingStore.activeSession != nil {
-                            Menu {
+                        Section {
+                            if fastingStore.activeSession != nil {
+                                Menu {
+                                    Button {
+                                        endFast()
+                                    } label: {
+                                        Label("End Fast", systemImage: "stop.fill")
+                                    }
+                                    Button(role: .destructive) {
+                                        fastingStore.cancelActive()
+                                        notificationManager.cancelFastingGoal()
+                                    } label: {
+                                        Label("Cancel Fast", systemImage: "trash")
+                                    }
+                                } label: {
+                                    Label("Fasting", systemImage: "timer")
+                                }
+                            } else {
                                 Button {
-                                    endFast()
+                                    presentFoodDestination {
+                                        showFastingStart = true
+                                    }
                                 } label: {
-                                    Label("End Fast", systemImage: "stop.fill")
+                                    Label("Start Fast", systemImage: "timer")
                                 }
-                                Button(role: .destructive) {
-                                    fastingStore.cancelActive()
-                                    notificationManager.cancelFastingGoal()
-                                } label: {
-                                    Label("Cancel Fast", systemImage: "trash")
-                                }
-                            } label: {
-                                Label("Fasting", systemImage: "timer")
-                            }
-                        } else {
-                            Button {
-                                presentFoodDestination {
-                                    showFastingStart = true
-                                }
-                            } label: {
-                                Label("Start Fast", systemImage: "timer")
                             }
                         }
                     }
                     if waterTrackingEnabled {
-                        Menu {
-                            waterQuickMenuItems
-                        } label: {
-                            Label("Water", systemImage: "drop.fill")
+                        Section {
+                            Menu {
+                                waterQuickMenuItems
+                            } label: {
+                                Label("Water", systemImage: "drop.fill")
+                            }
                         }
                     }
                     if walkRunQuickLogEnabled {
-                        Button {
-                            outdoorActivitySheet = .walking
-                        } label: {
-                            Label("Walking", systemImage: "figure.walk")
-                        }
-                        Button {
-                            outdoorActivitySheet = .running
-                        } label: {
-                            Label("Running", systemImage: "figure.run")
+                        Section {
+                            Button {
+                                outdoorActivitySheet = .walking
+                            } label: {
+                                Label("Walking", systemImage: "figure.walk")
+                            }
+                            Button {
+                                outdoorActivitySheet = .running
+                            } label: {
+                                Label("Running", systemImage: "figure.run")
+                            }
                         }
                     }
                     if fastingStore.activeSession == nil {
@@ -2213,17 +2219,21 @@ extension HomeView {
     var configuredFoodAddMenuContent: some View {
         let config = AddMenuSettings.load()
         if config.usesFlatLayout {
-            ForEach(config.flatMethods) { method in
-                addMenuButton(for: method)
+            Section {
+                ForEach(config.flatMethods) { method in
+                    addMenuButton(for: method)
+                }
             }
         } else {
             ForEach(config.groups.filter { !$0.methods.isEmpty }) { group in
-                Menu {
-                    ForEach(group.methods) { method in
-                        addMenuButton(for: method)
+                Section {
+                    Menu {
+                        ForEach(group.methods) { method in
+                            addMenuButton(for: method)
+                        }
+                    } label: {
+                        Label(group.name, systemImage: addMenuGroupIcon(for: group))
                     }
-                } label: {
-                    Label(group.name, systemImage: addMenuGroupIcon(for: group))
                 }
             }
         }

--- a/ios/calorietracker/Views/AddMenuSettingsView.swift
+++ b/ios/calorietracker/Views/AddMenuSettingsView.swift
@@ -22,37 +22,39 @@ struct AddMenuSettingsView: View {
                             .foregroundStyle(AppColors.calorie)
                     }
                 }
-
-                if config.usesFlatLayout {
-                    flatMethodsSection
-                } else {
-                    groupOrderSection
-                    ForEach($config.groups) { $group in
-                        groupSection(group: $group)
-                    }
-                }
-
-                if !hiddenMethods.isEmpty {
-                    Section {
-                        ForEach(hiddenMethods) { method in
-                            Label(method.title, systemImage: method.systemImageName)
-                                .foregroundStyle(.secondary)
-                        }
-                    } header: {
-                        Text("Hidden Methods")
-                    } footer: {
-                        Text("These logging methods are not shown on the Home + menu.")
-                    }
-                }
-
-                Button("Reset to Default", role: .destructive) {
-                    AddMenuSettings.reset()
-                    config = .iOSDefault
-                }
             } header: {
                 Text("Food Add Menu")
             } footer: {
                 Text("Customize the Home + button food menu. Water and fasting stay separate when enabled. This does not change app-icon Quick Actions.")
+            }
+
+            if config.usesFlatLayout {
+                flatMethodsSection
+            } else {
+                groupOrderSection
+                ForEach($config.groups) { $group in
+                    groupSection(group: $group)
+                }
+            }
+
+            if !hiddenMethods.isEmpty {
+                Section {
+                    ForEach(hiddenMethods) { method in
+                        Label(method.title, systemImage: method.systemImageName)
+                            .foregroundStyle(.secondary)
+                    }
+                } header: {
+                    Text("Hidden Methods")
+                } footer: {
+                    Text("These logging methods are not shown on the Home + menu.")
+                }
+            }
+
+            Section {
+                Button("Reset to Default", role: .destructive) {
+                    AddMenuSettings.reset()
+                    config = .iOSDefault
+                }
             }
         }
         .environment(\.editMode, $editMode)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After configurable + Menu (#188 / PR #263), food groups should read as distinct blocks on both platforms. Android + Menu settings already did this with `AddMenuSectionCard` spacing; iOS settings and both Home + menus did not.

Merged `main` (includes Walk/Run → Workouts #266). Home + separators apply only to what remains on Home + (Fasting, Water, food groups).

## iOS + Menu settings (`AddMenuSettingsView.swift`)

**Before:** Groups stepper, group order, per-group editors, hidden methods, and reset were nested inside one parent `Section` ("Food Add Menu"). Nested Form sections collapse, so groups looked mashed together.

**After:** Sibling Form sections:
- Groups stepper + footer
- Group order (when grouped)
- One section per group (name, methods, add method)
- Hidden methods section
- Reset button section

Matches the Android card-per-group layout in `AddMenuSettingsScreen.kt`.

## iOS Home + menu (`ContentView.swift`)

**Before:** `configuredFoodAddMenuContent` emitted consecutive nested `Menu`s with no separation; Fasting / Water / food groups were one flat list.

**After:**
- Each food group nested `Menu` wrapped in its own `Section` (native grouped-table separator between groups)
- Flat layout (0 groups) wraps methods in a single `Section` — no fake groups
- Fasting and Water each in their own `Section` so they are visually distinct from food groups
- Walk/Run stay on Workouts (main #266) — not on Home +
- Drill-in navigation unchanged (tap group → methods)

## Android Home + menu (`HomeScreen.kt`)

**Before:** Root add-menu listed food-group rows back-to-back with no divider before Water / Fasting.

**After:**
- `SheetHairline()` between food groups when grouped (not between methods inside drill-in)
- `maybeFoodBoundaryHairline()` emits one `SheetHairline()` before the **first** subsequent non-food block (Water or Fasting) when food was shown — works even when Water tracking is disabled
- Flat layout unchanged (no dividers between individual methods)
- Walk/Run stay on Workouts (main #266) — not on Home +
- Android + Menu settings left as-is (already correct)

## Out of scope

- No changes to `AddMenuConfig` schema, defaults, widgets, deep links, or Quick Actions
- No flattening of grouped Home + into one method list
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-467ea967-5abc-4ae0-bf4f-c0c4d0a815ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-467ea967-5abc-4ae0-bf4f-c0c4d0a815ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR visually separates configurable food groups and adjacent tracking actions in the Android and iOS Home + menus, while restructuring the iOS settings form into distinct sections.
- Adds Android hairlines between food groups and before the first subsequent Water or Fasting block.
- Wraps iOS Fasting, Water, flat food methods, and grouped food menus in native sections.
- Splits the iOS food-menu settings controls into sibling form sections.
- The previously reported missing separator before Fasting when Water is disabled is resolved.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the only new issue is a non-blocking unused test import.

The separator logic now handles Fasting when Water tracking is disabled, fully resolving the previous finding. The remaining feedback is limited to an unused import that does not affect compilation or runtime behavior.

**Files Needing Attention:** android/app/src/test/java/com/apoorvdarshan/calorietracker/models/WorkoutModelsTest.kt

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt | Adds separators between grouped food entries and before the first subsequent non-food block, including the Water-disabled Fasting case. |
| ios/calorietracker/ContentView.swift | Uses native menu sections to visually distinguish Fasting, Water, and configurable food blocks. |
| ios/calorietracker/Views/AddMenuSettingsView.swift | Promotes food-menu configuration elements into separate sibling Form sections. |
| android/app/src/test/java/com/apoorvdarshan/calorietracker/models/WorkoutModelsTest.kt | Adds an unused assertion import without changing test behavior. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Open Home + menu] --> B{Food menu layout}
    B -->|Flat| C[Food methods in one block]
    B -->|Grouped| D[Food group blocks with separators]
    C --> E{Water enabled?}
    D --> E
    E -->|Yes| F[Boundary separator then Water]
    E -->|No| G{Fasting enabled?}
    F --> G
    G -->|Yes, food boundary not yet emitted| H[Boundary separator then Fasting]
    G -->|Yes, boundary already emitted| I[Fasting]
    G -->|No| J[End]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20apoorvdarshan%2Ffud-ai%20PR%20%23267%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=267&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Ftest%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fmodels%2FWorkoutModelsTest.kt%3A5%0A**Unused%20Assertion%20Import**%0A%0A%60assertFalse%60%20is%20imported%20but%20never%20used%20in%20this%20test%20file.%20It%20does%20not%20add%20coverage%20or%20change%20behavior%2C%20and%20leaves%20an%20unnecessary%20compiler%20warning%20and%20test-source%20clutter.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=267&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22apoorvdarshan%2Ffud-ai%22%20on%20the%20existing%20branch%20%22cursor%2Fadd-menu-group-separators-38f8%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fadd-menu-group-separators-38f8%22.%0A%0A%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Ftest%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fmodels%2FWorkoutModelsTest.kt%3A5%0A**Unused%20Assertion%20Import**%0A%0A%60assertFalse%60%20is%20imported%20but%20never%20used%20in%20this%20test%20file.%20It%20does%20not%20add%20coverage%20or%20change%20behavior%2C%20and%20leaves%20an%20unnecessary%20compiler%20warning%20and%20test-source%20clutter.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=267&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Ftest%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fmodels%2FWorkoutModelsTest.kt%3A5%0A**Unused%20Assertion%20Import**%0A%0A%60assertFalse%60%20is%20imported%20but%20never%20used%20in%20this%20test%20file.%20It%20does%20not%20add%20coverage%20or%20change%20behavior%2C%20and%20leaves%20an%20unnecessary%20compiler%20warning%20and%20test-source%20clutter.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=267&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
android/app/src/test/java/com/apoorvdarshan/calorietracker/models/WorkoutModelsTest.kt:5
**Unused Assertion Import**

`assertFalse` is imported but never used in this test file. It does not add coverage or change behavior, and leaves an unnecessary compiler warning and test-source clutter.

```suggestion

```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(android): import assertFalse in Work..."](https://github.com/apoorvdarshan/fud-ai/commit/7f74f48650c9a5b5d2fa0c446e812660dfd7e037) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62985780)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Added a visual divider in the Android add menu to separate food logging options from water and fasting actions.
  - Improved menu organization on iOS by grouping food, water, and fasting actions into distinct sections.
  - Reorganized the add-menu settings screen so group configuration, hidden methods, and reset controls appear in clearer sections.
  - These updates improve visual structure without changing available actions or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->