### PR TITLE
Credit Claeshs for Health Connect nutrition retry (#272)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,10 @@ PRs, bug reports, and feature ideas for any of these are welcome.
 
 Ukrainian (Android + iOS) was contributed by [Oleksandr Belei](https://github.com/oleksandr-belei) (#184 → #270).
 
+## Health Connect
+
+Android Health Connect nutrition write retries (queue + foreground drain for unconfirmed food sync) were contributed by [Claeshs](https://github.com/Claeshs) (#204 → #272).
+
 ## Getting Started (iOS)
 
 1. Fork the repo


### PR DESCRIPTION
## Summary
- Credits [@Claeshs](https://github.com/Claeshs) as author of the Health Connect nutrition write-retry contribution (#204 → #272)
- Apoorv listed as co-author on the commit

## Test plan
- [ ] Confirm commit author shows Claeshs on GitHub

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a Health Connect section to the contributor guide crediting Claeshs for the Android nutrition write-retry contribution.
- Documents the queue and foreground-drain behavior.
- Links the contributor and references the original and rebased pull requests.

<h3>Confidence Score: 5/5</h3>

The documentation-only change appears safe to merge.

The attribution and technical description agree with the relevant commit history and implementation, and no actionable issues were identified.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| CONTRIBUTING.md | Adds an accurate contributor attribution for the Health Connect nutrition retry implementation. |

<sub>Reviews (1): Last reviewed commit: ["Credit Claeshs for Health Connect nutrit..."](https://github.com/apoorvdarshan/fud-ai/commit/ef172929c71d2f5dd3b84a44a6dfb797b24b6c7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63361087)</sub>

<!-- /greptile_comment -->