### PR TITLE
Let the review sheet set date & time before logging (rebase of #192)

### DIFF
--- a/android/app/src/androidTest/java/com/apoorvdarshan/calorietracker/ui/home/AddFoodStateRestorationTest.kt
+++ b/android/app/src/androidTest/java/com/apoorvdarshan/calorietracker/ui/home/AddFoodStateRestorationTest.kt
@@ -30,7 +30,14 @@ import com.apoorvdarshan.calorietracker.models.MealType
 import com.apoorvdarshan.calorietracker.models.ServingUnitOption
 import com.apoorvdarshan.calorietracker.services.ai.FoodAnalysis
 import com.apoorvdarshan.calorietracker.ui.theme.FudAITheme
+import com.apoorvdarshan.calorietracker.ui.util.clockTimePattern
 import java.io.ByteArrayOutputStream
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Rule
@@ -214,6 +221,69 @@ class AddFoodStateRestorationTest {
             assertEquals(175.0, submission?.quantity)
             assertEquals(analysis.calories, submission?.editedAnalysis?.calories)
         }
+    }
+
+    @Test
+    fun analysisReviewRestoresEditedDateAndTimeBeforeLogging() {
+        val restoration = StateRestorationTester(compose)
+        val app = InstrumentationRegistry.getInstrumentation()
+            .targetContext.applicationContext as FudAIApp
+        val zone = ZoneId.systemDefault()
+        val initialInstant = LocalDate.of(2024, 6, 15).atTime(10, 30).atZone(zone).toInstant()
+        val expectedDate = LocalDate.of(2024, 6, 20)
+        val expectedTime = LocalTime.of(16, 45)
+        val expectedInstant = expectedDate.atTime(expectedTime).atZone(zone).toInstant()
+        val analysis = FoodAnalysis(
+            name = "Brown rice",
+            calories = 120,
+            protein = 3.0,
+            carbs = 24.0,
+            fat = 1.0,
+            servingSizeGrams = 100.0
+        )
+        var submittedTimestamp: Instant? = null
+        restoration.setContent {
+            FudAITheme {
+                FoodResultSheet(
+                    analysis = analysis,
+                    preferGramsByDefault = true,
+                    initialTimestamp = initialInstant,
+                    container = app.container,
+                    analyzeIngredientText = { error("No analysis should run while editing a draft") },
+                    lookupIngredientBarcode = { error("No barcode lookup should run while editing a draft") },
+                    analyzeIngredientImage = { error("No image analysis should run while editing a draft") },
+                    onSave = { _, _, _, _, _, _, _, _, timestamp ->
+                        submittedTimestamp = timestamp
+                    },
+                    onDismiss = {}
+                )
+            }
+        }
+
+        val list = SemanticsMatcher.keyIsDefined(SemanticsActions.ScrollToIndex)
+        compose.onNode(list).performScrollToNode(hasText(string(R.string.label_date)))
+        compose.onNodeWithText(string(R.string.label_date)).performClick()
+        compose.onNode(hasText("20")).performScrollTo()
+        compose.onNodeWithText(string(R.string.action_done)).performClick()
+
+        compose.onNodeWithText(string(R.string.label_time)).performClick()
+        compose.onNode(hasSetTextAction() and hasText("10")).performTextReplacement("16")
+        compose.onNode(hasSetTextAction() and hasText("30")).performTextReplacement("45")
+        compose.onNodeWithText(string(R.string.action_done)).performClick()
+
+        compose.onNodeWithText("Jun 20, 2024").assertExists()
+
+        restoration.emulateSavedInstanceStateRestore()
+
+        compose.onNodeWithText("Jun 20, 2024").assertExists()
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val timeLabel = expectedTime.format(
+            DateTimeFormatter.ofPattern(clockTimePattern(context), Locale.US)
+        )
+        compose.onNodeWithText(timeLabel).assertExists()
+        compose.runOnIdle { assertNull(submittedTimestamp) }
+        compose.onNodeWithText(string(R.string.action_log)).performClick()
+        compose.runOnIdle { assertEquals(expectedInstant, submittedTimestamp) }
     }
 
     private fun string(id: Int): String =

