### PR TITLE
Workout diary: set autofill, lift history, Coach awareness

### DIFF
--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/WorkoutRepository.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/WorkoutRepository.kt
@@ -2,6 +2,9 @@ package com.apoorvdarshan.calorietracker.data
 
 import com.apoorvdarshan.calorietracker.models.CompletedExercise
 import com.apoorvdarshan.calorietracker.models.CompletedSet
+import com.apoorvdarshan.calorietracker.models.ExerciseLiftDay
+import com.apoorvdarshan.calorietracker.models.ExerciseLiftHistory
+import com.apoorvdarshan.calorietracker.models.ExerciseLiftSet
 import com.apoorvdarshan.calorietracker.models.ExerciseTimer
 import com.apoorvdarshan.calorietracker.models.ExerciseTimerAction
 import com.apoorvdarshan.calorietracker.models.PlannedExercise
@@ -160,7 +163,10 @@ class WorkoutRepository(
         val target = count.coerceIn(1, 12)
         updateExercise(WorkoutDate.requireKey(dateKey), exerciseId) { exercise ->
             val sets = when {
-                target > exercise.sets.size -> exercise.sets + List(target - exercise.sets.size) { PlannedSet() }
+                target > exercise.sets.size -> {
+                    val template = exercise.sets.lastOrNull() ?: PlannedSet()
+                    exercise.sets + List(target - exercise.sets.size) { template.copyingFromPrevious() }
+                }
                 target < exercise.sets.size -> exercise.sets.take(target)
                 else -> exercise.sets
             }
@@ -284,6 +290,34 @@ class WorkoutRepository(
             .map { it.dateKey }
             .sortedDescending()
     }
+
+    suspend fun exerciseLiftHistory(
+        itemId: String,
+        name: String,
+        before: LocalDate,
+        limit: Int = 90
+    ): List<ExerciseLiftDay> = exerciseLiftHistory(itemId, name, WorkoutDate.key(before), limit)
+
+    suspend fun exerciseLiftHistory(
+        itemId: String,
+        name: String,
+        beforeDateKey: String,
+        limit: Int = 90
+    ): List<ExerciseLiftDay> =
+        ExerciseLiftHistory.history(snapshot(), itemId, name, beforeDateKey, limit)
+
+    suspend fun lastExerciseLiftSummary(
+        itemId: String,
+        name: String,
+        before: LocalDate,
+        displayUnit: WorkoutWeightUnit
+    ): String? = ExerciseLiftHistory.lastSummary(
+        snapshot(),
+        itemId,
+        name,
+        WorkoutDate.key(before),
+        displayUnit
+    )
 
     suspend fun updatePreferences(transform: (WorkoutPreferences) -> WorkoutPreferences) {
         updateState { current ->
@@ -769,7 +803,6 @@ class WorkoutRepository(
         sessions.filter { it.caloriesBurned != null }
             .groupBy { it.diaryDateKey }
             .mapValues { (_, values) -> values.maxWith(preferredSessionComparator) }
-
 
     companion object {
         private val sessionDescendingComparator =

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/models/WorkoutModels.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/models/WorkoutModels.kt
@@ -679,17 +679,6 @@ object ExerciseLiftHistory {
         return left.isNotEmpty() && left == right
     }
 
-    fun performedSets(planned: List<PlannedSet>): List<ExerciseLiftSet> =
-        planned.mapNotNull { set ->
-            val reps = set.reps.trim()
-            if (reps.isEmpty()) return@mapNotNull null
-            ExerciseLiftSet(
-                weight = set.weight.trim(),
-                weightUnit = set.weightUnit,
-                reps = reps
-            )
-        }
-
     fun performedSets(completed: List<CompletedSet>): List<ExerciseLiftSet> =
         completed.filter { it.isPerformed }.map {
             ExerciseLiftSet(
@@ -719,7 +708,9 @@ object ExerciseLiftHistory {
         limit: Int = 90
     ): List<ExerciseLiftDay> {
         val before = WorkoutDate.requireKey(beforeDateKey)
-        val dateKeys = (state.dayPlans.keys + state.completedSessions.map { it.diaryDateKey })
+        val dateKeys = state.completedSessions
+            .map { it.diaryDateKey }
+            .distinct()
             .filter { it < before }
             .sortedDescending()
         val results = mutableListOf<ExerciseLiftDay>()
@@ -748,19 +739,11 @@ object ExerciseLiftHistory {
         name: String,
         dateKey: String
     ): List<ExerciseLiftSet> {
-        state.dayPlans[dateKey]?.exercises
-            ?.firstOrNull { !it.isCardio && matches(itemId, name, it.itemId, it.name) }
-            ?.let { exercise ->
-                val sets = performedSets(exercise.sets)
-                if (sets.isNotEmpty()) return sets
-            }
-
-        preferredHistorySession(state, dateKey)
+        return preferredHistorySession(state, dateKey)
             ?.exercises
             ?.firstOrNull { matches(itemId, name, it.itemId, it.name) }
-            ?.let { return performedSets(it.sets) }
-
-        return emptyList()
+            ?.let { performedSets(it.sets) }
+            .orEmpty()
     }
 
     private fun preferredHistorySession(state: WorkoutPersistedState, dateKey: String): WorkoutSession? {

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/models/WorkoutModels.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/models/WorkoutModels.kt
@@ -673,7 +673,7 @@ object ExerciseLiftHistory {
         name.trim().lowercase().replace(Regex("\\s+"), " ")
 
     fun matches(itemId: String, name: String, candidateItemId: String, candidateName: String): Boolean {
-        if (itemId.isNotEmpty() && itemId == candidateItemId) return true
+        if (itemId.isNotEmpty()) return itemId == candidateItemId
         val left = normalizedName(name)
         val right = normalizedName(candidateName)
         return left.isNotEmpty() && left == right

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/models/WorkoutModels.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/models/WorkoutModels.kt
@@ -229,6 +229,13 @@ data class PlannedSet(
         weightUnit = if (carryingWeight) weightUnit else null
     )
 
+    /** New sets inherit weight, unit, and reps from the set above; RPE stays blank. */
+    fun copyingFromPrevious(): PlannedSet = PlannedSet(
+        weight = weight,
+        weightUnit = weightUnit,
+        reps = reps
+    )
+
     fun displayWeight(targetUnit: WorkoutWeightUnit): String {
         val sourceUnit = weightUnit ?: return weight
         val numericWeight = weight.replace(',', '.').toDoubleOrNull()
@@ -647,5 +654,124 @@ data class WorkoutSplitGroup(
             val configured = groups(split, available).filter { it.muscles.isNotEmpty() }
             return configured.ifEmpty { available.map { WorkoutSplitGroup(it, setOf(it)) } }
         }
+    }
+}
+
+data class ExerciseLiftSet(
+    val weight: String,
+    val weightUnit: WorkoutWeightUnit?,
+    val reps: String
+)
+
+data class ExerciseLiftDay(
+    val dateKey: String,
+    val sets: List<ExerciseLiftSet>
+)
+
+object ExerciseLiftHistory {
+    fun normalizedName(name: String): String =
+        name.trim().lowercase().replace(Regex("\\s+"), " ")
+
+    fun matches(itemId: String, name: String, candidateItemId: String, candidateName: String): Boolean {
+        if (itemId.isNotEmpty() && itemId == candidateItemId) return true
+        val left = normalizedName(name)
+        val right = normalizedName(candidateName)
+        return left.isNotEmpty() && left == right
+    }
+
+    fun performedSets(planned: List<PlannedSet>): List<ExerciseLiftSet> =
+        planned.mapNotNull { set ->
+            val reps = set.reps.trim()
+            if (reps.isEmpty()) return@mapNotNull null
+            ExerciseLiftSet(
+                weight = set.weight.trim(),
+                weightUnit = set.weightUnit,
+                reps = reps
+            )
+        }
+
+    fun performedSets(completed: List<CompletedSet>): List<ExerciseLiftSet> =
+        completed.filter { it.isPerformed }.map {
+            ExerciseLiftSet(
+                weight = it.weight.trim(),
+                weightUnit = it.weightUnit,
+                reps = it.reps.trim()
+            )
+        }
+
+    fun formatSetLine(set: ExerciseLiftSet, displayUnit: WorkoutWeightUnit): String {
+        if (set.reps.isEmpty()) return ""
+        if (set.weight.isEmpty()) return "${set.reps} reps"
+        val planned = PlannedSet(weight = set.weight, weightUnit = set.weightUnit, reps = set.reps)
+        return "${planned.displayWeight(displayUnit)} ${displayUnit.storageValue} × ${set.reps}"
+    }
+
+    fun formatSummary(sets: List<ExerciseLiftSet>, displayUnit: WorkoutWeightUnit): String =
+        sets.mapNotNull { line ->
+            formatSetLine(line, displayUnit).takeIf { it.isNotEmpty() }
+        }.joinToString(", ")
+
+    fun history(
+        state: WorkoutPersistedState,
+        itemId: String,
+        name: String,
+        beforeDateKey: String,
+        limit: Int = 90
+    ): List<ExerciseLiftDay> {
+        val before = WorkoutDate.requireKey(beforeDateKey)
+        val dateKeys = (state.dayPlans.keys + state.completedSessions.map { it.diaryDateKey })
+            .filter { it < before }
+            .sortedDescending()
+        val results = mutableListOf<ExerciseLiftDay>()
+        for (key in dateKeys) {
+            if (results.size >= limit) break
+            val sets = liftSets(state, itemId, name, key)
+            if (sets.isNotEmpty()) results += ExerciseLiftDay(key, sets)
+        }
+        return results
+    }
+
+    fun lastSummary(
+        state: WorkoutPersistedState,
+        itemId: String,
+        name: String,
+        beforeDateKey: String,
+        displayUnit: WorkoutWeightUnit
+    ): String? {
+        val latest = history(state, itemId, name, beforeDateKey, limit = 1).firstOrNull() ?: return null
+        return formatSummary(latest.sets, displayUnit).takeIf { it.isNotEmpty() }
+    }
+
+    private fun liftSets(
+        state: WorkoutPersistedState,
+        itemId: String,
+        name: String,
+        dateKey: String
+    ): List<ExerciseLiftSet> {
+        state.dayPlans[dateKey]?.exercises
+            ?.firstOrNull { !it.isCardio && matches(itemId, name, it.itemId, it.name) }
+            ?.let { exercise ->
+                val sets = performedSets(exercise.sets)
+                if (sets.isNotEmpty()) return sets
+            }
+
+        preferredHistorySession(state, dateKey)
+            ?.exercises
+            ?.firstOrNull { matches(itemId, name, it.itemId, it.name) }
+            ?.let { return performedSets(it.sets) }
+
+        return emptyList()
+    }
+
+    private fun preferredHistorySession(state: WorkoutPersistedState, dateKey: String): WorkoutSession? {
+        val sessions = state.completedSessions.filter { it.diaryDateKey == dateKey }
+        if (sessions.isEmpty()) return null
+        val burns = sessions.filter { it.caloriesBurned != null }
+        if (burns.isNotEmpty()) {
+            return burns.maxWith(
+                compareBy<WorkoutSession> { it.healthSyncVersion ?: 0 }.thenBy { it.completedAt }
+            )
+        }
+        return sessions.maxByOrNull { it.completedAt }
     }
 }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/ChatService.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/ChatService.kt
@@ -249,6 +249,7 @@ class ChatService(
         lines.add("- \"How consistent has my fasting been?\" → call get_fasting_history(from, to)")
         lines.add("- \"What's my data range?\" → call get_data_summary")
         lines.add("- \"How is my training progressing?\" → call get_training_summary(from, to), then get_workout_history only if individual sets are needed")
+        lines.add("- \"What did I bench last?\" / one-lift trends → call get_exercise_lift_history(exercise)")
         lines.add("- \"What workout do I have planned?\" → call get_workout_plans")
         lines.add("- Use get_workout_preferences when injuries, available equipment, split, schedule, RPE scale, or strength baselines affect the answer.")
         lines.add("Do NOT call tools for questions you can answer from the profile/forecast below.")

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/CoachTools.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/CoachTools.kt
@@ -367,13 +367,14 @@ class CoachTools(
         val exercise = args.exercise?.trim().orEmpty()
         if (exercise.isEmpty()) return jsonError("exercise is required.")
         val catalogId = args.catalogId?.trim().orEmpty()
-        val toDate = args.to?.let(LocalDate::parse) ?: LocalDate.now(clock)
-        val fromDate = args.from?.let(LocalDate::parse) ?: toDate.minusDays(365)
+        val toDate = parseDate(args.to) ?: LocalDate.now(clock)
+        val fromDate = parseDate(args.from) ?: toDate.minusDays(365)
         val limit = args.boundedLimit(default = 60, maximum = 120)
         val fromKey = fromDate.toString()
         val toKey = toDate.toString()
 
-        val dateKeys = (workoutPlans.map { it.dateKey } + workoutSessions.map { it.diaryDateKey })
+        val dateKeys = workoutSessions
+            .map { it.diaryDateKey }
             .distinct()
             .filter { it in fromKey..toKey }
             .sortedDescending()
@@ -416,14 +417,6 @@ class CoachTools(
     }
 
     private fun coachLiftSets(catalogId: String, name: String, dateKey: String): List<ExerciseLiftSet>? {
-        workoutPlans.firstOrNull { it.dateKey == dateKey }
-            ?.exercises
-            ?.firstOrNull { !it.isCardio && ExerciseLiftHistory.matches(catalogId, name, it.itemId, it.name) }
-            ?.let { exercise ->
-                val sets = ExerciseLiftHistory.performedSets(exercise.sets)
-                if (sets.isNotEmpty()) return sets
-            }
-
         val daySessions = workoutSessions.filter { it.diaryDateKey == dateKey }
         val preferred = daySessions.filter { it.caloriesBurned != null }.maxWithOrNull(
             compareBy<WorkoutSession> { it.healthSyncVersion ?: 0 }.thenBy { it.completedAt }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/CoachTools.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/CoachTools.kt
@@ -5,6 +5,8 @@ import com.apoorvdarshan.calorietracker.models.FoodEntry
 import com.apoorvdarshan.calorietracker.models.FastingSession
 import com.apoorvdarshan.calorietracker.models.FoodSource
 import com.apoorvdarshan.calorietracker.models.MealType
+import com.apoorvdarshan.calorietracker.models.ExerciseLiftHistory
+import com.apoorvdarshan.calorietracker.models.ExerciseLiftSet
 import com.apoorvdarshan.calorietracker.models.WorkoutDate
 import com.apoorvdarshan.calorietracker.models.WorkoutDayPlan
 import com.apoorvdarshan.calorietracker.models.WorkoutPreferences
@@ -43,7 +45,9 @@ class CoachTools(
         ToolArguments(
             from = args.optString("from").takeIf { it.isNotBlank() },
             to = args.optString("to").takeIf { it.isNotBlank() },
-            limit = (args.opt("limit") as? Number)?.toInt()
+            limit = (args.opt("limit") as? Number)?.toInt(),
+            exercise = args.optString("exercise").takeIf { it.isNotBlank() },
+            catalogId = args.optString("catalog_id").takeIf { it.isNotBlank() }
         )
     )
 
@@ -57,7 +61,9 @@ class CoachTools(
                 is Number -> value.toInt()
                 is String -> value.toIntOrNull()
                 else -> null
-            }
+            },
+            exercise = args["exercise"] as? String,
+            catalogId = args["catalog_id"] as? String
         )
     )
 
@@ -72,6 +78,7 @@ class CoachTools(
         "get_workout_plans" -> getWorkoutPlans(args)
         "get_workout_preferences" -> getWorkoutPreferences()
         "get_training_summary" -> getTrainingSummary(args)
+        "get_exercise_lift_history" -> getExerciseLiftHistory(args)
         else -> jsonError("Unknown tool: $name. Available tools: ${TOOL_NAMES.joinToString(", ")}")
     }
 
@@ -356,6 +363,76 @@ class CoachTools(
         )
     }
 
+    private fun getExerciseLiftHistory(args: ToolArguments): String {
+        val exercise = args.exercise?.trim().orEmpty()
+        if (exercise.isEmpty()) return jsonError("exercise is required.")
+        val catalogId = args.catalogId?.trim().orEmpty()
+        val toDate = args.to?.let(LocalDate::parse) ?: LocalDate.now(clock)
+        val fromDate = args.from?.let(LocalDate::parse) ?: toDate.minusDays(365)
+        val limit = args.boundedLimit(default = 60, maximum = 120)
+        val fromKey = fromDate.toString()
+        val toKey = toDate.toString()
+
+        val dateKeys = (workoutPlans.map { it.dateKey } + workoutSessions.map { it.diaryDateKey })
+            .distinct()
+            .filter { it in fromKey..toKey }
+            .sortedDescending()
+
+        val sessions = mutableListOf<Map<String, Any?>>()
+        var bestLoadKg: Double? = null
+        for (key in dateKeys) {
+            if (sessions.size >= limit) break
+            val sets = coachLiftSets(catalogId, exercise, key) ?: continue
+            if (sets.isEmpty()) continue
+            val setPayloads = sets.map { set ->
+                linkedMapOf<String, Any?>("reps" to (set.reps.toIntOrNull() ?: 0)).apply {
+                    if (set.weight.isNotEmpty()) {
+                        put("weight", set.weight)
+                        val unit = set.weightUnit ?: workoutPlanWeightUnit
+                        put("weight_unit", unit.storageValue)
+                        weightKg(set.weight, unit)?.let { kilograms ->
+                            put("weight_kg", round1(kilograms))
+                            bestLoadKg = maxOf(bestLoadKg ?: kilograms, kilograms)
+                        }
+                    }
+                }
+            }
+            sessions += linkedMapOf("date" to key, "sets" to setPayloads)
+        }
+
+        return json(
+            linkedMapOf<String, Any?>(
+                "exercise" to exercise,
+                "from" to fromKey,
+                "to" to toKey,
+                "count" to sessions.size,
+                "sessions" to sessions
+            ).apply {
+                if (catalogId.isNotEmpty()) put("catalog_id", catalogId)
+                bestLoadKg?.let { put("best_load_kg", round1(it)) }
+                sessions.firstOrNull()?.let { put("last_session", it) }
+            }
+        )
+    }
+
+    private fun coachLiftSets(catalogId: String, name: String, dateKey: String): List<ExerciseLiftSet>? {
+        workoutPlans.firstOrNull { it.dateKey == dateKey }
+            ?.exercises
+            ?.firstOrNull { !it.isCardio && ExerciseLiftHistory.matches(catalogId, name, it.itemId, it.name) }
+            ?.let { exercise ->
+                val sets = ExerciseLiftHistory.performedSets(exercise.sets)
+                if (sets.isNotEmpty()) return sets
+            }
+
+        val daySessions = workoutSessions.filter { it.diaryDateKey == dateKey }
+        val preferred = daySessions.filter { it.caloriesBurned != null }.maxWithOrNull(
+            compareBy<WorkoutSession> { it.healthSyncVersion ?: 0 }.thenBy { it.completedAt }
+        ) ?: daySessions.maxByOrNull { it.completedAt }
+        return preferred?.exercises
+            ?.firstOrNull { ExerciseLiftHistory.matches(catalogId, name, it.itemId, it.name) }
+            ?.let { ExerciseLiftHistory.performedSets(it.sets) }
+    }
+
     private fun getTrainingSummary(args: ToolArguments): String {
         val range = parseRange(args)
         val sessions = effectiveWorkoutSessions().filter { session ->
@@ -561,7 +638,9 @@ class CoachTools(
     private data class ToolArguments(
         val from: String? = null,
         val to: String? = null,
-        val limit: Int? = null
+        val limit: Int? = null,
+        val exercise: String? = null,
+        val catalogId: String? = null
     ) {
         fun boundedLimit(default: Int, maximum: Int): Int = limit?.coerceIn(1, maximum) ?: default
     }
@@ -601,7 +680,8 @@ class CoachTools(
             "get_workout_history",
             "get_workout_plans",
             "get_workout_preferences",
-            "get_training_summary"
+            "get_training_summary",
+            "get_exercise_lift_history"
         )
 
         /** Workout tools are deliberately always available, even before the first session. */
@@ -614,10 +694,11 @@ class CoachTools(
             "get_calorie_totals" to "Daily calorie totals (sum of all logged foods per day) between two dates. Returns date + kcal. Use when the user asks about intake patterns older than the last 14 days.",
             "get_food_entries" to "Individual logged food items (name + calories + macros) between two dates. Use when the user asks about specific meals, what they ate on a given date, or wants macro breakdowns rather than just kcal totals.",
             "get_fasting_history" to "Fetch explicitly tracked fasting sessions between two dates, including start/end timestamps, duration, goal, and whether the goal was reached. Never infer fasting from missing food logs.",
-            "get_workout_history" to "Fetch completed workouts between two dates, including calculated calorie burn, saved exercise durations and intensity, and logged sets with weight, reps, and RPE. A timed exercise can be performed without any reps or sets.",
+            "get_workout_history" to "Fetch completed workouts between two dates, including calculated calorie burn, saved exercise durations and intensity, and logged sets with weight, reps, and RPE. A timed exercise can be performed without any reps or sets. For one specific lift across many dates, prefer get_exercise_lift_history.",
             "get_workout_plans" to "Fetch dated workout diary plans, set targets, saved exercise durations, and current timer state. Running or paused timer time is unsaved. Optional ISO from/to dates narrow the result; without them it returns recent and upcoming plans around today.",
             "get_workout_preferences" to "Fetch workout-only preferences such as target muscles, injuries or issues, equipment, schedule, split, RPE scale, and strength numbers.",
-            "get_training_summary" to "Summarize workouts between two dates: calculated calorie burn plus sessions, saved exercise duration, sets, reps, volume, best load, and average RPE by exercise. Timed cardio does not require reps or sets."
+            "get_training_summary" to "Summarize workouts between two dates: calculated calorie burn plus sessions, saved exercise duration, sets, reps, volume, best load, and average RPE by exercise. Timed cardio does not require reps or sets.",
+            "get_exercise_lift_history" to "Fetch per-exercise lift history from the local workout diary: dated sessions with logged weight × reps sets, the most recent session, and best load in kg. Use for questions like \"what did I bench last?\" or trends for one lift. Optional catalog_id narrows matching; otherwise exercise name is used."
         )
 
         /** One schema source is wrapped for Gemini, Anthropic, and OpenAI by [ChatService]. */
@@ -633,6 +714,19 @@ class CoachTools(
                         "to" to linkedMapOf("type" to "string", "description" to "Optional ISO date yyyy-MM-dd, inclusive end"),
                         "limit" to linkedMapOf("type" to "integer", "description" to "Optional max plans to return")
                     )
+                )
+            }
+            if (toolName == "get_exercise_lift_history") {
+                return linkedMapOf(
+                    "type" to "object",
+                    "properties" to linkedMapOf(
+                        "exercise" to linkedMapOf("type" to "string", "description" to "Exercise name, e.g. Bench Press"),
+                        "catalog_id" to linkedMapOf("type" to "string", "description" to "Optional library id when known"),
+                        "from" to linkedMapOf("type" to "string", "description" to "Optional ISO date yyyy-MM-dd, inclusive start (defaults to one year before to)"),
+                        "to" to linkedMapOf("type" to "string", "description" to "Optional ISO date yyyy-MM-dd, inclusive end (defaults to today)"),
+                        "limit" to linkedMapOf("type" to "integer", "description" to "Optional max dated sessions to return")
+                    ),
+                    "required" to listOf("exercise")
                 )
             }
             return linkedMapOf(

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutDiaryScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutDiaryScreen.kt
@@ -156,6 +156,7 @@ internal fun WorkoutDiaryScreen(
     var workoutVoiceVisible by androidx.compose.runtime.saveable.rememberSaveable { mutableStateOf(false) }
     var workoutTranscript by androidx.compose.runtime.saveable.rememberSaveable { mutableStateOf("") }
     var copySheetVisible by remember { mutableStateOf(false) }
+    var historyRequest by remember { mutableStateOf<WorkoutExerciseHistoryRequest?>(null) }
     var addMenuExpanded by remember { mutableStateOf(false) }
     val listState = rememberLazyListState()
     val focusManager = LocalFocusManager.current
@@ -297,7 +298,11 @@ internal fun WorkoutDiaryScreen(
                             rpeScale = state.preferences.rpeScale,
                             editingDate = state.selectedDate,
                             isSaved = isSaved,
+                            lastTimeSummary = viewModel.lastExerciseLiftSummary(exercise.itemId, exercise.name),
                             onOpen = { viewModel.openDiaryExercise(exercise) },
+                            onShowHistory = {
+                                historyRequest = WorkoutExerciseHistoryRequest(exercise.itemId, exercise.name)
+                            },
                             onToggleSaved = toggleSaved,
                             onRemove = removeExercise,
                             onSetCount = { viewModel.setSetCount(exercise.id, it) },
@@ -463,6 +468,16 @@ internal fun WorkoutDiaryScreen(
                 copySheetVisible = false
             },
             onDismiss = { copySheetVisible = false }
+        )
+    }
+
+    historyRequest?.let { request ->
+        WorkoutExerciseHistorySheet(
+            request = request,
+            selectedDate = state.selectedDate,
+            weightUnit = state.weightUnit,
+            history = viewModel.exerciseLiftHistory(request.itemId, request.name),
+            onDismiss = { historyRequest = null }
         )
     }
 
@@ -874,7 +889,9 @@ private fun WorkoutExerciseCard(
     rpeScale: WorkoutRpeScale,
     editingDate: LocalDate,
     isSaved: Boolean,
+    lastTimeSummary: String?,
     onOpen: () -> Unit,
+    onShowHistory: () -> Unit,
     onToggleSaved: () -> Unit,
     onRemove: () -> Unit,
     onSetCount: (Int) -> Unit,
@@ -940,6 +957,31 @@ private fun WorkoutExerciseCard(
                     tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.34f),
                     modifier = Modifier.size(20.dp)
                 )
+            }
+
+            if (!exercise.isCardio && !lastTimeSummary.isNullOrBlank()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        "Last time: $lastTimeSummary",
+                        modifier = Modifier.weight(1f),
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.58f),
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        "History",
+                        modifier = Modifier.clickable(onClick = onShowHistory),
+                        color = AppColors.Calorie,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
             }
 
             Row(

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutDiaryScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutDiaryScreen.kt
@@ -959,21 +959,25 @@ private fun WorkoutExerciseCard(
                 )
             }
 
-            if (!exercise.isCardio && !lastTimeSummary.isNullOrBlank()) {
+            if (!exercise.isCardio) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    Text(
-                        "Last time: $lastTimeSummary",
-                        modifier = Modifier.weight(1f),
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.58f),
-                        fontSize = 12.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis
-                    )
+                    if (!lastTimeSummary.isNullOrBlank()) {
+                        Text(
+                            "Last time: $lastTimeSummary",
+                            modifier = Modifier.weight(1f),
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.58f),
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    } else {
+                        Spacer(modifier = Modifier.weight(1f))
+                    }
                     Text(
                         "History",
                         modifier = Modifier.clickable(onClick = onShowHistory),

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutExerciseHistorySheet.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutExerciseHistorySheet.kt
@@ -1,0 +1,103 @@
+package com.apoorvdarshan.calorietracker.ui.workouts
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.apoorvdarshan.calorietracker.models.ExerciseLiftDay
+import com.apoorvdarshan.calorietracker.models.ExerciseLiftHistory
+import com.apoorvdarshan.calorietracker.models.WorkoutDate
+import com.apoorvdarshan.calorietracker.models.WorkoutWeightUnit
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+data class WorkoutExerciseHistoryRequest(
+    val itemId: String,
+    val name: String
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WorkoutExerciseHistorySheet(
+    request: WorkoutExerciseHistoryRequest,
+    selectedDate: LocalDate,
+    weightUnit: WorkoutWeightUnit,
+    history: List<ExerciseLiftDay>,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                request.name,
+                fontSize = 17.sp,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center
+            )
+            if (history.isEmpty()) {
+                Text(
+                    "No lift history yet",
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.58f),
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.padding(vertical = 24.dp)
+                )
+            } else {
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                    items(history, key = { it.dateKey }) { day ->
+                        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            Text(
+                                dayTitle(day.dateKey, selectedDate),
+                                color = MaterialTheme.colorScheme.onSurface,
+                                fontSize = 15.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                            Text(
+                                ExerciseLiftHistory.formatSummary(day.sets, weightUnit),
+                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.58f),
+                                fontSize = 13.sp,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun dayTitle(dateKey: String, selectedDate: LocalDate): String {
+    val date = WorkoutDate.parse(dateKey) ?: return dateKey
+    val today = LocalDate.now()
+    return when {
+        date == today -> "Today"
+        date == today.minusDays(1) -> "Yesterday"
+        date == selectedDate -> "Selected day"
+        else -> date.format(DateTimeFormatter.ofPattern("EEE, MMM d, yyyy", Locale.getDefault()))
+    }
+}

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutsViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutsViewModel.kt
@@ -14,6 +14,8 @@ import com.apoorvdarshan.calorietracker.data.WorkoutRepository
 import com.apoorvdarshan.calorietracker.models.Gender
 import com.apoorvdarshan.calorietracker.models.ExerciseTimerAction
 import com.apoorvdarshan.calorietracker.models.WorkoutIntensity
+import com.apoorvdarshan.calorietracker.models.ExerciseLiftDay
+import com.apoorvdarshan.calorietracker.models.ExerciseLiftHistory
 import com.apoorvdarshan.calorietracker.models.PlannedExercise
 import com.apoorvdarshan.calorietracker.models.WorkoutDate
 import com.apoorvdarshan.calorietracker.models.WorkoutPersistedState
@@ -343,6 +345,23 @@ class WorkoutsViewModel(app: Application) : AndroidViewModel(app) {
     fun dismissNotice() {
         diaryUiState = diaryUiState.copy(notice = null)
     }
+
+    fun lastExerciseLiftSummary(itemId: String, name: String): String? =
+        ExerciseLiftHistory.lastSummary(
+            latestPersistedState,
+            itemId,
+            name,
+            WorkoutDate.key(diaryUiState.selectedDate),
+            workoutWeightUnit
+        )
+
+    fun exerciseLiftHistory(itemId: String, name: String): List<ExerciseLiftDay> =
+        ExerciseLiftHistory.history(
+            latestPersistedState,
+            itemId,
+            name,
+            WorkoutDate.key(diaryUiState.selectedDate)
+        )
 
     fun openDiaryExercise(exercise: PlannedExercise) {
         openExerciseSnapshot = exercise.asExerciseItem()

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutsViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutsViewModel.kt
@@ -80,6 +80,7 @@ class WorkoutsViewModel(app: Application) : AndroidViewModel(app) {
     private var workoutRepository: WorkoutRepository? = null
     private var repositoryJob: Job? = null
     private var latestPersistedState = WorkoutPersistedState()
+    private var exerciseLiftSummaries: Map<String, String?> = emptyMap()
     private var bodyWeightKg = 70.0
     private var workoutWeightUnit = WorkoutWeightUnit.LBS
     private var profileGender = Gender.MALE
@@ -347,13 +348,7 @@ class WorkoutsViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     fun lastExerciseLiftSummary(itemId: String, name: String): String? =
-        ExerciseLiftHistory.lastSummary(
-            latestPersistedState,
-            itemId,
-            name,
-            WorkoutDate.key(diaryUiState.selectedDate),
-            workoutWeightUnit
-        )
+        exerciseLiftSummaries[liftSummaryKey(itemId, name)]
 
     fun exerciseLiftHistory(itemId: String, name: String): List<ExerciseLiftDay> =
         ExerciseLiftHistory.history(
@@ -422,6 +417,26 @@ class WorkoutsViewModel(app: Application) : AndroidViewModel(app) {
             weightUnit = workoutWeightUnit,
             visualGender = profileGender
         )
+        rebuildExerciseLiftSummaries()
+    }
+
+    private fun liftSummaryKey(itemId: String, name: String): String =
+        "$itemId\u0000${ExerciseLiftHistory.normalizedName(name)}"
+
+    private fun rebuildExerciseLiftSummaries() {
+        val beforeKey = WorkoutDate.key(diaryUiState.selectedDate)
+        exerciseLiftSummaries = diaryUiState.exercises
+            .asSequence()
+            .filterNot { it.isCardio }
+            .associate { exercise ->
+                liftSummaryKey(exercise.itemId, exercise.name) to ExerciseLiftHistory.lastSummary(
+                    latestPersistedState,
+                    exercise.itemId,
+                    exercise.name,
+                    beforeKey,
+                    workoutWeightUnit
+                )
+            }
     }
 
     val hasActiveFilters: Boolean

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutsViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutsViewModel.kt
@@ -81,6 +81,7 @@ class WorkoutsViewModel(app: Application) : AndroidViewModel(app) {
     private var repositoryJob: Job? = null
     private var latestPersistedState = WorkoutPersistedState()
     private var exerciseLiftSummaries: Map<String, String?> = emptyMap()
+    private var exerciseLiftSummaryInputs: ExerciseLiftSummaryInputs? = null
     private var bodyWeightKg = 70.0
     private var workoutWeightUnit = WorkoutWeightUnit.LBS
     private var profileGender = Gender.MALE
@@ -417,14 +418,46 @@ class WorkoutsViewModel(app: Application) : AndroidViewModel(app) {
             weightUnit = workoutWeightUnit,
             visualGender = profileGender
         )
-        rebuildExerciseLiftSummaries()
+        rebuildExerciseLiftSummariesIfNeeded()
     }
 
     private fun liftSummaryKey(itemId: String, name: String): String =
         "$itemId\u0000${ExerciseLiftHistory.normalizedName(name)}"
 
-    private fun rebuildExerciseLiftSummaries() {
+    private data class ExerciseLiftSummaryInputs(
+        val beforeKey: String,
+        val weightUnit: WorkoutWeightUnit,
+        val historyToken: Int,
+        val exerciseKeys: Set<String>
+    )
+
+    private fun completedSessionsHistoryToken(state: WorkoutPersistedState): Int =
+        state.completedSessions.fold(0) { token, session ->
+            var next = 31 * token + session.diaryDateKey.hashCode()
+            next = 31 * next + session.completedAt.hashCode()
+            next = 31 * next + (session.healthSyncVersion ?: 0)
+            session.exercises.fold(next) { exerciseToken, exercise ->
+                var perExercise = 31 * exerciseToken + exercise.itemId.hashCode()
+                perExercise = 31 * perExercise + exercise.sets.count { it.isPerformed }
+                perExercise
+            }
+        }
+
+    private fun rebuildExerciseLiftSummariesIfNeeded() {
         val beforeKey = WorkoutDate.key(diaryUiState.selectedDate)
+        val exerciseKeys = diaryUiState.exercises
+            .asSequence()
+            .filterNot { it.isCardio }
+            .map { liftSummaryKey(it.itemId, it.name) }
+            .toSet()
+        val inputs = ExerciseLiftSummaryInputs(
+            beforeKey = beforeKey,
+            weightUnit = workoutWeightUnit,
+            historyToken = completedSessionsHistoryToken(latestPersistedState),
+            exerciseKeys = exerciseKeys
+        )
+        if (inputs == exerciseLiftSummaryInputs) return
+        exerciseLiftSummaryInputs = inputs
         exerciseLiftSummaries = diaryUiState.exercises
             .asSequence()
             .filterNot { it.isCardio }

--- a/android/app/src/test/java/com/apoorvdarshan/calorietracker/data/WorkoutRepositoryTest.kt
+++ b/android/app/src/test/java/com/apoorvdarshan/calorietracker/data/WorkoutRepositoryTest.kt
@@ -96,7 +96,7 @@ class WorkoutRepositoryTest {
         assertEquals("8", edited.sets.first().reps)
         assertEquals("7.5", edited.sets.first().rpe)
         assertTrue(edited.sets.drop(1).all {
-            it.weight.isEmpty() && it.weightUnit == null && it.reps.isEmpty() &&
+            it.weight == "82.5" && it.weightUnit == WorkoutWeightUnit.KG && it.reps == "8" &&
                 it.rpe.isEmpty() && it.rpeScale == null
         })
 

--- a/android/app/src/test/java/com/apoorvdarshan/calorietracker/models/WorkoutModelsTest.kt
+++ b/android/app/src/test/java/com/apoorvdarshan/calorietracker/models/WorkoutModelsTest.kt
@@ -181,6 +181,19 @@ class WorkoutModelsTest {
     }
 
     @Test
+    fun liftHistoryMatchingUsesCatalogIdExclusivelyWhenProvided() {
+        assertTrue(
+            ExerciseLiftHistory.matches("bench-press", "Bench Press", "bench-press", "Bench Press")
+        )
+        assertFalse(
+            ExerciseLiftHistory.matches("bench-press", "Bench Press", "custom-bench", "Bench Press")
+        )
+        assertTrue(
+            ExerciseLiftHistory.matches("", "Bench Press", "custom-bench", "Bench Press")
+        )
+    }
+
+    @Test
     fun timedCaloriesUseRpeAcrossScalesAndIgnoreBlankSets() {
         fun timed(rpe: String, scale: WorkoutRpeScale) = exercise(PlannedSet(rpe = rpe, rpeScale = scale)).copy(
             timer = ExerciseTimer(accumulatedSeconds = 600.0, savedDurationSeconds = 600.0)

--- a/android/app/src/test/java/com/apoorvdarshan/calorietracker/services/ai/CoachWorkoutToolsTest.kt
+++ b/android/app/src/test/java/com/apoorvdarshan/calorietracker/services/ai/CoachWorkoutToolsTest.kt
@@ -175,6 +175,84 @@ class CoachWorkoutToolsTest {
     }
 
     @Test
+    fun exerciseLiftHistoryRespectsCatalogIdOverSameName() {
+        val catalogBench = session(
+            dateKey = "2026-07-19",
+            completedAt = "2026-07-19T10:00:00Z",
+            caloriesBurned = 180,
+            exercise = "Bench Press",
+            sets = listOf(set(1, "60", "8", "7"))
+        )
+        val customBench = session(
+            dateKey = "2026-07-18",
+            completedAt = "2026-07-18T10:00:00Z",
+            caloriesBurned = 170,
+            exercise = "Bench Press",
+            sets = listOf(set(1, "100", "5", "8"))
+        ).copy(
+            exercises = listOf(
+                CompletedExercise(
+                    itemId = "custom-bench",
+                    name = "Bench Press",
+                    targetMuscles = listOf("Chest"),
+                    equipment = "Barbell",
+                    sets = listOf(set(1, "100", "5", "8"))
+                )
+            )
+        )
+        val payload = json(
+            tools(workoutSessions = listOf(catalogBench, customBench), workoutPlanWeightUnit = WorkoutWeightUnit.KG)
+                .execute(
+                    "get_exercise_lift_history",
+                    mapOf(
+                        "exercise" to "Bench Press",
+                        "catalog_id" to "bench-press",
+                        "to" to "2026-07-20"
+                    )
+                )
+        )
+        assertEquals(1, payload["count"].asInt)
+        val sets = payload.getAsJsonArray("sessions")[0].asJsonObject.getAsJsonArray("sets")
+        assertEquals("60", sets[0].asJsonObject["weight"].asString)
+    }
+
+    @Test
+    fun exerciseLiftHistoryUsesAuthoritativeSameDaySnapshot() {
+        val legacy = session(
+            dateKey = "2026-07-12",
+            completedAt = "2026-07-12T08:00:00Z",
+            exercise = "Bench Press",
+            sets = listOf(set(1, "80", "5", "7"))
+        )
+        val newerClockButOlderVersion = session(
+            dateKey = "2026-07-12",
+            completedAt = "2026-07-12T11:00:00Z",
+            caloriesBurned = 190,
+            healthSyncVersion = 1,
+            exercise = "Bench Press",
+            sets = listOf(set(1, "82.5", "6", "7.5"))
+        )
+        val authoritative = session(
+            dateKey = "2026-07-12",
+            completedAt = "2026-07-12T10:00:00Z",
+            caloriesBurned = 210,
+            healthSyncVersion = 2,
+            exercise = "Bench Press",
+            sets = listOf(set(1, "85", "8", "8"))
+        )
+        val payload = json(
+            tools(workoutSessions = listOf(legacy, newerClockButOlderVersion, authoritative))
+                .execute(
+                    "get_exercise_lift_history",
+                    mapOf("exercise" to "Bench Press", "to" to "2026-07-20")
+                )
+        )
+        val sets = payload.getAsJsonArray("sessions")[0].asJsonObject.getAsJsonArray("sets")
+        assertEquals("85", sets[0].asJsonObject["weight"].asString)
+        assertEquals(8, sets[0].asJsonObject["reps"].asInt)
+    }
+
+    @Test
     fun summaryAndHistoryUseNewestCalculatedSameDaySnapshot() {
         val legacy = session(
             dateKey = "2026-07-12",

--- a/android/app/src/test/java/com/apoorvdarshan/calorietracker/services/ai/CoachWorkoutToolsTest.kt
+++ b/android/app/src/test/java/com/apoorvdarshan/calorietracker/services/ai/CoachWorkoutToolsTest.kt
@@ -114,6 +114,28 @@ class CoachWorkoutToolsTest {
 
     @Test
     fun exerciseLiftHistoryReturnsRecentSetsForOneLift() {
+        val logged = session(
+            dateKey = "2026-07-19",
+            completedAt = "2026-07-19T10:00:00Z",
+            caloriesBurned = 180,
+            exercise = "Bench Press",
+            sets = listOf(set(1, "60", "8", "7"))
+        )
+        val payload = json(
+            tools(workoutSessions = listOf(logged), workoutPlanWeightUnit = WorkoutWeightUnit.KG)
+                .execute("get_exercise_lift_history", mapOf("exercise" to "Bench Press", "to" to "2026-07-20"))
+        )
+        assertEquals(1, payload["count"].asInt)
+        val sessions = payload.getAsJsonArray("sessions")
+        assertEquals("2026-07-19", sessions[0].asJsonObject["date"].asString)
+        val sets = sessions[0].asJsonObject.getAsJsonArray("sets")
+        assertEquals("60", sets[0].asJsonObject["weight"].asString)
+        assertEquals(8, sets[0].asJsonObject["reps"].asInt)
+        assertEquals("2026-07-19", payload.getAsJsonObject("last_session")["date"].asString)
+    }
+
+    @Test
+    fun exerciseLiftHistoryIgnoresUnsavedDayPlans() {
         val plan = WorkoutDayPlan(
             dateKey = "2026-07-19",
             exercises = listOf(
@@ -126,13 +148,30 @@ class CoachWorkoutToolsTest {
             tools(workoutPlans = listOf(plan), workoutPlanWeightUnit = WorkoutWeightUnit.KG)
                 .execute("get_exercise_lift_history", mapOf("exercise" to "Bench Press", "to" to "2026-07-20"))
         )
+        assertEquals(0, payload["count"].asInt)
+        assertFalse(payload.has("last_session"))
+    }
+
+    @Test
+    fun exerciseLiftHistoryToleratesMalformedDates() {
+        val logged = session(
+            dateKey = "2026-07-19",
+            completedAt = "2026-07-19T10:00:00Z",
+            caloriesBurned = 180,
+            exercise = "Bench Press",
+            sets = listOf(set(1, "60", "8", "7"))
+        )
+        val payload = json(
+            tools(
+                workoutSessions = listOf(logged),
+                workoutPlanWeightUnit = WorkoutWeightUnit.KG,
+                clock = Clock.fixed(Instant.parse("2026-07-20T12:00:00Z"), ZoneOffset.UTC)
+            ).execute(
+                "get_exercise_lift_history",
+                mapOf("exercise" to "Bench Press", "from" to "not-a-date", "to" to "also-bad")
+            )
+        )
         assertEquals(1, payload["count"].asInt)
-        val sessions = payload.getAsJsonArray("sessions")
-        assertEquals("2026-07-19", sessions[0].asJsonObject["date"].asString)
-        val sets = sessions[0].asJsonObject.getAsJsonArray("sets")
-        assertEquals("60", sets[0].asJsonObject["weight"].asString)
-        assertEquals(8, sets[0].asJsonObject["reps"].asInt)
-        assertEquals("2026-07-19", payload.getAsJsonObject("last_session")["date"].asString)
     }
 
     @Test
@@ -350,7 +389,8 @@ class CoachWorkoutToolsTest {
         workoutSessions: List<WorkoutSession> = emptyList(),
         workoutPlans: List<WorkoutDayPlan> = emptyList(),
         workoutPreferences: WorkoutPreferences = WorkoutPreferences(),
-        workoutPlanWeightUnit: WorkoutWeightUnit = WorkoutWeightUnit.LBS
+        workoutPlanWeightUnit: WorkoutWeightUnit = WorkoutWeightUnit.LBS,
+        clock: Clock = Clock.systemDefaultZone()
     ) = CoachTools(
         weights = emptyList(),
         bodyFats = emptyList(),
@@ -358,7 +398,8 @@ class CoachWorkoutToolsTest {
         workoutSessions = workoutSessions,
         workoutPlans = workoutPlans,
         workoutPreferences = workoutPreferences,
-        workoutPlanWeightUnit = workoutPlanWeightUnit
+        workoutPlanWeightUnit = workoutPlanWeightUnit,
+        clock = clock
     )
 
     private fun session(

--- a/android/app/src/test/java/com/apoorvdarshan/calorietracker/services/ai/CoachWorkoutToolsTest.kt
+++ b/android/app/src/test/java/com/apoorvdarshan/calorietracker/services/ai/CoachWorkoutToolsTest.kt
@@ -109,6 +109,30 @@ class CoachWorkoutToolsTest {
         for (name in listOf("get_workout_history", "get_training_summary")) {
             assertEquals(listOf("from", "to"), CoachTools.parameterSchemaFor(name)["required"])
         }
+        assertEquals(listOf("exercise"), CoachTools.parameterSchemaFor("get_exercise_lift_history")["required"])
+    }
+
+    @Test
+    fun exerciseLiftHistoryReturnsRecentSetsForOneLift() {
+        val plan = WorkoutDayPlan(
+            dateKey = "2026-07-19",
+            exercises = listOf(
+                plannedExercise(
+                    listOf(PlannedSet(weight = "60", weightUnit = WorkoutWeightUnit.KG, reps = "8"))
+                ).copy(itemId = "bench", name = "Bench Press")
+            )
+        )
+        val payload = json(
+            tools(workoutPlans = listOf(plan), workoutPlanWeightUnit = WorkoutWeightUnit.KG)
+                .execute("get_exercise_lift_history", mapOf("exercise" to "Bench Press", "to" to "2026-07-20"))
+        )
+        assertEquals(1, payload["count"].asInt)
+        val sessions = payload.getAsJsonArray("sessions")
+        assertEquals("2026-07-19", sessions[0].asJsonObject["date"].asString)
+        val sets = sessions[0].asJsonObject.getAsJsonArray("sets")
+        assertEquals("60", sets[0].asJsonObject["weight"].asString)
+        assertEquals(8, sets[0].asJsonObject["reps"].asInt)
+        assertEquals("2026-07-19", payload.getAsJsonObject("last_session")["date"].asString)
     }
 
     @Test

--- a/ios/calorietracker/Models/StrengthWorkoutSession.swift
+++ b/ios/calorietracker/Models/StrengthWorkoutSession.swift
@@ -733,18 +733,6 @@ enum StrengthExerciseLiftHistory {
         return !left.isEmpty && left == right
     }
 
-    static func performedSets(from planned: [StrengthPlannedSet]) -> [StrengthExerciseLiftSet] {
-        planned.compactMap { set in
-            let reps = set.reps.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !reps.isEmpty else { return nil }
-            return StrengthExerciseLiftSet(
-                weight: set.weight.trimmingCharacters(in: .whitespacesAndNewlines),
-                weightUnit: set.weightUnit ?? "",
-                reps: reps
-            )
-        }
-    }
-
     static func performedSets(from completed: [StrengthCompletedSet]) -> [StrengthExerciseLiftSet] {
         completed.filter(\.isPerformed).map {
             StrengthExerciseLiftSet(weight: $0.weight, weightUnit: $0.weightUnit, reps: $0.reps)

--- a/ios/calorietracker/Models/StrengthWorkoutSession.swift
+++ b/ios/calorietracker/Models/StrengthWorkoutSession.swift
@@ -242,6 +242,15 @@ struct StrengthPlannedSet: Identifiable, Codable, Equatable, Hashable {
         )
     }
 
+    /// New sets inherit weight, unit, and reps from the set above; RPE stays blank.
+    func copyingFromPrevious() -> StrengthPlannedSet {
+        StrengthPlannedSet(
+            weight: weight,
+            weightUnit: weightUnit,
+            reps: reps
+        )
+    }
+
     /// Presents a persisted load in the app-wide unit without relabeling the
     /// underlying value. Editing the field then stores the new text together
     /// with the currently selected global unit.
@@ -694,5 +703,66 @@ struct StrengthWorkoutSplitGroup: Identifiable, Hashable {
         return availableMuscles.map { muscle in
             StrengthWorkoutSplitGroup(title: muscle, muscles: [muscle])
         }
+    }
+}
+
+struct StrengthExerciseLiftSet: Equatable, Hashable {
+    let weight: String
+    let weightUnit: String
+    let reps: String
+}
+
+struct StrengthExerciseLiftDay: Identifiable, Equatable, Hashable {
+    var id: String { dateKey }
+    let dateKey: String
+    let sets: [StrengthExerciseLiftSet]
+}
+
+enum StrengthExerciseLiftHistory {
+    static func normalizedName(_ name: String) -> String {
+        name
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+    }
+
+    static func matches(itemID: String, name: String, candidateItemID: String, candidateName: String) -> Bool {
+        if !itemID.isEmpty, itemID == candidateItemID { return true }
+        let left = normalizedName(name)
+        let right = normalizedName(candidateName)
+        return !left.isEmpty && left == right
+    }
+
+    static func performedSets(from planned: [StrengthPlannedSet]) -> [StrengthExerciseLiftSet] {
+        planned.compactMap { set in
+            let reps = set.reps.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !reps.isEmpty else { return nil }
+            return StrengthExerciseLiftSet(
+                weight: set.weight.trimmingCharacters(in: .whitespacesAndNewlines),
+                weightUnit: set.weightUnit ?? "",
+                reps: reps
+            )
+        }
+    }
+
+    static func performedSets(from completed: [StrengthCompletedSet]) -> [StrengthExerciseLiftSet] {
+        completed.filter(\.isPerformed).map {
+            StrengthExerciseLiftSet(weight: $0.weight, weightUnit: $0.weightUnit, reps: $0.reps)
+        }
+    }
+
+    static func formatSetLine(_ set: StrengthExerciseLiftSet, displayUnit: WeightUnit) -> String {
+        guard !set.reps.isEmpty else { return "" }
+        guard !set.weight.isEmpty else { return "\(set.reps) reps" }
+        let planned = StrengthPlannedSet(weight: set.weight, weightUnit: set.weightUnit, reps: set.reps)
+        return "\(planned.displayWeight(in: displayUnit)) \(displayUnit.rawValue) × \(set.reps)"
+    }
+
+    static func formatSummary(_ sets: [StrengthExerciseLiftSet], displayUnit: WeightUnit) -> String {
+        sets.compactMap { line in
+            let formatted = formatSetLine(line, displayUnit: displayUnit)
+            return formatted.isEmpty ? nil : formatted
+        }
+        .joined(separator: ", ")
     }
 }

--- a/ios/calorietracker/Models/StrengthWorkoutSession.swift
+++ b/ios/calorietracker/Models/StrengthWorkoutSession.swift
@@ -727,7 +727,7 @@ enum StrengthExerciseLiftHistory {
     }
 
     static func matches(itemID: String, name: String, candidateItemID: String, candidateName: String) -> Bool {
-        if !itemID.isEmpty, itemID == candidateItemID { return true }
+        if !itemID.isEmpty { return itemID == candidateItemID }
         let left = normalizedName(name)
         let right = normalizedName(candidateName)
         return !left.isEmpty && left == right

--- a/ios/calorietracker/Services/ChatService.swift
+++ b/ios/calorietracker/Services/ChatService.swift
@@ -259,6 +259,7 @@ struct ChatService {
         lines.append("- \"What's my data range?\" → call get_data_summary")
         if workoutAccessEnabled {
             lines.append("- \"How is my training progressing?\" → call get_training_summary(from, to), then get_workout_history only if individual sets are needed")
+            lines.append("- \"What did I bench last?\" / one-lift trends → call get_exercise_lift_history(exercise)")
             lines.append("- \"What workout do I have planned?\" → call get_workout_plans")
             lines.append("- Use get_workout_preferences when injuries, available equipment, split, schedule, RPE scale, or strength baselines affect the answer.")
         }

--- a/ios/calorietracker/Services/CoachTools.swift
+++ b/ios/calorietracker/Services/CoachTools.swift
@@ -528,8 +528,12 @@ struct CoachTools {
 
     private func coachLiftSets(itemID: String, name: String, on dateKey: String) -> [StrengthExerciseLiftSet]? {
         let daySessions = workoutSessions.filter { $0.stableDiaryDateKey == dateKey }
-        let preferred = daySessions.first(where: { $0.caloriesBurned != nil })
-            ?? daySessions.max(by: { $0.completedAt < $1.completedAt })
+        let preferred = daySessions.filter { $0.caloriesBurned != nil }.max(by: {
+            let leftVersion = $0.healthSyncVersion ?? 0
+            let rightVersion = $1.healthSyncVersion ?? 0
+            if leftVersion == rightVersion { return $0.completedAt < $1.completedAt }
+            return leftVersion < rightVersion
+        }) ?? daySessions.max(by: { $0.completedAt < $1.completedAt })
         guard let session = preferred,
               let exercise = session.exercises.first(where: {
                   StrengthExerciseLiftHistory.matches(

--- a/ios/calorietracker/Services/CoachTools.swift
+++ b/ios/calorietracker/Services/CoachTools.swift
@@ -488,9 +488,9 @@ struct CoachTools {
         let fromKey = Self.iso(Calendar.current.startOfDay(for: from))
         let toKey = Self.iso(Calendar.current.startOfDay(for: to))
 
-        var dateKeys = Set(workoutPlans.map(\.dateKey))
-        dateKeys.formUnion(effectiveWorkoutSessions.map(\.stableDiaryDateKey))
-        let inRange = dateKeys.filter { $0 >= fromKey && $0 <= toKey }.sorted(by: >)
+        let inRange = Set(effectiveWorkoutSessions.map(\.stableDiaryDateKey))
+            .filter { $0 >= fromKey && $0 <= toKey }
+            .sorted(by: >)
 
         var sessions: [[String: Any]] = []
         var bestLoadKg: Double?
@@ -527,19 +527,6 @@ struct CoachTools {
     }
 
     private func coachLiftSets(itemID: String, name: String, on dateKey: String) -> [StrengthExerciseLiftSet]? {
-        if let plan = workoutPlans.first(where: { $0.dateKey == dateKey }),
-           let exercise = plan.exercises.first(where: {
-               !$0.isCardio && StrengthExerciseLiftHistory.matches(
-                   itemID: itemID,
-                   name: name,
-                   candidateItemID: $0.itemID,
-                   candidateName: $0.name
-               )
-           }) {
-            let sets = StrengthExerciseLiftHistory.performedSets(from: exercise.sets)
-            if !sets.isEmpty { return sets }
-        }
-
         let daySessions = workoutSessions.filter { $0.stableDiaryDateKey == dateKey }
         let preferred = daySessions.first(where: { $0.caloriesBurned != nil })
             ?? daySessions.max(by: { $0.completedAt < $1.completedAt })

--- a/ios/calorietracker/Services/CoachTools.swift
+++ b/ios/calorietracker/Services/CoachTools.swift
@@ -39,6 +39,7 @@ struct CoachTools {
         "get_workout_plans",
         "get_workout_preferences",
         "get_training_summary",
+        "get_exercise_lift_history",
     ]
 
     /// The provider schemas are built from this instance value, preventing any
@@ -76,10 +77,11 @@ struct CoachTools {
         "get_calorie_totals": "Daily calorie totals (sum of all logged foods per day) between two dates. Returns date + kcal. Use when the user asks about intake patterns older than the last 14 days.",
         "get_food_entries": "Individual logged food items (name + calories + macros) between two dates. Use when the user asks about specific meals, what they ate on a given date, or wants macro breakdowns rather than just kcal totals.",
         "get_fasting_history": "Fetch explicitly tracked fasting sessions between two dates, including start/end timestamps, duration, goal, and whether the goal was reached. Never infer fasting from missing food logs.",
-        "get_workout_history": "Fetch completed workouts between two dates, including calculated calorie burn, saved exercise durations and intensity, and logged sets with weight, reps, and RPE. A timed exercise can be performed without any reps or sets.",
+        "get_workout_history": "Fetch completed workouts between two dates, including calculated calorie burn, saved exercise durations and intensity, and logged sets with weight, reps, and RPE. A timed exercise can be performed without any reps or sets. For one specific lift across many dates, prefer get_exercise_lift_history.",
         "get_workout_plans": "Fetch dated workout diary plans, set targets, saved exercise durations, and current timer state. Running or paused timer time is unsaved. Optional ISO from/to dates narrow the result; without them it returns recent and upcoming plans around today.",
         "get_workout_preferences": "Fetch workout-only preferences such as target muscles, injuries or issues, equipment, schedule, split, RPE scale, and strength numbers.",
         "get_training_summary": "Summarize workouts between two dates: calculated calorie burn plus sessions, saved exercise duration, sets, reps, volume, best load, and average RPE by exercise. Timed cardio does not require reps or sets.",
+        "get_exercise_lift_history": "Fetch per-exercise lift history from the local workout diary: dated sessions with logged weight × reps sets, the most recent session, and best load in kg. Use for questions like \"what did I bench last?\" or trends for one lift. Optional catalog_id narrows matching; otherwise exercise name is used.",
     ]
 
     /// One schema source is translated to each provider's wrapper by
@@ -97,6 +99,19 @@ struct CoachTools {
                     "to": ["type": "string", "description": "Optional ISO date yyyy-MM-dd, inclusive end"],
                     "limit": ["type": "integer", "description": "Optional max plans to return"],
                 ],
+            ]
+        }
+        if toolName == "get_exercise_lift_history" {
+            return [
+                "type": "object",
+                "properties": [
+                    "exercise": ["type": "string", "description": "Exercise name, e.g. Bench Press"],
+                    "catalog_id": ["type": "string", "description": "Optional library id when known"],
+                    "from": ["type": "string", "description": "Optional ISO date yyyy-MM-dd, inclusive start (defaults to one year before to)"],
+                    "to": ["type": "string", "description": "Optional ISO date yyyy-MM-dd, inclusive end (defaults to today)"],
+                    "limit": ["type": "integer", "description": "Optional max dated sessions to return"],
+                ],
+                "required": ["exercise"],
             ]
         }
         return [
@@ -140,6 +155,8 @@ struct CoachTools {
             return getWorkoutPreferences()
         case "get_training_summary":
             return getTrainingSummary(arguments: arguments)
+        case "get_exercise_lift_history":
+            return getExerciseLiftHistory(arguments: arguments)
         default:
             return jsonError("Unknown tool: \(name). Available tools: \(availableToolNames.joined(separator: ", "))")
         }
@@ -452,6 +469,91 @@ struct CoachTools {
                 "overhead_press": strengthValue(preferences.strength.overheadPressKg),
             ],
         ])
+    }
+
+    private func getExerciseLiftHistory(arguments: [String: Any]) -> String {
+        guard let exercise = (arguments["exercise"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !exercise.isEmpty
+        else {
+            return jsonError("exercise is required.")
+        }
+        let catalogID = (arguments["catalog_id"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let to = (arguments["to"] as? String).flatMap(Self.parseDate) ?? Date()
+        let from = (arguments["from"] as? String).flatMap(Self.parseDate)
+            ?? Calendar.current.date(byAdding: .day, value: -365, to: to)
+            ?? to
+        let limit = (arguments["limit"] as? Int).map { min(max($0, 1), 120) } ?? 60
+        let fromKey = Self.iso(Calendar.current.startOfDay(for: from))
+        let toKey = Self.iso(Calendar.current.startOfDay(for: to))
+
+        var dateKeys = Set(workoutPlans.map(\.dateKey))
+        dateKeys.formUnion(effectiveWorkoutSessions.map(\.stableDiaryDateKey))
+        let inRange = dateKeys.filter { $0 >= fromKey && $0 <= toKey }.sorted(by: >)
+
+        var sessions: [[String: Any]] = []
+        var bestLoadKg: Double?
+        for key in inRange {
+            guard sessions.count < limit else { break }
+            guard let sets = coachLiftSets(itemID: catalogID, name: exercise, on: key), !sets.isEmpty else { continue }
+            let setPayloads = sets.map { set -> [String: Any] in
+                var payload: [String: Any] = ["reps": Int(set.reps) ?? 0]
+                if !set.weight.isEmpty {
+                    payload["weight"] = set.weight
+                    let unit = set.weightUnit.isEmpty ? workoutPlanWeightUnit.rawValue : set.weightUnit
+                    payload["weight_unit"] = unit
+                    if let kg = Self.weightKg(value: set.weight, unit: unit) {
+                        payload["weight_kg"] = (kg * 10).rounded() / 10
+                        bestLoadKg = max(bestLoadKg ?? kg, kg)
+                    }
+                }
+                return payload
+            }
+            sessions.append(["date": key, "sets": setPayloads])
+        }
+
+        var payload: [String: Any] = [
+            "exercise": exercise,
+            "from": fromKey,
+            "to": toKey,
+            "count": sessions.count,
+            "sessions": sessions,
+        ]
+        if !catalogID.isEmpty { payload["catalog_id"] = catalogID }
+        if let bestLoadKg { payload["best_load_kg"] = (bestLoadKg * 10).rounded() / 10 }
+        if let last = sessions.first { payload["last_session"] = last }
+        return jsonString(payload)
+    }
+
+    private func coachLiftSets(itemID: String, name: String, on dateKey: String) -> [StrengthExerciseLiftSet]? {
+        if let plan = workoutPlans.first(where: { $0.dateKey == dateKey }),
+           let exercise = plan.exercises.first(where: {
+               !$0.isCardio && StrengthExerciseLiftHistory.matches(
+                   itemID: itemID,
+                   name: name,
+                   candidateItemID: $0.itemID,
+                   candidateName: $0.name
+               )
+           }) {
+            let sets = StrengthExerciseLiftHistory.performedSets(from: exercise.sets)
+            if !sets.isEmpty { return sets }
+        }
+
+        let daySessions = workoutSessions.filter { $0.stableDiaryDateKey == dateKey }
+        let preferred = daySessions.first(where: { $0.caloriesBurned != nil })
+            ?? daySessions.max(by: { $0.completedAt < $1.completedAt })
+        guard let session = preferred,
+              let exercise = session.exercises.first(where: {
+                  StrengthExerciseLiftHistory.matches(
+                      itemID: itemID,
+                      name: name,
+                      candidateItemID: $0.itemID,
+                      candidateName: $0.name
+                  )
+              })
+        else { return nil }
+        return StrengthExerciseLiftHistory.performedSets(from: exercise.sets)
     }
 
     private func getTrainingSummary(arguments: [String: Any]) -> String {

--- a/ios/calorietracker/Stores/StrengthWorkoutStore.swift
+++ b/ios/calorietracker/Stores/StrengthWorkoutStore.swift
@@ -31,6 +31,8 @@ final class StrengthWorkoutStore {
 
     private let defaults: UserDefaults
     private let storageKey: String
+    private var liftSummaryCacheKey: (beforeKey: String, displayUnit: WeightUnit)?
+    private var liftSummaryCache: [String: String] = [:]
 
     init(defaults: UserDefaults = .standard, storageKey: String = StrengthWorkoutStore.defaultStorageKey) {
         self.defaults = defaults
@@ -240,9 +242,9 @@ final class StrengthWorkoutStore {
         limit: Int = 90
     ) -> [StrengthExerciseLiftDay] {
         let beforeKey = Self.dateKey(for: date)
-        var dateKeys = Set(dayPlans.keys)
-        dateKeys.formUnion(completedSessions.map(\.stableDiaryDateKey))
-        let priorKeys = dateKeys.filter { $0 < beforeKey }.sorted(by: >)
+        let priorKeys = Set(completedSessions.map(\.stableDiaryDateKey))
+            .filter { $0 < beforeKey }
+            .sorted(by: >)
 
         var results: [StrengthExerciseLiftDay] = []
         for key in priorKeys {
@@ -260,10 +262,22 @@ final class StrengthWorkoutStore {
         before date: Date,
         displayUnit: WeightUnit
     ) -> String? {
+        let beforeKey = Self.dateKey(for: date)
+        let token = (beforeKey, displayUnit)
+        if liftSummaryCacheKey != token {
+            liftSummaryCache = [:]
+            liftSummaryCacheKey = token
+        }
+        let cacheKey = "\(itemID)\u{0}\(StrengthExerciseLiftHistory.normalizedName(name))"
+        if let cached = liftSummaryCache[cacheKey] {
+            return cached.isEmpty ? nil : cached
+        }
         guard let latest = exerciseLiftHistory(itemID: itemID, name: name, before: date, limit: 1).first else {
+            liftSummaryCache[cacheKey] = ""
             return nil
         }
         let summary = StrengthExerciseLiftHistory.formatSummary(latest.sets, displayUnit: displayUnit)
+        liftSummaryCache[cacheKey] = summary
         return summary.isEmpty ? nil : summary
     }
 
@@ -511,32 +525,17 @@ final class StrengthWorkoutStore {
     }
 
     private func liftSets(for itemID: String, name: String, on dateKey: String) -> [StrengthExerciseLiftSet] {
-        if let plan = dayPlans[dateKey],
-           let exercise = plan.exercises.first(where: {
-               ! $0.isCardio && StrengthExerciseLiftHistory.matches(
-                   itemID: itemID,
-                   name: name,
-                   candidateItemID: $0.itemID,
-                   candidateName: $0.name
-               )
-           }) {
-            let sets = StrengthExerciseLiftHistory.performedSets(from: exercise.sets)
-            if !sets.isEmpty { return sets }
-        }
-
-        if let session = preferredHistorySession(on: dateKey),
-           let exercise = session.exercises.first(where: {
-               StrengthExerciseLiftHistory.matches(
-                   itemID: itemID,
-                   name: name,
-                   candidateItemID: $0.itemID,
-                   candidateName: $0.name
-               )
-           }) {
-            return StrengthExerciseLiftHistory.performedSets(from: exercise.sets)
-        }
-
-        return []
+        guard let session = preferredHistorySession(on: dateKey),
+              let exercise = session.exercises.first(where: {
+                  StrengthExerciseLiftHistory.matches(
+                      itemID: itemID,
+                      name: name,
+                      candidateItemID: $0.itemID,
+                      candidateName: $0.name
+                  )
+              })
+        else { return [] }
+        return StrengthExerciseLiftHistory.performedSets(from: exercise.sets)
     }
 
     private func preferredHistorySession(on dateKey: String) -> StrengthWorkoutSession? {
@@ -594,6 +593,8 @@ final class StrengthWorkoutStore {
     }
 
     private func save() {
+        liftSummaryCache = [:]
+        liftSummaryCacheKey = nil
         let state = PersistedState(
             dayPlans: dayPlans,
             completedSessions: completedSessions,

--- a/ios/calorietracker/Stores/StrengthWorkoutStore.swift
+++ b/ios/calorietracker/Stores/StrengthWorkoutStore.swift
@@ -136,8 +136,9 @@ final class StrengthWorkoutStore {
         updateExercise(exerciseID, on: date) { exercise in
             let target = min(max(count, 1), 12)
             if target > exercise.sets.count {
+                let template = exercise.sets.last ?? StrengthPlannedSet()
                 exercise.sets.append(contentsOf: (exercise.sets.count..<target).map { _ in
-                    StrengthPlannedSet()
+                    template.copyingFromPrevious()
                 })
             } else if target < exercise.sets.count {
                 exercise.sets.removeLast(exercise.sets.count - target)
@@ -230,6 +231,40 @@ final class StrengthWorkoutStore {
             return planDate
         }
         .sorted(by: >)
+    }
+
+    func exerciseLiftHistory(
+        itemID: String,
+        name: String,
+        before date: Date,
+        limit: Int = 90
+    ) -> [StrengthExerciseLiftDay] {
+        let beforeKey = Self.dateKey(for: date)
+        var dateKeys = Set(dayPlans.keys)
+        dateKeys.formUnion(completedSessions.map(\.stableDiaryDateKey))
+        let priorKeys = dateKeys.filter { $0 < beforeKey }.sorted(by: >)
+
+        var results: [StrengthExerciseLiftDay] = []
+        for key in priorKeys {
+            guard results.count < limit else { break }
+            let sets = liftSets(for: itemID, name: name, on: key)
+            guard !sets.isEmpty else { continue }
+            results.append(StrengthExerciseLiftDay(dateKey: key, sets: sets))
+        }
+        return results
+    }
+
+    func lastExerciseLiftSummary(
+        itemID: String,
+        name: String,
+        before date: Date,
+        displayUnit: WeightUnit
+    ) -> String? {
+        guard let latest = exerciseLiftHistory(itemID: itemID, name: name, before: date, limit: 1).first else {
+            return nil
+        }
+        let summary = StrengthExerciseLiftHistory.formatSummary(latest.sets, displayUnit: displayUnit)
+        return summary.isEmpty ? nil : summary
     }
 
     @discardableResult
@@ -473,6 +508,50 @@ final class StrengthWorkoutStore {
             guard let index = plan.exercises.firstIndex(where: { $0.id == exerciseID }) else { return }
             mutate(&plan.exercises[index])
         }
+    }
+
+    private func liftSets(for itemID: String, name: String, on dateKey: String) -> [StrengthExerciseLiftSet] {
+        if let plan = dayPlans[dateKey],
+           let exercise = plan.exercises.first(where: {
+               ! $0.isCardio && StrengthExerciseLiftHistory.matches(
+                   itemID: itemID,
+                   name: name,
+                   candidateItemID: $0.itemID,
+                   candidateName: $0.name
+               )
+           }) {
+            let sets = StrengthExerciseLiftHistory.performedSets(from: exercise.sets)
+            if !sets.isEmpty { return sets }
+        }
+
+        if let session = preferredHistorySession(on: dateKey),
+           let exercise = session.exercises.first(where: {
+               StrengthExerciseLiftHistory.matches(
+                   itemID: itemID,
+                   name: name,
+                   candidateItemID: $0.itemID,
+                   candidateName: $0.name
+               )
+           }) {
+            return StrengthExerciseLiftHistory.performedSets(from: exercise.sets)
+        }
+
+        return []
+    }
+
+    private func preferredHistorySession(on dateKey: String) -> StrengthWorkoutSession? {
+        let sessions = completedSessions.filter { $0.stableDiaryDateKey == dateKey }
+        guard !sessions.isEmpty else { return nil }
+        let burns = sessions.filter { $0.caloriesBurned != nil }
+        if let latestBurn = burns.max(by: {
+            let left = $0.healthSyncVersion ?? 0
+            let right = $1.healthSyncVersion ?? 0
+            if left == right { return $0.completedAt < $1.completedAt }
+            return left < right
+        }) {
+            return latestBurn
+        }
+        return sessions.max(by: { $0.completedAt < $1.completedAt })
     }
 
     private func completedExerciseLogs(

--- a/ios/calorietracker/Stores/StrengthWorkoutStore.swift
+++ b/ios/calorietracker/Stores/StrengthWorkoutStore.swift
@@ -31,7 +31,7 @@ final class StrengthWorkoutStore {
 
     private let defaults: UserDefaults
     private let storageKey: String
-    private var liftSummaryCacheKey: (beforeKey: String, displayUnit: WeightUnit)?
+    private var liftSummaryCacheKey: (beforeKey: String, displayUnit: WeightUnit, historyToken: Int)?
     private var liftSummaryCache: [String: String] = [:]
 
     init(defaults: UserDefaults = .standard, storageKey: String = StrengthWorkoutStore.defaultStorageKey) {
@@ -263,7 +263,7 @@ final class StrengthWorkoutStore {
         displayUnit: WeightUnit
     ) -> String? {
         let beforeKey = Self.dateKey(for: date)
-        let token = (beforeKey, displayUnit)
+        let token = (beforeKey, displayUnit, liftSummaryHistoryToken)
         if liftSummaryCacheKey != token {
             liftSummaryCache = [:]
             liftSummaryCacheKey = token
@@ -592,9 +592,19 @@ final class StrengthWorkoutStore {
         preferences.sanitize()
     }
 
+    private var liftSummaryHistoryToken: Int {
+        completedSessions.reduce(into: 0) { token, session in
+            token = 31 &* token &+ session.stableDiaryDateKey.hashValue
+            token = 31 &* token &+ session.completedAt.hashValue
+            token = 31 &* token &+ (session.healthSyncVersion ?? 0)
+            for exercise in session.exercises {
+                token = 31 &* token &+ exercise.itemID.hashValue
+                token = 31 &* token &+ exercise.sets.filter(\.isPerformed).count
+            }
+        }
+    }
+
     private func save() {
-        liftSummaryCache = [:]
-        liftSummaryCacheKey = nil
         let state = PersistedState(
             dayPlans: dayPlans,
             completedSessions: completedSessions,

--- a/ios/calorietracker/Views/WorkoutLogView.swift
+++ b/ios/calorietracker/Views/WorkoutLogView.swift
@@ -1007,13 +1007,17 @@ private struct WorkoutLogExerciseCard: View {
             .accessibilityLabel("\(exercise.name), \(exercise.primaryMuscles.joined(separator: ", ")), \(exercise.rawEquipment)")
             .accessibilityHint("Opens exercise instructions")
 
-            if !isCardio, let lastTimeSummary {
+            if !isCardio {
                 HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    Text("Last time: \(lastTimeSummary)")
-                        .font(.system(.caption, design: .rounded, weight: .semibold))
-                        .foregroundStyle(Color.workoutMutedText)
-                        .lineLimit(2)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                    if let lastTimeSummary {
+                        Text("Last time: \(lastTimeSummary)")
+                            .font(.system(.caption, design: .rounded, weight: .semibold))
+                            .foregroundStyle(Color.workoutMutedText)
+                            .lineLimit(2)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    } else {
+                        Spacer(minLength: 0)
+                    }
 
                     Button(action: showHistory) {
                         Text("History")

--- a/ios/calorietracker/Views/WorkoutLogView.swift
+++ b/ios/calorietracker/Views/WorkoutLogView.swift
@@ -77,6 +77,7 @@ struct WorkoutLogView: View {
     @State private var isTextSheetPresented = false
     @State private var workoutInputUsesVoice = false
     @State private var selectedDetailItem: ExerciseLibraryItem?
+    @State private var historyRequest: WorkoutLogExerciseHistoryRequest?
 
     @State private var isNoPerformedSetAlertPresented = false
     @State private var isCalculatingBurn = false
@@ -252,10 +253,22 @@ struct WorkoutLogView: View {
                                     weightUnit: weightUnit,
                                     rpeScale: workoutStore.preferences.rpeScale,
                                     isSaved: workoutStore.savedExerciseIDs.contains(exercise.itemID),
+                                    lastTimeSummary: workoutStore.lastExerciseLiftSummary(
+                                        itemID: exercise.itemID,
+                                        name: exercise.name,
+                                        before: selectedDate,
+                                        displayUnit: weightUnit
+                                    ),
                                     focusedField: $focusedSetField,
                                     openDetail: {
                                         guard focusedSetField == nil else { return }
                                         selectedDetailItem = exercise.libraryItem
+                                    },
+                                    showHistory: {
+                                        historyRequest = WorkoutLogExerciseHistoryRequest(
+                                            itemID: exercise.itemID,
+                                            name: exercise.name
+                                        )
                                     },
                                     toggleSaved: {
                                         workoutStore.toggleSaved(exercise.itemID)
@@ -446,6 +459,21 @@ struct WorkoutLogView: View {
                         isCopySheetPresented = false
                     },
                     onClose: { isCopySheetPresented = false }
+                )
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+            }
+            .sheet(item: $historyRequest) { request in
+                WorkoutLogExerciseHistorySheet(
+                    request: request,
+                    selectedDate: selectedDate,
+                    weightUnit: weightUnit,
+                    history: workoutStore.exerciseLiftHistory(
+                        itemID: request.itemID,
+                        name: request.name,
+                        before: selectedDate
+                    ),
+                    onClose: { historyRequest = nil }
                 )
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
@@ -906,13 +934,22 @@ private struct WorkoutLogSetFocus: Hashable {
     let field: Field
 }
 
+private struct WorkoutLogExerciseHistoryRequest: Identifiable {
+    let itemID: String
+    let name: String
+
+    var id: String { itemID }
+}
+
 private struct WorkoutLogExerciseCard: View {
     let exercise: StrengthPlannedExercise
     let weightUnit: WeightUnit
     let rpeScale: StrengthWorkoutRPEScale
     let isSaved: Bool
+    let lastTimeSummary: String?
     let focusedField: FocusState<WorkoutLogSetFocus?>.Binding
     let openDetail: () -> Void
+    let showHistory: () -> Void
     let toggleSaved: () -> Void
     let removeExercise: () -> Void
     let timerAction: (StrengthExerciseTimerAction) -> Void
@@ -969,6 +1006,24 @@ private struct WorkoutLogExerciseCard: View {
             .buttonStyle(.plain)
             .accessibilityLabel("\(exercise.name), \(exercise.primaryMuscles.joined(separator: ", ")), \(exercise.rawEquipment)")
             .accessibilityHint("Opens exercise instructions")
+
+            if !isCardio, let lastTimeSummary {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text("Last time: \(lastTimeSummary)")
+                        .font(.system(.caption, design: .rounded, weight: .semibold))
+                        .foregroundStyle(Color.workoutMutedText)
+                        .lineLimit(2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Button(action: showHistory) {
+                        Text("History")
+                            .font(.system(.caption, design: .rounded, weight: .heavy))
+                            .foregroundStyle(Color.workoutAccent)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityHint("Shows past logged sets for this exercise")
+                }
+            }
 
             VStack(alignment: .leading, spacing: 10) {
                 HStack(alignment: .center, spacing: 6) {
@@ -2059,6 +2114,61 @@ private struct WorkoutLogCopyDay: Identifiable {
     let exercises: [StrengthPlannedExercise]
 
     var id: String { StrengthWorkoutStore.dateKey(for: date) }
+}
+
+private struct WorkoutLogExerciseHistorySheet: View {
+    let request: WorkoutLogExerciseHistoryRequest
+    let selectedDate: Date
+    let weightUnit: WeightUnit
+    let history: [StrengthExerciseLiftDay]
+    let onClose: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if history.isEmpty {
+                    ContentUnavailableView("No lift history yet", systemImage: "clock.arrow.circlepath")
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                } else {
+                    ForEach(history) { day in
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(dayTitle(for: day.dateKey))
+                                .font(.headline.weight(.semibold))
+                                .foregroundStyle(Color.workoutCharcoal)
+                            Text(StrengthExerciseLiftHistory.formatSummary(day.sets, displayUnit: weightUnit))
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(Color.workoutMutedText)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                        .padding(.vertical, 4)
+                        .listRowBackground(Color.workoutPanel.opacity(0.24))
+                        .listRowSeparatorTint(Color.workoutHairline.opacity(0.28))
+                    }
+                }
+            }
+            .scrollContentBackground(.hidden)
+            .listStyle(.plain)
+            .background(Color.workoutBackground)
+            .navigationTitle(request.name)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done", action: onClose)
+                        .font(.headline.weight(.heavy))
+                        .foregroundStyle(Color.workoutAccent)
+                }
+            }
+        }
+    }
+
+    private func dayTitle(for dateKey: String) -> String {
+        guard let date = StrengthWorkoutStore.date(for: dateKey) else { return dateKey }
+        if Calendar.current.isDateInToday(date) { return "Today" }
+        if Calendar.current.isDateInYesterday(date) { return "Yesterday" }
+        if Calendar.current.isDate(date, inSameDayAs: selectedDate) { return "Selected day" }
+        return date.formatted(.dateTime.weekday(.wide).month(.abbreviated).day().year())
+    }
 }
 
 private struct WorkoutLogCopySheet: View {

--- a/ios/calorietrackerTests/CoachWorkoutToolsTests.swift
+++ b/ios/calorietrackerTests/CoachWorkoutToolsTests.swift
@@ -391,6 +391,53 @@ struct CoachWorkoutToolsTests {
             let schema = CoachTools.parameterSchema(for: name)
             #expect(schema["required"] as? [String] == ["from", "to"])
         }
+
+        let liftSchema = CoachTools.parameterSchema(for: "get_exercise_lift_history")
+        #expect(liftSchema["required"] as? [String] == ["exercise"])
+    }
+
+    @Test func exerciseLiftHistoryReturnsRecentSetsForOneLift() throws {
+        let bench = WorkoutTestFixture.exercise(id: "bench", name: "Bench Press")
+        let yesterday = WorkoutTestFixture.date(2026, 7, 19)
+        let today = WorkoutTestFixture.date(2026, 7, 20)
+        let store = WorkoutTestFixture().makeStore()
+        store.toggleExercise(bench, on: yesterday)
+        var planned = try #require(store.exercises(for: yesterday).first)
+        var firstSet = try #require(planned.sets.first)
+        store.updateSet(
+            exerciseID: planned.id,
+            setID: firstSet.id,
+            on: yesterday,
+            weight: "60",
+            weightUnit: .kg,
+            reps: "8"
+        )
+        store.toggleExercise(bench, on: today)
+
+        let tools = CoachTools(
+            weights: [],
+            bodyFats: [],
+            foods: [],
+            workoutSessions: store.completedSessions,
+            workoutPlans: Array(store.dayPlans.values),
+            workoutPreferences: store.preferences,
+            workoutPlanWeightUnit: .kg,
+            workoutAccessEnabled: true
+        )
+        let payload = try WorkoutCoachFixture.jsonObject(
+            tools.execute(
+                name: "get_exercise_lift_history",
+                arguments: ["exercise": "Bench Press", "to": "2026-07-20"]
+            )
+        )
+        let sessions = try #require(payload["sessions"] as? [[String: Any]])
+        #expect(payload["count"] as? Int == 1)
+        #expect(sessions.first?["date"] as? String == "2026-07-19")
+        let sets = try #require(sessions.first?["sets"] as? [[String: Any]])
+        #expect(sets.first?["weight"] as? String == "60")
+        #expect(sets.first?["reps"] as? Int == 8)
+        let last = try #require(payload["last_session"] as? [String: Any])
+        #expect(last["date"] as? String == "2026-07-19")
     }
 }
 

--- a/ios/calorietrackerTests/CoachWorkoutToolsTests.swift
+++ b/ios/calorietrackerTests/CoachWorkoutToolsTests.swift
@@ -440,6 +440,114 @@ struct CoachWorkoutToolsTests {
         let last = try #require(payload["last_session"] as? [String: Any])
         #expect(last["date"] as? String == "2026-07-19")
     }
+
+    @Test func exerciseLiftHistoryRespectsCatalogIdOverSameName() throws {
+        let catalogBench = WorkoutCoachFixture.session(
+            date: WorkoutTestFixture.date(2026, 7, 19),
+            caloriesBurned: 180,
+            exercise: "Bench Press",
+            sets: [WorkoutCoachFixture.set(number: 1, weight: "60", reps: "8", rpe: "7")]
+        )
+        let customBench = StrengthWorkoutSession(
+            diaryDate: WorkoutTestFixture.date(2026, 7, 18),
+            startedAt: WorkoutTestFixture.date(2026, 7, 18),
+            completedAt: WorkoutTestFixture.date(2026, 7, 18),
+            durationSeconds: 600,
+            exercises: [
+                StrengthCompletedExercise(
+                    itemID: "custom-bench",
+                    name: "Bench Press",
+                    targetMuscles: ["Chest"],
+                    equipment: "Barbell",
+                    sets: [WorkoutCoachFixture.set(number: 1, weight: "100", reps: "5", rpe: "8")]
+                )
+            ],
+            caloriesBurned: 170
+        )
+        let tools = CoachTools(
+            weights: [],
+            bodyFats: [],
+            foods: [],
+            workoutSessions: [catalogBench, customBench],
+            workoutPlans: [],
+            workoutPlanWeightUnit: .kg,
+            workoutAccessEnabled: true
+        )
+        let payload = try WorkoutCoachFixture.jsonObject(
+            tools.execute(
+                name: "get_exercise_lift_history",
+                arguments: [
+                    "exercise": "Bench Press",
+                    "catalog_id": "bench-press",
+                    "to": "2026-07-20",
+                ]
+            )
+        )
+        let sessions = try #require(payload["sessions"] as? [[String: Any]])
+        #expect(payload["count"] as? Int == 1)
+        let sets = try #require(sessions.first?["sets"] as? [[String: Any]])
+        #expect(sets.first?["weight"] as? String == "60")
+    }
+
+    @Test func exerciseLiftHistoryUsesAuthoritativeSameDaySnapshot() throws {
+        let legacy = WorkoutCoachFixture.session(
+            date: WorkoutTestFixture.date(2026, 7, 12),
+            exercise: "Bench Press",
+            sets: [WorkoutCoachFixture.set(number: 1, weight: "80", reps: "5", rpe: "7")]
+        )
+        var newerClockButOlderVersion = WorkoutCoachFixture.session(
+            date: WorkoutTestFixture.date(2026, 7, 12),
+            caloriesBurned: 190,
+            exercise: "Bench Press",
+            sets: [WorkoutCoachFixture.set(number: 1, weight: "82.5", reps: "6", rpe: "7.5")]
+        )
+        newerClockButOlderVersion = StrengthWorkoutSession(
+            id: newerClockButOlderVersion.id,
+            diaryDate: newerClockButOlderVersion.diaryDate,
+            diaryDateKey: newerClockButOlderVersion.diaryDateKey,
+            startedAt: newerClockButOlderVersion.startedAt,
+            completedAt: WorkoutTestFixture.date(2026, 7, 12).addingTimeInterval(11 * 3600),
+            durationSeconds: newerClockButOlderVersion.durationSeconds,
+            exercises: newerClockButOlderVersion.exercises,
+            caloriesBurned: 190,
+            healthSyncVersion: 1
+        )
+        var authoritative = WorkoutCoachFixture.session(
+            date: WorkoutTestFixture.date(2026, 7, 12),
+            caloriesBurned: 210,
+            exercise: "Bench Press",
+            sets: [WorkoutCoachFixture.set(number: 1, weight: "85", reps: "8", rpe: "8")]
+        )
+        authoritative = StrengthWorkoutSession(
+            id: authoritative.id,
+            diaryDate: authoritative.diaryDate,
+            diaryDateKey: authoritative.diaryDateKey,
+            startedAt: authoritative.startedAt,
+            completedAt: WorkoutTestFixture.date(2026, 7, 12).addingTimeInterval(10 * 3600),
+            durationSeconds: authoritative.durationSeconds,
+            exercises: authoritative.exercises,
+            caloriesBurned: 210,
+            healthSyncVersion: 2
+        )
+        let tools = CoachTools(
+            weights: [],
+            bodyFats: [],
+            foods: [],
+            workoutSessions: [legacy, newerClockButOlderVersion, authoritative],
+            workoutPlans: [],
+            workoutAccessEnabled: true
+        )
+        let payload = try WorkoutCoachFixture.jsonObject(
+            tools.execute(
+                name: "get_exercise_lift_history",
+                arguments: ["exercise": "Bench Press", "to": "2026-07-20"]
+            )
+        )
+        let sessions = try #require(payload["sessions"] as? [[String: Any]])
+        let sets = try #require(sessions.first?["sets"] as? [[String: Any]])
+        #expect(sets.first?["weight"] as? String == "85")
+        #expect(sets.first?["reps"] as? Int == 8)
+    }
 }
 
 @MainActor

--- a/ios/calorietrackerTests/CoachWorkoutToolsTests.swift
+++ b/ios/calorietrackerTests/CoachWorkoutToolsTests.swift
@@ -412,6 +412,7 @@ struct CoachWorkoutToolsTests {
             weightUnit: .kg,
             reps: "8"
         )
+        _ = store.upsertCalculatedWorkout(on: yesterday, caloriesBurned: 180, weightUnit: .kg)
         store.toggleExercise(bench, on: today)
 
         let tools = CoachTools(

--- a/ios/calorietrackerTests/StrengthWorkoutStoreTests.swift
+++ b/ios/calorietrackerTests/StrengthWorkoutStoreTests.swift
@@ -273,9 +273,9 @@ struct StrengthWorkoutStoreTests {
         #expect(planned.sets[0].reps == "1234")
         #expect(planned.sets[0].rpe == "7.5")
         #expect(planned.sets.dropFirst().allSatisfy {
-            $0.weight.isEmpty
-                && $0.weightUnit == nil
-                && $0.reps.isEmpty
+            $0.weight == "100.5"
+                && $0.weightUnit == WeightUnit.kg.rawValue
+                && $0.reps == "1234"
                 && $0.rpe.isEmpty
                 && $0.rpeScale == nil
         })
@@ -296,6 +296,37 @@ struct StrengthWorkoutStoreTests {
         #expect(store.exercises(for: date)[0].sets[0].rpe == "20")
         store.updateSet(exerciseID: planned.id, setID: firstSet.id, on: date, rpe: "5")
         #expect(store.exercises(for: date)[0].sets[0].rpe == "20")
+    }
+
+    @Test func exerciseLiftHistoryFindsMostRecentPriorDay() throws {
+        let bench = WorkoutTestFixture.exercise(id: "bench", name: "Bench Press")
+        let yesterday = WorkoutTestFixture.date(2026, 7, 19)
+        let today = WorkoutTestFixture.date(2026, 7, 20)
+        let store = WorkoutTestFixture().makeStore()
+        store.toggleExercise(bench, on: yesterday)
+        var planned = try #require(store.exercises(for: yesterday).first)
+        var set = try #require(planned.sets.first)
+        store.updateSet(
+            exerciseID: planned.id,
+            setID: set.id,
+            on: yesterday,
+            weight: "60",
+            weightUnit: .kg,
+            reps: "8"
+        )
+        store.toggleExercise(bench, on: today)
+
+        let summary = store.lastExerciseLiftSummary(
+            itemID: bench.id,
+            name: bench.name,
+            before: today,
+            displayUnit: .kg
+        )
+        #expect(summary == "60 kg × 8")
+
+        let history = store.exerciseLiftHistory(itemID: bench.id, name: bench.name, before: today)
+        #expect(history.count == 1)
+        #expect(history[0].dateKey == StrengthWorkoutStore.dateKey(for: yesterday))
     }
 
     @Test func plannedSetWeightDisplayFollowsGlobalUnitWithoutMutatingStoredLoad() {

--- a/ios/calorietrackerTests/StrengthWorkoutStoreTests.swift
+++ b/ios/calorietrackerTests/StrengthWorkoutStoreTests.swift
@@ -298,6 +298,33 @@ struct StrengthWorkoutStoreTests {
         #expect(store.exercises(for: date)[0].sets[0].rpe == "20")
     }
 
+    @Test func liftHistoryMatchingUsesCatalogIdExclusivelyWhenProvided() {
+        #expect(
+            StrengthExerciseLiftHistory.matches(
+                itemID: "bench-press",
+                name: "Bench Press",
+                candidateItemID: "bench-press",
+                candidateName: "Bench Press"
+            )
+        )
+        #expect(
+            !StrengthExerciseLiftHistory.matches(
+                itemID: "bench-press",
+                name: "Bench Press",
+                candidateItemID: "custom-bench",
+                candidateName: "Bench Press"
+            )
+        )
+        #expect(
+            StrengthExerciseLiftHistory.matches(
+                itemID: "",
+                name: "Bench Press",
+                candidateItemID: "custom-bench",
+                candidateName: "Bench Press"
+            )
+        )
+    }
+
     @Test func exerciseLiftHistoryFindsMostRecentPriorDay() throws {
         let bench = WorkoutTestFixture.exercise(id: "bench", name: "Bench Press")
         let yesterday = WorkoutTestFixture.date(2026, 7, 19)

--- a/ios/calorietrackerTests/StrengthWorkoutStoreTests.swift
+++ b/ios/calorietrackerTests/StrengthWorkoutStoreTests.swift
@@ -314,6 +314,7 @@ struct StrengthWorkoutStoreTests {
             weightUnit: .kg,
             reps: "8"
         )
+        _ = store.upsertCalculatedWorkout(on: yesterday, caloriesBurned: 180, weightUnit: .kg)
         store.toggleExercise(bench, on: today)
 
         let summary = store.lastExerciseLiftSummary(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Kyle's workout diary UX feedback with iOS + Android parity.

### A) Set autofill
When increasing set count (+ set), new sets copy **weight, unit, and reps** from the previous set. RPE and timers stay blank.

- iOS: `StrengthPlannedSet.copyingFromPrevious()` wired in `StrengthWorkoutStore.setSetCount`
- Android: `PlannedSet.copyingFromPrevious()` wired in `WorkoutRepository.setSetCount`

### B) Last time + History
Under each strength exercise in the workout diary:
- **Last time:** e.g. `60 kg × 8` (respects user weight unit prefs)
- **History:** opens a sheet listing past dates with logged sets for that exercise

Data comes from local day plans and completed session snapshots, matched by `itemID` with normalized name fallback.

### C) Coach awareness
New tool: **`get_exercise_lift_history`**
- Per-exercise dated sessions with weight × reps
- `last_session` and `best_load_kg` in the payload
- Updated tool descriptions + chat hints so Coach knows to use it for "what did I bench last?" style questions

Existing workout tool contracts are unchanged; this extends carefully.

## Manual test notes
1. Log 2 sets on an exercise, tap + set → 3rd set should copy weight/reps (RPE blank)
2. Log an exercise yesterday, open today → **Last time** appears under that exercise
3. Tap **History** → past dates + sets listed without swiping days
4. Ask Coach: "What did I bench last?" → should call `get_exercise_lift_history`

## Tests
- Updated iOS/Android unit tests for set autofill behavior
- Added store + Coach tests for lift history lookup and schema

_Android unit tests not run in cloud VM (no Android SDK). iOS tests not run (no Xcode in VM)._
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-490f3bc6-82d1-4764-a6b2-636bbd0ab287?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-490f3bc6-82d1-4764-a6b2-636bbd0ab287&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added exercise lift history for Android and iOS, including dated sets, formatted weights, and “Last time” summaries.
  - Added History views to workout diary and log screens for non-cardio exercises.
  - Enabled Coach to answer questions about an exercise’s recent performance and trends.
- **Improvements**
  - New workout sets now retain the previous set’s weight, unit, and repetitions when added.
  - Exercise matching prioritizes catalog identity when available.
- **Tests**
  - Added coverage for lift history, matching, session selection, and Coach tool behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds workout-diary quality-of-life features with Android and iOS parity:
- Autofills newly added sets from the preceding set while leaving RPE and timer data blank.
- Displays prior lift summaries and provides per-exercise history sheets based on completed sessions.
- Adds Coach tooling for exercise-specific lift history, including recent sessions and best load.
- Includes tests covering autofill, matching, completed-session selection, malformed dates, and tool payloads.

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge, with no outstanding correctness or repository-rule issues identified.

The earlier completed-plan, malformed-date, hidden-history, and repeated-composition findings are addressed in the current code; the remaining prior performance thread’s cache now rebuilds from selected date, unit, exercise keys, and completed-session history changes.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/src/main/java/com/apoorvdarshan/calorietracker/models/WorkoutModels.kt | Adds set-copying and completed-session lift-history matching, formatting, and selection logic. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/services/ai/CoachTools.kt | Adds the exercise lift-history Coach tool, schema, tolerant date handling, and payload generation. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutsViewModel.kt | Caches last-lift summaries and exposes completed lift history to the diary UI. |
| ios/calorietracker/Stores/StrengthWorkoutStore.swift | Implements set autofill and cached completed-session lift-history access on iOS. |
| ios/calorietracker/Services/CoachTools.swift | Adds the iOS Coach lift-history contract and response generation. |
| ios/calorietracker/Views/WorkoutLogView.swift | Presents last-time summaries and an exercise history sheet in the iOS workout diary. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Completed workout sessions] --> B[Match exercise by catalog ID or normalized name]
  B --> C[Keep performed sets]
  C --> D[Diary last-time summary]
  C --> E[Exercise history sheet]
  C --> F[get_exercise_lift_history]
  F --> G[Coach response with sessions, last session, and best load]
```

<sub>Reviews (3): Last reviewed commit: ["Merge origin/main into workout set autof..."](https://github.com/apoorvdarshan/fud-ai/commit/c95b135069299a7cf3b413ef660cbbc18f30c0af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62981964)</sub>

<!-- /greptile_comment -->