### PR TITLE
Retry nutrition writes Health Connect never confirmed (rebased #204)

### DIFF
--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/FudAIApp.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/FudAIApp.kt
@@ -246,6 +246,12 @@ class AppContainer(app: FudAIApp) {
         if (healthReadSyncInFlight) return
         if (!prefs.healthConnectEnabled.first()) return
         if (!health.isAvailable()) return
+
+        // Nutrition writes Health Connect never confirmed retry here. Deliberately ahead of
+        // the read-capability guard below: a user who granted write but no reads still has a
+        // queue to drain, and returning early would strand it forever.
+        foodRepository.retryPendingHealthWrites()
+
         val caps = health.capabilities()
         val workoutBurnRead = health.hasActiveEnergyRead()
         if (!caps.weightRead && !caps.bodyFatRead && !caps.nutritionRead &&

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FoodRepository.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FoodRepository.kt
@@ -7,6 +7,7 @@ import com.apoorvdarshan.calorietracker.services.ReviewPrompter
 import com.apoorvdarshan.calorietracker.models.MealType
 import com.apoorvdarshan.calorietracker.services.FoodImageStore
 import com.apoorvdarshan.calorietracker.services.health.HealthConnectManager
+import com.apoorvdarshan.calorietracker.services.health.NutritionWriteGate
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -73,9 +74,7 @@ class FoodRepository(
         if (prefs.fastingSessions.first().any { it.isActive }) return false
         val current = prefs.foodEntries.first()
         prefs.setFoodEntries(current + entry)
-        if (shouldSyncHealth()) {
-            health?.writeNutrition(entry)
-        }
+        healthRetry.sync(entry, isUpdate = false)
         // One-time organic review moment: the first successful food log (iOS parity).
         if (!prefs.reviewPromptedAfterFirstLog.first()) {
             prefs.setReviewPromptedAfterFirstLog(true)
@@ -102,17 +101,21 @@ class FoodRepository(
             }
         }
         if (shouldSyncHealth()) {
-            health?.updateNutrition(entry)
+            healthRetry.sync(entry, isUpdate = true)
         } else {
             // Sync off: still clean up the stale HC record for this entry (iOS
             // parity, best-effort) so the restore path can't resurrect the
             // pre-edit version later.
             health?.deleteNutrition(entry.id)
+            healthRetry.forget(entry.id)
         }
     }
 
     suspend fun deleteEntry(entryId: UUID) {
         ensureFavoritesMigrated()
+        // Drop the queue entry under the same mutex retry/sync uses, before the local
+        // row disappears, so an in-flight retry cannot recreate Health Connect data.
+        healthRetry.forget(entryId)
         val current = prefs.foodEntries.first()
         prefs.setFoodEntries(current.filter { it.id != entryId })
         pruneOrphanedImages()
@@ -164,7 +167,8 @@ class FoodRepository(
 
         if (shouldSyncHealth()) {
             removedIds.forEach { health?.deleteNutrition(it) }
-            changed.forEach { health?.updateNutrition(it) }
+            healthRetry.forgetAll(removedIds)
+            healthRetry.syncAll(changed, isUpdate = true)
         } else {
             // Prevent stale records written by an earlier sync-enabled session
             // from restoring pre-import values later.
@@ -240,9 +244,35 @@ class FoodRepository(
         if (seeded.isNotEmpty()) prefs.setFavoriteFoodEntries(seeded)
     }
 
+    /**
+     * Deferred retry for nutrition writes Health Connect never confirmed. The adapter keeps
+     * [HealthConnectManager] out of the retry's own type signature, matching how
+     * [WorkoutHealthSync] is supplied to [WorkoutRepository].
+     */
+    private val healthRetry = NutritionHealthRetry(
+        prefs,
+        health?.let { manager ->
+            object : NutritionHealthSync {
+                override suspend fun writeGate() = manager.nutritionWriteGate()
+                override suspend fun write(entry: FoodEntry) = manager.writeNutrition(entry)
+                override suspend fun update(entry: FoodEntry) = manager.updateNutrition(entry)
+                override suspend fun delete(entryId: UUID) = manager.deleteNutrition(entryId)
+            }
+        }
+    )
+
+    /** Re-attempt writes that were never confirmed. Called from the app-foreground sync. */
+    suspend fun retryPendingHealthWrites() = healthRetry.retryPending()
+
+    /**
+     * Whether the user has Health Connect sync switched on. Deliberately does not ask
+     * whether the nutrition-write permission is granted: that question is answered inside
+     * [NutritionHealthRetry] via [NutritionWriteGate], because a permission probe that
+     * fails must not be read as "no permission". Doing so here silently discarded writes.
+     */
     private suspend fun shouldSyncHealth(): Boolean {
-        val manager = health ?: return false
-        return prefs.healthConnectEnabled.first() && manager.hasNutritionWrite()
+        if (health == null) return false
+        return prefs.healthConnectEnabled.first()
     }
 
     /**

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/NutritionHealthRetry.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/NutritionHealthRetry.kt
@@ -1,0 +1,173 @@
+package com.apoorvdarshan.calorietracker.data
+
+import com.apoorvdarshan.calorietracker.models.FoodEntry
+import com.apoorvdarshan.calorietracker.services.health.NutritionWriteGate
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.UUID
+
+/**
+ * Health Connect as the food log needs it. Mirrors [WorkoutHealthSync] so the retry path
+ * can be exercised without a live Health Connect service.
+ */
+interface NutritionHealthSync {
+    suspend fun writeGate(): NutritionWriteGate
+    suspend fun write(entry: FoodEntry): Boolean
+
+    /**
+     * Delete-then-write on the entry's own clientRecordId. Used for every retry, so a
+     * second attempt cannot duplicate a record that did land after all — the delete
+     * targets that one entry, never the day or the whole log.
+     */
+    suspend fun update(entry: FoodEntry): Boolean
+
+    /** Best-effort undo when a write completes after the local entry was removed. */
+    suspend fun delete(entryId: UUID): Boolean = false
+}
+
+/** The slice of persistence the retry needs. Mirrors [WorkoutStateStore]. */
+interface NutritionSyncStore {
+    val foodEntries: Flow<List<FoodEntry>>
+    val healthConnectEnabled: Flow<Boolean>
+    val pendingNutritionHealthWrites: Flow<Set<String>>
+    suspend fun setPendingNutritionHealthWrites(ids: Set<String>)
+}
+
+/**
+ * Keeps food entries whose Health Connect write was never confirmed, and re-attempts them
+ * on the next foreground sync.
+ *
+ * Before this existed, `FoodRepository.addEntry` called `writeNutrition` and discarded the
+ * result, and the permission probe in front of it turned an unreachable Health Connect
+ * service into "no permission". Either path dropped the entry with no exception, no log
+ * and no retry: the food log kept it, Health Connect never heard about it, and nothing in
+ * the app knew the two had diverged. [WorkoutRepository] already defers and retries its
+ * burn writes this way; nutrition simply never got the same treatment.
+ */
+class NutritionHealthRetry(
+    private val store: NutritionSyncStore,
+    private val health: NutritionHealthSync?
+) {
+    private val mutex = Mutex()
+
+    /**
+     * Push [entry] to Health Connect, queueing it when the write is not confirmed.
+     *
+     * On [NutritionWriteGate.UNKNOWN] the write is attempted anyway. Health Connect
+     * enforces its own permissions, so the worst case is a rejection we then queue and
+     * resolve on the next pass — strictly better than assuming the answer and dropping
+     * the entry.
+     */
+    suspend fun sync(entry: FoodEntry, isUpdate: Boolean) = syncAll(listOf(entry), isUpdate)
+
+    /**
+     * Push several entries in one pass. A diary import can carry hundreds of changed
+     * entries, and resolving the gate per entry would mean one Health Connect IPC
+     * round-trip each, so the gate and the queue are resolved once for the batch.
+     */
+    suspend fun syncAll(entries: List<FoodEntry>, isUpdate: Boolean) {
+        val adapter = health ?: return
+        if (entries.isEmpty()) return
+        mutex.withLock { syncAllLocked(adapter, entries, isUpdate) }
+    }
+
+    /** Drop [id] from the queue — the write landed, or the entry no longer exists. */
+    suspend fun forget(id: UUID) = forgetAll(listOf(id))
+
+    /** Batch form of [forget], so an import does not rewrite the queue once per entry. */
+    suspend fun forgetAll(ids: Collection<UUID>) {
+        if (ids.isEmpty()) return
+        val keys = ids.mapTo(mutableSetOf()) { it.toString() }
+        mutex.withLock { updateQueueLocked { it - keys } }
+    }
+
+    /**
+     * Re-attempt every queued write. Called from the app-foreground Health Connect
+     * coordinator, alongside the workout deferred writes.
+     */
+    suspend fun retryPending() {
+        val adapter = health ?: return
+        mutex.withLock { retryPendingLocked(adapter) }
+    }
+
+    private suspend fun syncAllLocked(
+        adapter: NutritionHealthSync,
+        entries: List<FoodEntry>,
+        isUpdate: Boolean
+    ) {
+        if (!store.healthConnectEnabled.first()) return
+        if (adapter.writeGate() == NutritionWriteGate.DENIED) return
+
+        val keys = entries.map { it.id.toString() }
+        updateQueueLocked { it + keys }
+
+        val written = mutableSetOf<String>()
+        val failed = mutableSetOf<String>()
+        for (entry in entries) {
+            val key = entry.id.toString()
+            if (!isStillPending(key)) continue
+            val currentEntry = store.foodEntries.first().find { it.id == entry.id } ?: continue
+
+            val ok = if (isUpdate) adapter.update(currentEntry) else adapter.write(currentEntry)
+            when {
+                !isStillPending(key) -> undoWriteIfNeeded(adapter, entry.id, ok)
+                !entryStillExists(key) -> undoWriteIfNeeded(adapter, entry.id, ok)
+                ok -> written += key
+                else -> failed += key
+            }
+        }
+        updateQueueLocked { (it - written) + failed }
+    }
+
+    private suspend fun retryPendingLocked(adapter: NutritionHealthSync) {
+        val pending = store.pendingNutritionHealthWrites.first()
+        if (pending.isEmpty()) return
+        if (!store.healthConnectEnabled.first()) return
+        when (adapter.writeGate()) {
+            // Still cannot reach the service. Keep the queue and try again on the next
+            // foreground — discarding it here is the exact bug this retry exists to fix.
+            NutritionWriteGate.UNKNOWN -> return
+            // Nutrition write was revoked. Nothing is retryable any more, and an
+            // unbounded queue would otherwise outlive the permission forever.
+            NutritionWriteGate.DENIED -> {
+                store.setPendingNutritionHealthWrites(emptySet())
+                return
+            }
+            NutritionWriteGate.ALLOWED -> Unit
+        }
+
+        val remaining = mutableSetOf<String>()
+        for (key in pending) {
+            if (!isStillPending(key)) continue
+            val entry = store.foodEntries.first().find { it.id.toString() == key } ?: continue
+
+            val ok = adapter.update(entry)
+            when {
+                !isStillPending(key) -> undoWriteIfNeeded(adapter, entry.id, ok)
+                !entryStillExists(key) -> undoWriteIfNeeded(adapter, entry.id, ok)
+                ok -> Unit
+                else -> remaining += key
+            }
+        }
+        if (remaining != pending) store.setPendingNutritionHealthWrites(remaining)
+    }
+
+    private suspend fun isStillPending(key: String): Boolean =
+        key in store.pendingNutritionHealthWrites.first()
+
+    private suspend fun entryStillExists(key: String): Boolean =
+        store.foodEntries.first().any { it.id.toString() == key }
+
+    private suspend fun undoWriteIfNeeded(adapter: NutritionHealthSync, entryId: UUID, writeSucceeded: Boolean) {
+        if (writeSucceeded) adapter.delete(entryId)
+    }
+
+    /** Read-modify-write of the queue. Caller must hold [mutex]. */
+    private suspend fun updateQueueLocked(transform: (Set<String>) -> Set<String>) {
+        val current = store.pendingNutritionHealthWrites.first()
+        val next = transform(current)
+        if (next != current) store.setPendingNutritionHealthWrites(next)
+    }
+}

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/PreferencesStore.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/PreferencesStore.kt
@@ -92,7 +92,7 @@ class PreferencesStore(
     private val context: Context,
     private val isLocalGemmaExecutable: () -> Boolean = { false },
     private val isLocalWhisperExecutable: () -> Boolean = { false }
-) : WorkoutStateStore {
+) : WorkoutStateStore, NutritionSyncStore {
 
     private val json = Json { ignoreUnknownKeys = true }
     private val ds get() = context.fudaiDataStore
@@ -219,7 +219,7 @@ class PreferencesStore(
     suspend fun setLastNotifiedUpdateVersion(v: String) { ds.edit { it[Keys.LAST_NOTIFIED_UPDATE_VERSION] = v } }
 
     // -- Health Connect ---------------------------------------------------
-    val healthConnectEnabled: Flow<Boolean> = ds.data.map { it[Keys.HEALTH_CONNECT_ENABLED] ?: false }
+    override val healthConnectEnabled: Flow<Boolean> = ds.data.map { it[Keys.HEALTH_CONNECT_ENABLED] ?: false }
     suspend fun setHealthConnectEnabled(v: Boolean) { ds.edit { it[Keys.HEALTH_CONNECT_ENABLED] = v } }
 
     val healthPermissionsVersion: Flow<Int> = ds.data.map { it[Keys.HEALTH_TYPES_VERSION] ?: 0 }
@@ -248,6 +248,17 @@ class PreferencesStore(
     /// the restore should be allowed to run again.
     val healthFoodRestoreDone: Flow<Boolean> = ds.data.map { it[Keys.HEALTH_FOOD_RESTORE_DONE] ?: false }
     suspend fun setHealthFoodRestoreDone(v: Boolean) { ds.edit { it[Keys.HEALTH_FOOD_RESTORE_DONE] = v } }
+
+    /// Food entries whose Health Connect write was never confirmed, retried on the next
+    /// foreground sync. Comma-joined UUIDs, matching [healthChangesTokenTypes] — UUIDs
+    /// cannot contain a comma, so the encoding is unambiguous.
+    override val pendingNutritionHealthWrites: Flow<Set<String>> = ds.data.map {
+        it[Keys.PENDING_NUTRITION_HEALTH_WRITES]?.split(",")?.filter { s -> s.isNotBlank() }?.toSet()
+            ?: emptySet()
+    }
+    override suspend fun setPendingNutritionHealthWrites(ids: Set<String>) {
+        ds.edit { it[Keys.PENDING_NUTRITION_HEALTH_WRITES] = ids.joinToString(",") }
+    }
 
     val cloudBackupEnabled: Flow<Boolean> = ds.data.map { it[Keys.CLOUD_BACKUP_ENABLED] ?: false }
     suspend fun setCloudBackupEnabled(v: Boolean) { ds.edit { it[Keys.CLOUD_BACKUP_ENABLED] = v } }
@@ -969,7 +980,7 @@ class PreferencesStore(
     }
 
     // -- Food entries -----------------------------------------------------
-    val foodEntries: Flow<List<FoodEntry>> = ds.data.map { prefs ->
+    override val foodEntries: Flow<List<FoodEntry>> = ds.data.map { prefs ->
         prefs[Keys.FOOD_ENTRIES]?.let {
             runCatching { json.decodeFromString(ListSerializer(FoodEntry.serializer()), it) }.getOrNull()
         } ?: emptyList()
@@ -1187,6 +1198,7 @@ class PreferencesStore(
         val HEALTH_CHANGES_TOKEN = stringPreferencesKey("healthChangesToken")
         val HEALTH_CHANGES_TOKEN_TYPES = stringPreferencesKey("healthChangesTokenTypes")
         val HEALTH_FOOD_RESTORE_DONE = booleanPreferencesKey("healthFoodRestoreDone")
+        val PENDING_NUTRITION_HEALTH_WRITES = stringPreferencesKey("pendingNutritionHealthWrites")
         val CLOUD_BACKUP_ENABLED = booleanPreferencesKey("cloudBackupEnabled")
         val CLOUD_BACKUP_LAST_AT = stringPreferencesKey("cloudBackupLastAt")
         val CLOUD_BACKUP_LAST_HASH = stringPreferencesKey("cloudBackupLastHash")

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/health/HealthConnectManager.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/health/HealthConnectManager.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.UserManager
+import android.util.Log
 import androidx.health.connect.client.HealthConnectFeatures
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.PermissionController
@@ -74,6 +75,17 @@ internal fun healthAvailabilityMessageKind(
     HealthConnectAvailability.PROVIDER_UPDATE_REQUIRED ->
         HealthAvailabilityMessageKind.PROVIDER_UPDATE_REQUIRED
     HealthConnectAvailability.UNAVAILABLE -> HealthAvailabilityMessageKind.SYSTEM_UNAVAILABLE
+}
+
+/**
+ * Whether a nutrition write is permitted. [UNKNOWN] is deliberately distinct from [DENIED]:
+ * it means the permission probe failed, not that the user said no. Treating the two the same
+ * is what lets a transient Health Connect outage discard a food entry silently.
+ */
+enum class NutritionWriteGate {
+    ALLOWED,
+    DENIED,
+    UNKNOWN
 }
 
 internal fun resolveHealthConnectAvailability(
@@ -186,8 +198,34 @@ class HealthConnectManager(
     suspend fun hasNutritionHistory(): Boolean = supportsNutritionHistory() &&
         HealthPermission.PERMISSION_READ_HEALTH_DATA_HISTORY in granted()
 
-    private suspend fun granted(): Set<String> =
-        runCatching { client?.permissionController?.getGrantedPermissions() }.getOrNull() ?: emptySet()
+    /**
+     * Granted permissions, or null when the permission probe itself failed.
+     *
+     * Health Connect answers over IPC, and the service can be mid-update, cold-starting,
+     * or binder-timing-out — each of which throws here. Collapsing that into "nothing is
+     * granted" makes a transient outage indistinguishable from a permission the user
+     * actually revoked. That distinction matters on the write path: a revoked permission
+     * means there is nothing to do, while a failed probe means we do not yet know, and
+     * dropping the write is data loss the user never sees.
+     */
+    private suspend fun grantedOrNull(): Set<String>? =
+        runCatching { client?.permissionController?.getGrantedPermissions() }
+            .onFailure { Log.w(TAG, "Health Connect permission probe failed", it) }
+            .getOrNull()
+
+    /** Fail-closed view of [grantedOrNull] for the read paths, where "assume nothing is
+     *  granted" is the safe answer — a read that returns nothing loses no data. */
+    private suspend fun granted(): Set<String> = grantedOrNull() ?: emptySet()
+
+    /**
+     * Whether a nutrition write may proceed. [NutritionWriteGate.UNKNOWN] means the
+     * permission probe failed, not that permission is missing — callers should attempt
+     * the write anyway and treat a failure as retryable rather than skipping silently.
+     */
+    suspend fun nutritionWriteGate(): NutritionWriteGate = when (val g = grantedOrNull()) {
+        null -> NutritionWriteGate.UNKNOWN
+        else -> if (nutritionWrite in g) NutritionWriteGate.ALLOWED else NutritionWriteGate.DENIED
+    }
 
     /** The "connected" state: at least one Fud AI permission granted. Partial grants
      *  are valid — a read-only user still syncs the read direction. */
@@ -198,6 +236,8 @@ class HealthConnectManager(
     suspend fun hasBodyFatRead(): Boolean = bodyFatRead in granted()
     suspend fun hasBodyFatWrite(): Boolean = bodyFatWrite in granted()
     suspend fun hasNutritionRead(): Boolean = nutritionRead in granted()
+    /** Fail-closed, like its siblings. Do NOT gate a nutrition write on this: a failed
+     *  probe reads as false here, which is how writes went missing. Use [nutritionWriteGate]. */
     suspend fun hasNutritionWrite(): Boolean = nutritionWrite in granted()
     suspend fun hasActiveEnergyRead(): Boolean = activeEnergyRead in granted()
     suspend fun hasActiveEnergyWrite(): Boolean = activeEnergyWrite in granted()
@@ -855,6 +895,7 @@ class HealthConnectManager(
     }
 
     companion object {
+        private const val TAG = "HealthConnectManager"
         private val lastLoggedAvailabilityKey = AtomicReference<String?>(null)
         private val writeVersions = HealthWriteVersions()
 

--- a/android/app/src/test/java/com/apoorvdarshan/calorietracker/data/NutritionHealthRetryTest.kt
+++ b/android/app/src/test/java/com/apoorvdarshan/calorietracker/data/NutritionHealthRetryTest.kt
@@ -1,0 +1,263 @@
+package com.apoorvdarshan.calorietracker.data
+
+import com.apoorvdarshan.calorietracker.models.FoodEntry
+import com.apoorvdarshan.calorietracker.models.FoodSource
+import com.apoorvdarshan.calorietracker.services.health.NutritionWriteGate
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+import java.util.UUID
+
+class NutritionHealthRetryTest {
+
+    @Test
+    fun failedWriteIsQueuedAndRetriedAsAnIdempotentUpdate() = runBlocking {
+        val entry = foodEntry("Spaghetti Bolognese")
+        val store = FakeNutritionSyncStore(entries = listOf(entry))
+        val health = FakeNutritionHealthSync(writeSucceeds = false)
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.sync(entry, isUpdate = false)
+        assertEquals(setOf(entry.id.toString()), store.pending.value)
+
+        health.writeSucceeds = true
+        retry.retryPending()
+
+        // Retries go through update (delete-then-write on the entry's own clientRecordId),
+        // so a record that did land after all cannot end up duplicated.
+        assertEquals(listOf(entry.id), health.updated)
+        assertTrue(store.pending.value.isEmpty())
+    }
+
+    @Test
+    fun pendingIdIsRegisteredBeforeHealthConnectWrite() = runBlocking {
+        val entry = foodEntry("Oats")
+        val store = FakeNutritionSyncStore(entries = listOf(entry))
+        val health = FakeNutritionHealthSync(onWrite = {
+            assertEquals(setOf(entry.id.toString()), store.pending.value)
+        })
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.sync(entry, isUpdate = false)
+
+        assertTrue(store.pending.value.isEmpty())
+    }
+
+    @Test
+    fun probeFailureDoesNotDiscardTheWrite() = runBlocking {
+        val entry = foodEntry("Svinemorbrad")
+        val store = FakeNutritionSyncStore(entries = listOf(entry))
+        // The regression: an unreachable Health Connect used to read as "no permission".
+        val health = FakeNutritionHealthSync(gate = NutritionWriteGate.UNKNOWN, writeSucceeds = false)
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.sync(entry, isUpdate = false)
+
+        assertEquals(1, health.writes.size) // attempted rather than skipped
+        assertEquals(setOf(entry.id.toString()), store.pending.value)
+    }
+
+    @Test
+    fun probeStillFailingKeepsTheQueueIntact() = runBlocking {
+        val entry = foodEntry("Wasa Sport")
+        val store = FakeNutritionSyncStore(
+            entries = listOf(entry),
+            pending = setOf(entry.id.toString())
+        )
+        val health = FakeNutritionHealthSync(gate = NutritionWriteGate.UNKNOWN)
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.retryPending()
+
+        assertTrue(health.updated.isEmpty())
+        assertEquals(setOf(entry.id.toString()), store.pending.value)
+    }
+
+    @Test
+    fun revokedPermissionClearsTheQueueInsteadOfRetryingForever() = runBlocking {
+        val entry = foodEntry("Kaffe")
+        val store = FakeNutritionSyncStore(
+            entries = listOf(entry),
+            pending = setOf(entry.id.toString())
+        )
+        val health = FakeNutritionHealthSync(gate = NutritionWriteGate.DENIED)
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.retryPending()
+
+        assertTrue(health.updated.isEmpty())
+        assertTrue(store.pending.value.isEmpty())
+    }
+
+    @Test
+    fun deletedEntryIsDroppedFromTheQueueRatherThanRecreated() = runBlocking {
+        val gone = UUID.randomUUID()
+        val kept = foodEntry("Skyr")
+        val store = FakeNutritionSyncStore(
+            entries = listOf(kept),
+            pending = setOf(gone.toString(), kept.id.toString())
+        )
+        val health = FakeNutritionHealthSync()
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.retryPending()
+
+        assertEquals(listOf(kept.id), health.updated)
+        assertTrue(store.pending.value.isEmpty())
+    }
+
+    @Test
+    fun writeCompletingAfterForgetRollsBackHealthConnect() = runBlocking {
+        val entry = foodEntry("Toast")
+        val store = FakeNutritionSyncStore(
+            entries = listOf(entry),
+            pending = setOf(entry.id.toString())
+        )
+        val health = FakeNutritionHealthSync(onUpdate = {
+            store.pending.value = emptySet()
+        })
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.retryPending()
+
+        assertEquals(listOf(entry.id), health.deleted)
+        assertTrue(store.pending.value.isEmpty())
+    }
+
+    @Test
+    fun syncIsANoOpWhileHealthConnectIsSwitchedOff() = runBlocking {
+        val entry = foodEntry("Havregryn")
+        val store = FakeNutritionSyncStore(entries = listOf(entry), enabled = false)
+        val health = FakeNutritionHealthSync(writeSucceeds = false)
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.sync(entry, isUpdate = false)
+
+        assertTrue(health.writes.isEmpty())
+        assertTrue(store.pending.value.isEmpty())
+    }
+
+    @Test
+    fun successfulWriteLeavesNothingQueued() = runBlocking {
+        val entry = foodEntry("Chia")
+        val store = FakeNutritionSyncStore(entries = listOf(entry), pending = setOf(entry.id.toString()))
+        val health = FakeNutritionHealthSync()
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.sync(entry, isUpdate = false)
+
+        assertEquals(listOf(entry.id), health.writes)
+        assertTrue(store.pending.value.isEmpty())
+    }
+
+    @Test
+    fun batchResolvesTheGateOncePerCallNotOncePerEntry() = runBlocking {
+        // A diary import can carry hundreds of entries. writeGate() is a Health Connect IPC
+        // round-trip, so probing per entry would put the import on the wire hundreds of times.
+        val entries = (1..50).map { foodEntry("Meal $it") }
+        val store = FakeNutritionSyncStore(entries = entries)
+        val health = FakeNutritionHealthSync()
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.syncAll(entries, isUpdate = true)
+
+        assertEquals(1, health.gateProbes)
+        assertEquals(50, health.updated.size)
+    }
+
+    @Test
+    fun batchQueuesOnlyTheEntriesThatFailed() = runBlocking {
+        val ok = foodEntry("Skyr")
+        val bad = foodEntry("Spaghetti Bolognese")
+        val store = FakeNutritionSyncStore(entries = listOf(ok, bad))
+        val health = FakeNutritionHealthSync(failFor = setOf(bad.id))
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.syncAll(listOf(ok, bad), isUpdate = false)
+
+        assertEquals(setOf(bad.id.toString()), store.pending.value)
+    }
+
+    @Test
+    fun syncUsesLatestEntrySnapshotFromStore() = runBlocking {
+        val entry = foodEntry("Pasta")
+        val updated = entry.copy(calories = 480)
+        val store = FakeNutritionSyncStore(entries = listOf(updated))
+        val health = FakeNutritionHealthSync()
+        val retry = NutritionHealthRetry(store, health)
+
+        retry.sync(entry, isUpdate = true)
+
+        assertEquals(480, health.lastWrittenCalories)
+    }
+
+    private fun foodEntry(name: String) = FoodEntry(
+        name = name,
+        calories = 315,
+        protein = 18.0,
+        carbs = 40.0,
+        fat = 9.0,
+        timestamp = Instant.parse("2026-08-27T17:54:00Z"),
+        source = FoodSource.SNAP_FOOD
+    )
+}
+
+private class FakeNutritionSyncStore(
+    entries: List<FoodEntry> = emptyList(),
+    pending: Set<String> = emptySet(),
+    enabled: Boolean = true
+) : NutritionSyncStore {
+    val pending = MutableStateFlow(pending)
+    private val entriesFlow = MutableStateFlow(entries)
+    override val foodEntries: Flow<List<FoodEntry>> = entriesFlow
+    override val healthConnectEnabled: Flow<Boolean> = MutableStateFlow(enabled)
+    override val pendingNutritionHealthWrites: Flow<Set<String>> = this.pending
+    override suspend fun setPendingNutritionHealthWrites(ids: Set<String>) { pending.value = ids }
+}
+
+private class FakeNutritionHealthSync(
+    private val gate: NutritionWriteGate = NutritionWriteGate.ALLOWED,
+    var writeSucceeds: Boolean = true,
+    private val failFor: Set<UUID> = emptySet(),
+    private val onWrite: suspend () -> Unit = {},
+    private val onUpdate: suspend () -> Unit = {}
+) : NutritionHealthSync {
+    val writes = mutableListOf<UUID>()
+    val updated = mutableListOf<UUID>()
+    val deleted = mutableListOf<UUID>()
+    var gateProbes = 0
+        private set
+    var lastWrittenCalories: Int? = null
+        private set
+
+    override suspend fun writeGate(): NutritionWriteGate {
+        gateProbes++
+        return gate
+    }
+
+    override suspend fun write(entry: FoodEntry): Boolean {
+        onWrite()
+        writes += entry.id
+        lastWrittenCalories = entry.calories
+        return succeeds(entry)
+    }
+
+    override suspend fun update(entry: FoodEntry): Boolean {
+        onUpdate()
+        updated += entry.id
+        lastWrittenCalories = entry.calories
+        return succeeds(entry)
+    }
+
+    override suspend fun delete(entryId: UUID): Boolean {
+        deleted += entryId
+        return true
+    }
+
+    private fun succeeds(entry: FoodEntry) = writeSucceeds && entry.id !in failFor
+}


### PR DESCRIPTION
Rebased and bot-review fixes for #204 (original feature by @Claeshs).

**Supersedes:** #204 — push to `Claeshs/fud-ai:fix/nutrition-health-connect-retry` was blocked by GitHub App workflow permissions; this branch carries the same intent on current `main`.

## Changes vs original #204

- Rebased onto current `main` (conflicts resolved in `PreferencesStore`, `HealthConnectManager`, `FoodRepository`, `FudAIApp`).
- **Greptile P1:** Mutex-serialize `syncAll` / `retryPending` / `forget`; `deleteEntry` calls `forget` before local removal; post-write re-check + HC rollback if entry was deleted mid-flight.
- **CodeRabbit:** Enqueue pending nutrition IDs **before** Health Connect writes.
- **CodeRabbit:** `syncAll` holds the same mutex as `retryPending` via locked helpers.
- **Tests:** 12 unit tests in `NutritionHealthRetryTest` (enqueue-before-write, delete-vs-retry rollback, latest-entry snapshot).

## Original PR description

See #204 for full context, device testing notes, and deliberate out-of-scope items.

Co-authored-by: Claeshs <chs@jv.dk>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Health Connect nutrition syncing by retrying writes that were not confirmed.
  - Prevented temporary permission-check failures from silently discarding nutrition updates.
  - Cleared pending sync items when permissions are revoked or entries are deleted.
  - Improved handling of updates, imports, and partially failed batch synchronizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds durable retry tracking for nutrition writes that Health Connect did not confirm and drains that queue during foreground synchronization.

- Persists pending nutrition record IDs in `PreferencesStore`.
- Adds mutex-serialized nutrition synchronization, retry, forgetting, and post-write rollback behavior.
- Distinguishes unavailable permission probes from confirmed permission denial.
- Routes food additions, updates, and imports through the retry coordinator.
- Adds unit coverage for queue timing, retries, batches, deletion races, and current-entry snapshots.
- One synchronization-off race can leave a Health Connect nutrition record behind and should be corrected before merge.

<h3>Confidence Score: 4/5</h3>

This PR should not merge until the sync-disabled update path is serialized with active retries so a completed upsert cannot recreate a record after deletion.

The retry mechanism is otherwise well-contained and tested, but `updateEntry` deletes directly from Health Connect before waiting on the retry mutex; an active retry can consequently write afterward and clear its queue entry without rollback.

**Files Needing Attention:** android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FoodRepository.kt; android/app/src/main/java/com/apoorvdarshan/calorietracker/data/NutritionHealthRetry.kt

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/src/main/java/com/apoorvdarshan/calorietracker/data/NutritionHealthRetry.kt | Introduces the serialized persistent retry coordinator; behavior is generally coherent, but its update contract incorrectly describes delete-then-write semantics. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FoodRepository.kt | Integrates nutrition retries into food mutations, but the sync-disabled update path orders remote deletion before mutex-protected forgetting and can race an active retry. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/data/PreferencesStore.kt | Adds persistent encoding and flows for pending nutrition Health Connect write IDs. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/services/health/HealthConnectManager.kt | Preserves permission-probe failure as an unknown write gate while retaining fail-closed behavior for reads. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/FudAIApp.kt | Drains pending nutrition writes during foreground synchronization before read-capability early returns. |
| android/app/src/test/java/com/apoorvdarshan/calorietracker/data/NutritionHealthRetryTest.kt | Covers queueing, retries, gate states, batches, snapshots, and rollback, but not the repository-level sync-disabled update race. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Repo as FoodRepository
    participant Retry as NutritionHealthRetry
    participant Store as PreferencesStore
    participant HC as Health Connect

    Repo->>Store: Persist food entry
    Repo->>Retry: sync(entry)
    Retry->>Store: Enqueue entry ID
    Retry->>HC: Versioned upsert
    alt Write confirmed
        Retry->>Store: Remove pending ID
    else Write unconfirmed
        Retry->>Store: Keep pending ID
    end

    Note over Retry,HC: Next foreground
    Retry->>Store: Read pending IDs
    Retry->>HC: Retry versioned upsert
    alt Entry still exists and write succeeds
        Retry->>Store: Remove pending ID
    else Entry was forgotten or deleted
        Retry->>HC: Roll back completed write
    end
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20apoorvdarshan%2Ffud-ai%20PR%20%23272%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=272&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fdata%2FFoodRepository.kt%3A109-110%0A**Retry%20can%20restore%20deleted%20record**%0A%0AWhen%20Health%20Connect%20is%20switched%20off%20during%20an%20active%20retry%2C%20this%20branch%20deletes%20the%20remote%20record%20before%20%60forget%60%20acquires%20the%20retry%20mutex.%20The%20retry%20can%20finish%20its%20upsert%20after%20that%20deletion%2C%20see%20the%20ID%20as%20still%20pending%2C%20and%20clear%20the%20queue%20without%20rolling%20back%20the%20write.%20This%20leaves%20a%20Health%20Connect%20record%20behind%20even%20though%20synchronization%20is%20disabled.%20Forget%20the%20pending%20ID%20before%20deleting%20the%20record%2C%20as%20%60deleteEntry%60%20already%20does.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20healthRetry.forget%28entry.id%29%0A%20%20%20%20%20%20%20%20%20%20%20%20health%3F.deleteNutrition%28entry.id%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fdata%2FNutritionHealthRetry.kt%3A19-23%0A**Update%20contract%20contradicts%20implementation**%0A%0AThis%20contract%20says%20updates%20delete%20and%20then%20rewrite%20a%20record%2C%20but%20the%20production%20adapter%20calls%20%60HealthConnectManager.updateNutrition%60%2C%20which%20performs%20a%20versioned%20upsert%20without%20deleting%20first.%20The%20mismatch%20gives%20maintainers%20the%20wrong%20model%20of%20the%20operation's%20failure%20and%20atomicity%20behavior%20and%20could%20encourage%20a%20future%20implementation%20to%20introduce%20a%20destructive%20delete%2Fwrite%20window.%20Please%20document%20the%20stable-ID%20versioned%20upsert%20that%20the%20retry%20logic%20actually%20requires.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F**%0A%20%20%20%20%20*%20Versioned%20upsert%20on%20the%20entry's%20stable%20clientRecordId.%20Used%20for%20every%20retry%2C%20so%20a%0A%20%20%20%20%20*%20second%20attempt%20updates%20a%20record%20that%20did%20land%20after%20all%20instead%20of%20duplicating%20it.%0A%20%20%20%20%20*%2F%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=272&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22apoorvdarshan%2Ffud-ai%22%20on%20the%20existing%20branch%20%22fix%2F204-nutrition-health-connect-retry%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F204-nutrition-health-connect-retry%22.%0A%0A%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fdata%2FFoodRepository.kt%3A109-110%0A**Retry%20can%20restore%20deleted%20record**%0A%0AWhen%20Health%20Connect%20is%20switched%20off%20during%20an%20active%20retry%2C%20this%20branch%20deletes%20the%20remote%20record%20before%20%60forget%60%20acquires%20the%20retry%20mutex.%20The%20retry%20can%20finish%20its%20upsert%20after%20that%20deletion%2C%20see%20the%20ID%20as%20still%20pending%2C%20and%20clear%20the%20queue%20without%20rolling%20back%20the%20write.%20This%20leaves%20a%20Health%20Connect%20record%20behind%20even%20though%20synchronization%20is%20disabled.%20Forget%20the%20pending%20ID%20before%20deleting%20the%20record%2C%20as%20%60deleteEntry%60%20already%20does.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20healthRetry.forget%28entry.id%29%0A%20%20%20%20%20%20%20%20%20%20%20%20health%3F.deleteNutrition%28entry.id%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fdata%2FNutritionHealthRetry.kt%3A19-23%0A**Update%20contract%20contradicts%20implementation**%0A%0AThis%20contract%20says%20updates%20delete%20and%20then%20rewrite%20a%20record%2C%20but%20the%20production%20adapter%20calls%20%60HealthConnectManager.updateNutrition%60%2C%20which%20performs%20a%20versioned%20upsert%20without%20deleting%20first.%20The%20mismatch%20gives%20maintainers%20the%20wrong%20model%20of%20the%20operation's%20failure%20and%20atomicity%20behavior%20and%20could%20encourage%20a%20future%20implementation%20to%20introduce%20a%20destructive%20delete%2Fwrite%20window.%20Please%20document%20the%20stable-ID%20versioned%20upsert%20that%20the%20retry%20logic%20actually%20requires.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F**%0A%20%20%20%20%20*%20Versioned%20upsert%20on%20the%20entry's%20stable%20clientRecordId.%20Used%20for%20every%20retry%2C%20so%20a%0A%20%20%20%20%20*%20second%20attempt%20updates%20a%20record%20that%20did%20land%20after%20all%20instead%20of%20duplicating%20it.%0A%20%20%20%20%20*%2F%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=272&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fdata%2FFoodRepository.kt%3A109-110%0A**Retry%20can%20restore%20deleted%20record**%0A%0AWhen%20Health%20Connect%20is%20switched%20off%20during%20an%20active%20retry%2C%20this%20branch%20deletes%20the%20remote%20record%20before%20%60forget%60%20acquires%20the%20retry%20mutex.%20The%20retry%20can%20finish%20its%20upsert%20after%20that%20deletion%2C%20see%20the%20ID%20as%20still%20pending%2C%20and%20clear%20the%20queue%20without%20rolling%20back%20the%20write.%20This%20leaves%20a%20Health%20Connect%20record%20behind%20even%20though%20synchronization%20is%20disabled.%20Forget%20the%20pending%20ID%20before%20deleting%20the%20record%2C%20as%20%60deleteEntry%60%20already%20does.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20healthRetry.forget%28entry.id%29%0A%20%20%20%20%20%20%20%20%20%20%20%20health%3F.deleteNutrition%28entry.id%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fdata%2FNutritionHealthRetry.kt%3A19-23%0A**Update%20contract%20contradicts%20implementation**%0A%0AThis%20contract%20says%20updates%20delete%20and%20then%20rewrite%20a%20record%2C%20but%20the%20production%20adapter%20calls%20%60HealthConnectManager.updateNutrition%60%2C%20which%20performs%20a%20versioned%20upsert%20without%20deleting%20first.%20The%20mismatch%20gives%20maintainers%20the%20wrong%20model%20of%20the%20operation's%20failure%20and%20atomicity%20behavior%20and%20could%20encourage%20a%20future%20implementation%20to%20introduce%20a%20destructive%20delete%2Fwrite%20window.%20Please%20document%20the%20stable-ID%20versioned%20upsert%20that%20the%20retry%20logic%20actually%20requires.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F**%0A%20%20%20%20%20*%20Versioned%20upsert%20on%20the%20entry's%20stable%20clientRecordId.%20Used%20for%20every%20retry%2C%20so%20a%0A%20%20%20%20%20*%20second%20attempt%20updates%20a%20record%20that%20did%20land%20after%20all%20instead%20of%20duplicating%20it.%0A%20%20%20%20%20*%2F%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=272&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FoodRepository.kt:109-110
**Retry can restore deleted record**

When Health Connect is switched off during an active retry, this branch deletes the remote record before `forget` acquires the retry mutex. The retry can finish its upsert after that deletion, see the ID as still pending, and clear the queue without rolling back the write. This leaves a Health Connect record behind even though synchronization is disabled. Forget the pending ID before deleting the record, as `deleteEntry` already does.

```suggestion
            healthRetry.forget(entry.id)
            health?.deleteNutrition(entry.id)
```

### Issue 2
android/app/src/main/java/com/apoorvdarshan/calorietracker/data/NutritionHealthRetry.kt:19-23
**Update contract contradicts implementation**

This contract says updates delete and then rewrite a record, but the production adapter calls `HealthConnectManager.updateNutrition`, which performs a versioned upsert without deleting first. The mismatch gives maintainers the wrong model of the operation's failure and atomicity behavior and could encourage a future implementation to introduce a destructive delete/write window. Please document the stable-ID versioned upsert that the retry logic actually requires.

```suggestion
    /**
     * Versioned upsert on the entry's stable clientRecordId. Used for every retry, so a
     * second attempt updates a record that did land after all instead of duplicating it.
     */
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Retry nutrition writes Health Connect ne..."](https://github.com/apoorvdarshan/fud-ai/commit/ae09556837d4a14dc73b82d287c9f1bead0900b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63354619)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->