--- a/android/app/src/androidTest/java/com/apoorvdarshan/calorietracker/ui/home/AddFoodStateRestorationTest.kt
+++ b/android/app/src/androidTest/java/com/apoorvdarshan/calorietracker/ui/home/AddFoodStateRestorationTest.kt
@@ -178,7 +178,7 @@ class AddFoodStateRestorationTest {
                     analyzeIngredientText = { error("No analysis should run while editing a draft") },
                     lookupIngredientBarcode = { error("No barcode lookup should run while editing a draft") },
                     analyzeIngredientImage = { error("No image analysis should run while editing a draft") },
-                    onSave = { name, grams, known, scale, _, _, quantity, edited ->
+                    onSave = { name, grams, known, scale, _, _, quantity, edited, _ ->
                         submission = ReviewSubmission(name, grams, known, scale, quantity, edited)
                     },
                     onDismiss = {}

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/EditFoodEntrySheet.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/EditFoodEntrySheet.kt
@@ -34,8 +34,6 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.UnfoldMore
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.DatePicker
-import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -45,7 +43,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -60,7 +57,6 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
-import com.apoorvdarshan.calorietracker.ui.util.clockTimePattern
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -77,10 +73,8 @@ import com.apoorvdarshan.calorietracker.models.ServingUnitOption
 import com.apoorvdarshan.calorietracker.models.ServingAmountExpression
 import com.apoorvdarshan.calorietracker.models.SupplementalNutrient
 import com.apoorvdarshan.calorietracker.models.totals
-import com.apoorvdarshan.calorietracker.ui.components.DateWheelPicker
 import com.apoorvdarshan.calorietracker.ui.components.FudGlassDialog
 import com.apoorvdarshan.calorietracker.ui.components.FudGlassDialogActions
-import com.apoorvdarshan.calorietracker.ui.components.FudGlassTextField
 import com.apoorvdarshan.calorietracker.ui.components.FullScreenImageViewer
 import com.apoorvdarshan.calorietracker.ui.theme.AppColors
 import android.graphics.Bitmap
@@ -89,8 +83,6 @@ import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneId
 import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
-import java.util.Locale
 import kotlin.math.roundToInt
 
 /**
@@ -179,8 +171,6 @@ fun EditFoodEntrySheet(
     val sheetSurface = if (isDark) MaterialTheme.colorScheme.surface else Color(0xFFFAF3EE)
     val context = LocalContext.current
     val reprocessingFailed = stringResource(R.string.edit_reprocessing_failed)
-    val dateFormatter = remember { DateTimeFormatter.ofPattern("MMM d, yyyy", Locale.US) }
-    val timeFormatter = remember(context) { DateTimeFormatter.ofPattern(clockTimePattern(context), Locale.US) }
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
     val dismissKeyboard = {
@@ -679,45 +669,18 @@ fun EditFoodEntrySheet(
 
             item { SheetSectionHeader(stringResource(R.string.section_date_time)) }
             item {
-                SheetPillCard {
-                    Row(
-                        Modifier
-                            .fillMaxWidth()
-                            .clickable {
-                                dismissKeyboard()
-                                showDatePicker = true
-                            }
-                            .padding(horizontal = 18.dp, vertical = 12.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(stringResource(R.string.label_date), fontSize = 17.sp, modifier = Modifier.weight(1f))
-                        Text(
-                            loggedDate.format(dateFormatter),
-                            fontSize = 17.sp,
-                            color = AppColors.Calorie,
-                            fontWeight = FontWeight.Medium
-                        )
+                SheetDateTimeCard(
+                    loggedDate = loggedDate,
+                    loggedTime = loggedTime,
+                    onEditDate = {
+                        dismissKeyboard()
+                        showDatePicker = true
+                    },
+                    onEditTime = {
+                        dismissKeyboard()
+                        showTimePicker = true
                     }
-                    SheetHairline()
-                    Row(
-                        Modifier
-                            .fillMaxWidth()
-                            .clickable {
-                                dismissKeyboard()
-                                showTimePicker = true
-                            }
-                            .padding(horizontal = 18.dp, vertical = 12.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(stringResource(R.string.label_time), fontSize = 17.sp, modifier = Modifier.weight(1f))
-                        Text(
-                            loggedTime.format(timeFormatter),
-                            fontSize = 17.sp,
-                            color = AppColors.Calorie,
-                            fontWeight = FontWeight.Medium
-                        )
-                    }
-                }
+                )
             }
 
             item { SheetSectionHeader("Actions") }
@@ -805,30 +768,18 @@ fun EditFoodEntrySheet(
     }
 
     if (showDatePicker) {
-        var pickedDate by remember(loggedDate) { mutableStateOf(loggedDate) }
-        FudGlassDialog(onDismissRequest = { showDatePicker = false }) {
-            Text(stringResource(R.string.label_date), fontSize = 21.sp, fontWeight = FontWeight.Bold)
-            DateWheelPicker(
-                selected = pickedDate,
-                onSelect = { pickedDate = it },
-                minYear = LocalDate.now().year - 10,
-                maxYear = LocalDate.now().year,
-                modifier = Modifier.fillMaxWidth()
-            )
-            FudGlassDialogActions(
-                primaryText = stringResource(R.string.action_done),
-                onPrimary = {
-                    loggedDate = pickedDate
-                    showDatePicker = false
-                },
-                dismissText = stringResource(R.string.action_cancel),
-                onDismiss = { showDatePicker = false }
-            )
-        }
+        SheetDatePickerDialog(
+            initialDate = loggedDate,
+            onConfirm = {
+                loggedDate = it
+                showDatePicker = false
+            },
+            onDismiss = { showDatePicker = false }
+        )
     }
 
     if (showTimePicker) {
-        EditFoodTimeDialog(
+        SheetTimePickerDialog(
             initialTime = loggedTime,
             onConfirm = {
                 loggedTime = it
@@ -886,42 +837,3 @@ fun EditFoodEntrySheet(
     }
 }
 
-@Composable
-private fun EditFoodTimeDialog(
-    initialTime: LocalTime,
-    onConfirm: (LocalTime) -> Unit,
-    onDismiss: () -> Unit
-) {
-    var hourText by remember(initialTime) { mutableStateOf(initialTime.hour.toString().padStart(2, '0')) }
-    var minuteText by remember(initialTime) { mutableStateOf(initialTime.minute.toString().padStart(2, '0')) }
-
-    FudGlassDialog(onDismissRequest = onDismiss) {
-        Text(stringResource(R.string.label_time), fontSize = 21.sp, fontWeight = FontWeight.Bold)
-        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-            FudGlassTextField(
-                value = hourText,
-                onValueChange = { hourText = it.filter(Char::isDigit).take(2) },
-                placeholder = stringResource(R.string.placeholder_hour),
-                singleLine = true,
-                modifier = Modifier.weight(1f)
-            )
-            FudGlassTextField(
-                value = minuteText,
-                onValueChange = { minuteText = it.filter(Char::isDigit).take(2) },
-                placeholder = stringResource(R.string.placeholder_minute),
-                singleLine = true,
-                modifier = Modifier.weight(1f)
-            )
-        }
-        FudGlassDialogActions(
-            primaryText = stringResource(R.string.action_done),
-            onPrimary = {
-                val hour = hourText.toIntOrNull()?.coerceIn(0, 23) ?: initialTime.hour
-                val minute = minuteText.toIntOrNull()?.coerceIn(0, 59) ?: initialTime.minute
-                onConfirm(LocalTime.of(hour, minute))
-            },
-            dismissText = stringResource(R.string.action_cancel),
-            onDismiss = onDismiss
-        )
-    }
-}

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodDraftSavers.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodDraftSavers.kt
@@ -1,6 +1,8 @@
 package com.apoorvdarshan.calorietracker.ui.home
 
 import androidx.compose.runtime.saveable.Saver
+import java.time.LocalDate
+import java.time.LocalTime
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
@@ -8,4 +10,14 @@ import kotlinx.serialization.json.Json
 internal inline fun <reified T> foodDraftSaver(): Saver<T, String> = Saver(
     save = { Json.encodeToString(it) },
     restore = { runCatching { Json.decodeFromString<T>(it) }.getOrNull() }
+)
+
+internal val LocalDateSaver = Saver<LocalDate, Long>(
+    save = { it.toEpochDay() },
+    restore = { LocalDate.ofEpochDay(it) }
+)
+
+internal val LocalTimeSaver = Saver<LocalTime, Long>(
+    save = { it.toNanoOfDay() },
+    restore = { LocalTime.ofNanoOfDay(it) }
 )

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodResultSheet.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodResultSheet.kt
@@ -81,6 +81,9 @@ import com.apoorvdarshan.calorietracker.ui.components.FullScreenImageViewer
 import com.apoorvdarshan.calorietracker.ui.theme.AppColors
 import kotlin.math.roundToInt
 import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
 
 /**
  * First-time review sheet shown after photo / text / voice analysis returns
@@ -97,6 +100,7 @@ fun FoodResultSheet(
     profile: UserProfile? = null,
     dayEntries: List<FoodEntry> = emptyList(),
     source: FoodSource = FoodSource.TEXT_INPUT,
+    initialTimestamp: Instant = Instant.now(),
     isSubmitting: Boolean = false,
     container: com.apoorvdarshan.calorietracker.AppContainer,
     analyzeIngredientText: suspend (String) -> FoodAnalysis,
@@ -111,7 +115,8 @@ fun FoodResultSheet(
         mealType: MealType,
         selectedServingUnit: String?,
         selectedServingQuantity: Double?,
-        editedAnalysis: FoodAnalysis
+        editedAnalysis: FoodAnalysis,
+        timestamp: Instant
     ) -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -159,6 +164,14 @@ fun FoodResultSheet(
     val selectedServingQuantity = ServingAmountExpression.evaluate(servingQuantityText)?.takeIf { it > 0 }
     val scale = if (baseServingGrams > 0) servingGrams / baseServingGrams else 1.0
     var mealType by rememberSaveable { mutableStateOf(MealType.currentMeal) }
+    // Seeded from the viewed diary day (now when it is today); the Date & Time
+    // section lets the user adjust it before logging.
+    val zone = remember { ZoneId.systemDefault() }
+    val initialLoggedAt = remember(analysis) { initialTimestamp.atZone(zone) }
+    var loggedDate by remember(analysis) { mutableStateOf(initialLoggedAt.toLocalDate()) }
+    var loggedTime by remember(analysis) { mutableStateOf(initialLoggedAt.toLocalTime()) }
+    var showDatePicker by remember { mutableStateOf(false) }
+    var showTimePicker by remember { mutableStateOf(false) }
     var moreNutritionExpanded by rememberSaveable { mutableStateOf(false) }
     var nutritionUnlocked by rememberSaveable { mutableStateOf(false) }
     var editableCalories by rememberSaveable(analysis) { mutableStateOf(analysis.calories) }
@@ -364,7 +377,8 @@ fun FoodResultSheet(
                     mealType,
                     if (servingUnitOptions.isEmpty()) null else selectedServingOption.unit,
                     if (servingUnitOptions.isEmpty()) null else selectedServingQuantity,
-                    editedAnalysis()
+                    editedAnalysis(),
+                    loggedDate.atTime(loggedTime).atZone(zone).toInstant()
                 )
             },
             onSecondary = { whatIfEntry = previewEntry() }
@@ -716,7 +730,45 @@ fun FoodResultSheet(
                     }
                 }
             }
+
+            item { SheetSectionHeader(stringResource(R.string.section_date_time)) }
+            item {
+                SheetDateTimeCard(
+                    loggedDate = loggedDate,
+                    loggedTime = loggedTime,
+                    onEditDate = {
+                        dismissKeyboard()
+                        showDatePicker = true
+                    },
+                    onEditTime = {
+                        dismissKeyboard()
+                        showTimePicker = true
+                    }
+                )
+            }
         }
+    }
+
+    if (showDatePicker) {
+        SheetDatePickerDialog(
+            initialDate = loggedDate,
+            onConfirm = {
+                loggedDate = it
+                showDatePicker = false
+            },
+            onDismiss = { showDatePicker = false }
+        )
+    }
+
+    if (showTimePicker) {
+        SheetTimePickerDialog(
+            initialTime = loggedTime,
+            onConfirm = {
+                loggedTime = it
+                showTimePicker = false
+            },
+            onDismiss = { showTimePicker = false }
+        )
     }
 
     whatIfEntry?.let { entry ->

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodResultSheet.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodResultSheet.kt
@@ -99,6 +99,7 @@ fun FoodResultSheet(
     preferGramsByDefault: Boolean = false,
     profile: UserProfile? = null,
     dayEntries: List<FoodEntry> = emptyList(),
+    allEntries: List<FoodEntry> = dayEntries,
     source: FoodSource = FoodSource.TEXT_INPUT,
     initialTimestamp: Instant = Instant.now(),
     isSubmitting: Boolean = false,
@@ -168,8 +169,17 @@ fun FoodResultSheet(
     // section lets the user adjust it before logging.
     val zone = remember { ZoneId.systemDefault() }
     val initialLoggedAt = remember(analysis) { initialTimestamp.atZone(zone) }
-    var loggedDate by remember(analysis) { mutableStateOf(initialLoggedAt.toLocalDate()) }
-    var loggedTime by remember(analysis) { mutableStateOf(initialLoggedAt.toLocalTime()) }
+    var loggedDate by rememberSaveable(analysis, stateSaver = LocalDateSaver) {
+        mutableStateOf(initialLoggedAt.toLocalDate())
+    }
+    var loggedTime by rememberSaveable(analysis, stateSaver = LocalTimeSaver) {
+        mutableStateOf(initialLoggedAt.toLocalTime())
+    }
+    val whatIfDayEntries = remember(allEntries, loggedDate, zone) {
+        allEntries
+            .filter { it.timestamp.atZone(zone).toLocalDate() == loggedDate }
+            .sortedByDescending { it.timestamp }
+    }
     var showDatePicker by remember { mutableStateOf(false) }
     var showTimePicker by remember { mutableStateOf(false) }
     var moreNutritionExpanded by rememberSaveable { mutableStateOf(false) }
@@ -310,7 +320,7 @@ fun FoodResultSheet(
         protein = scaledMacro(editableProtein),
         carbs = scaledMacro(editableCarbs),
         fat = scaledMacro(editableFat),
-        timestamp = Instant.now(),
+        timestamp = loggedDate.atTime(loggedTime).atZone(zone).toInstant(),
         imageFilename = null,
         emoji = analysis.emoji,
         source = source,
@@ -774,7 +784,7 @@ fun FoodResultSheet(
     whatIfEntry?.let { entry ->
         WhatIfMealImpactDialog(
             entry = entry,
-            dayEntries = dayEntries,
+            dayEntries = whatIfDayEntries,
             profile = profile,
             onDismiss = { whatIfEntry = null },
             onSuggest = onWhatIfSuggestion

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodSheetPrimitives.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodSheetPrimitives.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.TextRange
@@ -69,7 +70,16 @@ import com.apoorvdarshan.calorietracker.R
 import com.apoorvdarshan.calorietracker.models.MealType
 import com.apoorvdarshan.calorietracker.models.ServingAmountExpression
 import com.apoorvdarshan.calorietracker.models.ServingUnitOption
+import com.apoorvdarshan.calorietracker.ui.components.DateWheelPicker
+import com.apoorvdarshan.calorietracker.ui.components.FudGlassDialog
+import com.apoorvdarshan.calorietracker.ui.components.FudGlassDialogActions
+import com.apoorvdarshan.calorietracker.ui.components.FudGlassTextField
 import com.apoorvdarshan.calorietracker.ui.theme.AppColors
+import com.apoorvdarshan.calorietracker.ui.util.clockTimePattern
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 // Shared visual primitives for the food review/edit sheets. Names are
 // `Sheet*`-prefixed so they don't collide with the look-alike privates in
@@ -701,6 +711,119 @@ internal fun SheetGlassDropdownMenuItem(
                 modifier = Modifier.size(18.dp)
             )
         }
+    }
+}
+
+/** Date/time card shared by the review and edit sheets. */
+@Composable
+internal fun SheetDateTimeCard(
+    loggedDate: LocalDate,
+    loggedTime: LocalTime,
+    onEditDate: () -> Unit,
+    onEditTime: () -> Unit
+) {
+    val context = LocalContext.current
+    val dateFormatter = remember { DateTimeFormatter.ofPattern("MMM d, yyyy", Locale.US) }
+    val timeFormatter = remember(context) { DateTimeFormatter.ofPattern(clockTimePattern(context), Locale.US) }
+    SheetPillCard {
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onEditDate)
+                .padding(horizontal = 18.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(stringResource(R.string.label_date), fontSize = 17.sp, modifier = Modifier.weight(1f))
+            Text(
+                loggedDate.format(dateFormatter),
+                fontSize = 17.sp,
+                color = AppColors.Calorie,
+                fontWeight = FontWeight.Medium
+            )
+        }
+        SheetHairline()
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onEditTime)
+                .padding(horizontal = 18.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(stringResource(R.string.label_time), fontSize = 17.sp, modifier = Modifier.weight(1f))
+            Text(
+                loggedTime.format(timeFormatter),
+                fontSize = 17.sp,
+                color = AppColors.Calorie,
+                fontWeight = FontWeight.Medium
+            )
+        }
+    }
+}
+
+/** Wheel-style logged-date picker dialog shared by the review and edit sheets. */
+@Composable
+internal fun SheetDatePickerDialog(
+    initialDate: LocalDate,
+    onConfirm: (LocalDate) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var pickedDate by remember(initialDate) { mutableStateOf(initialDate) }
+    FudGlassDialog(onDismissRequest = onDismiss) {
+        Text(stringResource(R.string.label_date), fontSize = 21.sp, fontWeight = FontWeight.Bold)
+        DateWheelPicker(
+            selected = pickedDate,
+            onSelect = { pickedDate = it },
+            minYear = LocalDate.now().year - 10,
+            maxYear = LocalDate.now().year,
+            modifier = Modifier.fillMaxWidth()
+        )
+        FudGlassDialogActions(
+            primaryText = stringResource(R.string.action_done),
+            onPrimary = { onConfirm(pickedDate) },
+            dismissText = stringResource(R.string.action_cancel),
+            onDismiss = onDismiss
+        )
+    }
+}
+
+/** Hour/minute logged-time entry dialog shared by the review and edit sheets. */
+@Composable
+internal fun SheetTimePickerDialog(
+    initialTime: LocalTime,
+    onConfirm: (LocalTime) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var hourText by remember(initialTime) { mutableStateOf(initialTime.hour.toString().padStart(2, '0')) }
+    var minuteText by remember(initialTime) { mutableStateOf(initialTime.minute.toString().padStart(2, '0')) }
+
+    FudGlassDialog(onDismissRequest = onDismiss) {
+        Text(stringResource(R.string.label_time), fontSize = 21.sp, fontWeight = FontWeight.Bold)
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            FudGlassTextField(
+                value = hourText,
+                onValueChange = { hourText = it.filter(Char::isDigit).take(2) },
+                placeholder = stringResource(R.string.placeholder_hour),
+                singleLine = true,
+                modifier = Modifier.weight(1f)
+            )
+            FudGlassTextField(
+                value = minuteText,
+                onValueChange = { minuteText = it.filter(Char::isDigit).take(2) },
+                placeholder = stringResource(R.string.placeholder_minute),
+                singleLine = true,
+                modifier = Modifier.weight(1f)
+            )
+        }
+        FudGlassDialogActions(
+            primaryText = stringResource(R.string.action_done),
+            onPrimary = {
+                val hour = hourText.toIntOrNull()?.coerceIn(0, 23) ?: initialTime.hour
+                val minute = minuteText.toIntOrNull()?.coerceIn(0, 59) ?: initialTime.minute
+                onConfirm(LocalTime.of(hour, minute))
+            },
+            dismissText = stringResource(R.string.action_cancel),
+            onDismiss = onDismiss
+        )
     }
 }
 

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodSheetPrimitives.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodSheetPrimitives.kt
@@ -773,8 +773,8 @@ internal fun SheetDatePickerDialog(
         DateWheelPicker(
             selected = pickedDate,
             onSelect = { pickedDate = it },
-            minYear = LocalDate.now().year - 10,
-            maxYear = LocalDate.now().year,
+            minYear = minOf(LocalDate.now().year - 10, initialDate.year),
+            maxYear = maxOf(LocalDate.now().year, initialDate.year),
             modifier = Modifier.fillMaxWidth()
         )
         FudGlassDialogActions(

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
@@ -1077,6 +1077,7 @@ CalorieHero(
             preferGramsByDefault = ui.preferGramsByDefault,
             profile = ui.profile,
             dayEntries = ui.todayEntries,
+            allEntries = allEntries,
             isSubmitting = ui.foodSaveInProgress,
             container = container,
             analyzeIngredientText = vm::analyzeIngredientText,

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
@@ -1070,6 +1070,7 @@ CalorieHero(
 
     if (ui.analyzing) AnalyzingOverlay(imageBytes = ui.pendingImageBytes)
     ui.pendingAnalysis?.let { analysis ->
+        val initialTimestamp = remember(analysis) { vm.timestampForSelectedDay() }
         FoodResultSheet(
             analysis = analysis,
             imageBytesList = ui.pendingImageBytesList,
@@ -1084,8 +1085,9 @@ CalorieHero(
             source = ui.pendingReviewSource?.source
                 ?: ui.pendingFoodSource
                 ?: if (ui.pendingImageBytes != null) FoodSource.SNAP_FOOD else FoodSource.TEXT_INPUT,
+            initialTimestamp = initialTimestamp,
             onWhatIfSuggestion = vm::suggestMealWhatIf,
-            onSave = { name, grams, servingSizeIsKnown, scale, mealType, selectedServingUnit, selectedServingQuantity, editedAnalysis ->
+            onSave = { name, grams, servingSizeIsKnown, scale, mealType, selectedServingUnit, selectedServingQuantity, editedAnalysis, timestamp ->
                 vm.saveAnalysis(
                     name = name,
                     servingGrams = grams,
@@ -1094,7 +1096,8 @@ CalorieHero(
                     mealType = mealType,
                     selectedServingUnit = selectedServingUnit,
                     selectedServingQuantity = selectedServingQuantity,
-                    editedAnalysis = editedAnalysis
+                    editedAnalysis = editedAnalysis,
+                    timestamp = timestamp
                 )
             },
             onDismiss = { vm.dismissPending() }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt
@@ -702,9 +702,14 @@ viewModelScope.launch {
         val snapshot = _ui.value
         val profile = snapshot.profile
             ?: return container.appContext.getString(R.string.finish_onboarding_hint)
+        val zone = ZoneId.systemDefault()
+        val day = entry.timestamp.atZone(zone).toLocalDate()
+        val dayEntries = container.foodRepository.entries.first()
+            .filter { it.timestamp.atZone(zone).toLocalDate() == day }
+            .sortedByDescending { it.timestamp }
         return container.foodAnalysis.suggestMealWhatIf(
             entry = entry,
-            dayEntries = snapshot.todayEntries,
+            dayEntries = dayEntries,
             profile = profile,
             weightMetric = snapshot.weightMetric
         )

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt
@@ -575,7 +575,8 @@ viewModelScope.launch {
         mealType: MealType = MealType.currentMeal,
         selectedServingUnit: String? = null,
         selectedServingQuantity: Double? = null,
-        editedAnalysis: FoodAnalysis? = null
+        editedAnalysis: FoodAnalysis? = null,
+        timestamp: Instant? = null
     ) {
         val pendingAnalysis = _ui.value.pendingAnalysis ?: return
         val analysis = editedAnalysis ?: pendingAnalysis
@@ -609,7 +610,7 @@ viewModelScope.launch {
                     protein = macro(analysis.protein),
                     carbs = macro(analysis.carbs),
                     fat = macro(analysis.fat),
-                    timestamp = timestampForSelectedDay(),
+                    timestamp = timestamp ?: timestampForSelectedDay(),
                     imageFilename = filenames.firstOrNull(),
                     additionalImageFilenames = filenames.drop(1),
                     emoji = analysis.emoji,
@@ -855,8 +856,9 @@ viewModelScope.launch {
      * Mirrors iOS `logDate: selectedDate` behavior. When viewing today, returns now.
      * When viewing a past or future day, combines that day with the current wall-clock
      * time so the entry shows a sensible time and lands on the correct calendar day.
+     * Also seeds the review sheet's editable Date & Time default.
      */
-    private fun timestampForSelectedDay(): Instant {
+    fun timestampForSelectedDay(): Instant {
         val day = _selectedDate.value
         val today = LocalDate.now()
         if (day == today) return Instant.now()

--- a/android/app/src/test/java/com/apoorvdarshan/calorietracker/ui/home/FoodDraftSaversTest.kt
+++ b/android/app/src/test/java/com/apoorvdarshan/calorietracker/ui/home/FoodDraftSaversTest.kt
@@ -5,6 +5,8 @@ import androidx.compose.runtime.saveable.SaverScope
 import com.apoorvdarshan.calorietracker.models.IngredientPortion
 import com.apoorvdarshan.calorietracker.models.MealIngredient
 import com.apoorvdarshan.calorietracker.models.ServingUnitOption
+import java.time.LocalDate
+import java.time.LocalTime
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -39,6 +41,14 @@ class FoodDraftSaversTest {
         val nutrients = mapOf("selenium" to 12.3, "manganese" to 0.8)
         assertEquals(options, restore(foodDraftSaver<List<ServingUnitOption>>(), options))
         assertEquals(nutrients, restore(foodDraftSaver<Map<String, Double>>(), nutrients))
+    }
+
+    @Test
+    fun loggedDateAndTimeSurviveSaveRestore() {
+        val date = LocalDate.of(2025, 1, 3)
+        val time = LocalTime.of(16, 45, 30)
+        assertEquals(date, restore(LocalDateSaver, date))
+        assertEquals(time, restore(LocalTimeSaver, time))
     }
 
     @Test

--- a/ios/calorietracker/ContentView.swift
+++ b/ios/calorietracker/ContentView.swift
@@ -1609,7 +1609,7 @@ private var dailyStepsTaskKey: String {
                             servingSizeIsKnown: result.servingSizeIsKnown,
                             logDate: logDateForSelectedDay,
                             profile: userProfile,
-                            dayEntries: foodStore.entries(for: logDateForSelectedDay),
+                            entriesForDate: { foodStore.entries(for: $0) },
                             weightMetric: weightUnitRaw == "kg",
                             onLog: { entry in
                                 if !foodStore.addEntry(entry) { showFoodLoggingBlocked = true }

--- a/ios/calorietracker/Views/FoodResultView.swift
+++ b/ios/calorietracker/Views/FoodResultView.swift
@@ -66,8 +66,10 @@ struct FoodResultView: View {
     @State private var imagePreview: FullScreenImagePreview?
     @State private var submissionGate = FoodSubmissionGate()
     @State var mealType: MealType = .currentMeal
+    // Editable log date/time; seeded from the diary day being viewed (now when
+    // it is today) so an untouched save behaves exactly like before.
+    @State private var loggedAt: Date
 
-    let logDate: Date
     let profile: UserProfile
     let dayEntries: [FoodEntry]
     let weightMetric: Bool
@@ -222,7 +224,7 @@ struct FoodResultView: View {
         self._editableFolate = State(initialValue: folate)
         self._editableOmega3 = State(initialValue: omega3)
         self._editableIngredients = State(initialValue: ingredients)
-        self.logDate = logDate
+        self._loggedAt = State(initialValue: logDate)
         self.profile = profile
         self.dayEntries = dayEntries
         self.weightMetric = weightMetric
@@ -536,6 +538,13 @@ struct FoodResultView: View {
                         .tint(AppColors.calorie)
                     }
 
+                    Section("Date & Time") {
+                        DatePicker("Date", selection: $loggedAt, displayedComponents: .date)
+                            .tint(AppColors.calorie)
+                        DatePicker("Time", selection: $loggedAt, displayedComponents: .hourAndMinute)
+                            .tint(AppColors.calorie)
+                    }
+
                 }
                 .scrollContentBackground(.hidden)
                 .background(AppColors.appBackground)
@@ -623,7 +632,7 @@ struct FoodResultView: View {
             protein: scaledProtein,
             carbs: scaledCarbs,
             fat: scaledFat,
-            timestamp: logDate,
+            timestamp: loggedAt,
             imageData: includeImage ? images.first?.jpegData(compressionQuality: 0.5) : nil,
             additionalImageData: includeImage ? images.dropFirst().compactMap { $0.jpegData(compressionQuality: 0.5) } : [],
             emoji: emoji,

--- a/ios/calorietracker/Views/FoodResultView.swift
+++ b/ios/calorietracker/Views/FoodResultView.swift
@@ -71,7 +71,7 @@ struct FoodResultView: View {
     @State private var loggedAt: Date
 
     let profile: UserProfile
-    let dayEntries: [FoodEntry]
+    let entriesForDate: (Date) -> [FoodEntry]
     let weightMetric: Bool
     var onLog: (FoodEntry) -> Void
     @Environment(\.dismiss) private var dismiss
@@ -163,7 +163,7 @@ struct FoodResultView: View {
         servingSizeIsKnown: Bool = true,
         logDate: Date = .now,
         profile: UserProfile,
-        dayEntries: [FoodEntry],
+        entriesForDate: @escaping (Date) -> [FoodEntry],
         weightMetric: Bool,
         onLog: @escaping (FoodEntry) -> Void
     ) {
@@ -226,9 +226,13 @@ struct FoodResultView: View {
         self._editableIngredients = State(initialValue: ingredients)
         self._loggedAt = State(initialValue: logDate)
         self.profile = profile
-        self.dayEntries = dayEntries
+        self.entriesForDate = entriesForDate
         self.weightMetric = weightMetric
         self.onLog = onLog
+    }
+
+    private var whatIfDayEntries: [FoodEntry] {
+        entriesForDate(loggedAt)
     }
 
     private static func formatGrams(_ value: Double) -> String {
@@ -578,7 +582,7 @@ struct FoodResultView: View {
                 .sheet(isPresented: $showWhatIfSheet) {
                     WhatIfMealImpactSheet(
                         entry: makeFoodEntry(includeImage: false),
-                        dayEntries: dayEntries,
+                        dayEntries: whatIfDayEntries,
                         profile: profile,
                         weightMetric: weightMetric
                     )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses bot review feedback on PR #269:

- **Date/time state restoration (Android)**: `loggedDate` and `loggedTime` now use `rememberSaveable` with explicit `LocalDateSaver` / `LocalTimeSaver` so activity recreation keeps user edits.
- **Future-year date picker (Android)**: `SheetDatePickerDialog` year range now includes `initialDate.year`, fixing January diary dates viewed from late December.
- **What-if day resolution (Android + iOS)**: What-if preview and AI suggestion now use diary entries for the selected log date, not the originally viewed day.
- **Tests**: Added restoration test for edited date/time + unit tests for the new savers.

Commit: f2e91077
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-577d6fac-cde7-428c-99ef-a1728294116b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-577d6fac-cde7-428c-99ef-a1728294116b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added editable date and time controls when reviewing or editing food entries on Android and iOS.
  - Added date and time picker dialogs for easier timestamp adjustments.
  - Food entries now save using the selected date and time, while defaulting to the appropriate current or selected-day timestamp.
  - Updated food editing screens with a consistent date-and-time presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds editable meal timestamps to the Android and iOS review sheets and propagates the selected timestamp through logging and What-if calculations.
- Adds shared Android date/time controls and state savers.
- Restores edited Android date/time values across activity recreation.
- Ensures Android date pickers retain initial dates outside the normal year range.
- Uses the selected meal date to gather matching diary entries for What-if calculations on both platforms.
- Adds iOS date and time controls before logging.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no new actionable failures remain, and both previous findings are resolved.

Android now preserves edited timestamps across state restoration and supports the initial date’s year in the shared picker. The selected-day What-if entry lookup is consistent on Android and iOS, and no blocking correctness or security issue remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodResultSheet.kt | Adds restorable date/time state, forwards the selected timestamp, and scopes What-if entries to the selected day. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodSheetPrimitives.kt | Extracts shared date/time controls and includes the initial date within the picker’s supported year range. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt | Saves optional review timestamps and gathers diary entries matching a What-if candidate’s day. |
| ios/calorietracker/Views/FoodResultView.swift | Adds editable logging date/time state and retrieves matching-day entries for What-if calculations. |
| android/app/src/androidTest/java/com/apoorvdarshan/calorietracker/ui/home/AddFoodStateRestorationTest.kt | Verifies edited review timestamps survive saved-instance-state restoration and are submitted unchanged. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor User
    participant Review as Food Review Sheet
    participant Diary as Diary Store
    participant WhatIf as What-if Analysis
    User->>Review: Select date and time
    Review->>Diary: Request entries for selected day
    Diary-->>Review: Matching day entries
    User->>Review: Preview impact
    Review->>WhatIf: Candidate meal + matching entries
    WhatIf-->>User: Selected-day impact
    User->>Review: Log meal
    Review->>Diary: Save with selected timestamp
```

<sub>Reviews (2): Last reviewed commit: ["Fix review sheet date/time state and Wha..."](https://github.com/apoorvdarshan/fud-ai/commit/f2e9107752aa99d86b0f5291e0c72a4e2e1e979f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63008576)</sub>

<!-- /greptile_comment -->