### PR TITLE
Wire hosted AI app secret for production worker

### DIFF
--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/FudAIApp.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/FudAIApp.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import com.apoorvdarshan.calorietracker.data.BodyFatRepository
 import com.apoorvdarshan.calorietracker.data.BodyMeasurementRepository
 import com.apoorvdarshan.calorietracker.data.ChatRepository
+import com.apoorvdarshan.calorietracker.data.ExerciseRepository
 import com.apoorvdarshan.calorietracker.data.FoodRepository
 import com.apoorvdarshan.calorietracker.data.FastingRepository
 import com.apoorvdarshan.calorietracker.data.KeyStore
@@ -65,6 +66,8 @@ class FudAIApp : Application() {
         container.notifications.createChannels()
         WidgetRefreshScheduler.onAppStarted(this)
         container.widgetSnapshotWriter.observe().launchIn(appScope)
+        // Warm exercise catalog off the main thread before the first Workouts tab open.
+        ExerciseRepository.warm(this)
         appScope.launch {
             container.prefs.reconcileLocalModelSelections()
             container.prefs.migrateAIModelSelections()

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/ExerciseRepository.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/ExerciseRepository.kt
@@ -1,9 +1,13 @@
 package com.apoorvdarshan.calorietracker.data
 
 import android.content.Context
+import android.os.SystemClock
+import android.util.Log
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import java.io.InputStreamReader
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Loads the bundled free-exercise-db dataset from assets and exposes filtering /
@@ -99,8 +103,33 @@ class ExerciseRepository private constructor(
     }
 
     companion object {
+        private const val TAG = "ExerciseRepository"
+
         @Volatile
         private var instance: ExerciseRepository? = null
+        private val warming = AtomicBoolean(false)
+        private val warmExecutor = Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "exercise-repo-warm").apply { isDaemon = true }
+        }
+
+        /** Already-loaded singleton, or null if [get]/[warm] has not finished yet. */
+        fun peek(): ExerciseRepository? = instance
+
+        /**
+         * Parses catalog + visual manifest on a background thread so the first Workouts
+         * tab open is not blocked by I/O. Safe to call repeatedly.
+         */
+        fun warm(context: Context) {
+            if (instance != null || !warming.compareAndSet(false, true)) return
+            val app = context.applicationContext
+            warmExecutor.execute {
+                try {
+                    get(app)
+                } finally {
+                    warming.set(false)
+                }
+            }
+        }
 
         fun get(context: Context): ExerciseRepository =
             instance ?: synchronized(this) {
@@ -108,37 +137,48 @@ class ExerciseRepository private constructor(
             }
 
         private fun load(context: Context): ExerciseRepository {
-            val items = try {
-                context.assets.open("exercises.json").use { stream ->
-                    InputStreamReader(stream, Charsets.UTF_8).use { reader ->
-                        val type = object : TypeToken<List<ExerciseRecord>>() {}.type
-                        val records: List<ExerciseRecord> = Gson().fromJson(reader, type) ?: emptyList()
-                        val mapped = records.mapNotNull { ExerciseItem.from(it) }
-                            .sortedWith { a, b -> a.name.compareTo(b.name, ignoreCase = true) }
-                        android.util.Log.d("ExerciseRepository", "parsed=${records.size} mapped=${mapped.size}")
-                        mapped
-                    }
+            val startedAt = SystemClock.elapsedRealtime()
+            val items = loadExercises(context)
+            // Never AssetManager.list("") here — ~7k flat PNGs make list() stall for seconds.
+            // Packaging audits (ExerciseVisualResolverTest + sync script) enforce completeness.
+            val authoredFrames = loadAuthoredFrames(context)
+            Log.d(
+                TAG,
+                "load complete exercises=${items.size} visuals=${authoredFrames.size} " +
+                    "ms=${SystemClock.elapsedRealtime() - startedAt}"
+            )
+            return ExerciseRepository(items, authoredFrames)
+        }
+
+        private fun loadExercises(context: Context): List<ExerciseItem> = try {
+            context.assets.open("exercises.json").use { stream ->
+                InputStreamReader(stream, Charsets.UTF_8).use { reader ->
+                    val type = object : TypeToken<List<ExerciseRecord>>() {}.type
+                    val records: List<ExerciseRecord> = Gson().fromJson(reader, type) ?: emptyList()
+                    val mapped = records.mapNotNull { ExerciseItem.from(it) }
+                        .sortedWith { a, b -> a.name.compareTo(b.name, ignoreCase = true) }
+                    Log.d(TAG, "parsed=${records.size} mapped=${mapped.size}")
+                    mapped
                 }
-            } catch (t: Throwable) {
-                // Never swallow this silently again — an empty Workouts library
-                // shipped to production because this catch left no trace.
-                android.util.Log.e("ExerciseRepository", "failed to load exercises.json", t)
-                emptyList()
             }
-            val assetNames = runCatching { context.assets.list("")?.toSet().orEmpty() }
-                .onFailure { android.util.Log.e("ExerciseRepository", "failed to list exercise assets", it) }
-                .getOrDefault(emptySet())
-            val manifestJSON = runCatching {
+        } catch (t: Throwable) {
+            // Never swallow this silently — an empty Workouts library shipped once
+            // because this catch left no trace.
+            Log.e(TAG, "failed to load exercises.json", t)
+            emptyList()
+        }
+
+        private fun loadAuthoredFrames(context: Context): Map<String, GenderedExerciseFrames> {
+            val json = runCatching {
                 context.assets.open(ExerciseVisualResolver.MANIFEST_ASSET_NAME)
                     .bufferedReader(Charsets.UTF_8)
                     .use { it.readText() }
             }
-                .onFailure { android.util.Log.e("ExerciseRepository", "failed to load exercise visual manifest", it) }
+                .onFailure { Log.e(TAG, "failed to load exercise visual manifest", it) }
                 .getOrNull()
-            val authoredFrames = manifestJSON
-                ?.let { ExerciseVisualResolver.parseManifest(it, packagedAssetNames = assetNames) }
-                .orEmpty()
-            return ExerciseRepository(items, authoredFrames)
+                ?: return emptyMap()
+            // packagedAssetNames=null: skip AssetManager.list; trust the packaging manifest.
+            return ExerciseVisualResolver.parseManifest(json)
         }
 
         /** Asset URI for a bundled exercise image filename (Coil-loadable). */

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/ExerciseVisuals.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/ExerciseVisuals.kt
@@ -64,9 +64,9 @@ internal object ExerciseVisualResolver {
     )
 
     /**
-     * Parses the shared packaging manifest and exposes only atomic male/female sets with 3–5
-     * contiguous frames. When [packagedAssetNames] is supplied, every referenced asset must also
-     * exist in the APK asset root; a partial package therefore falls back to the existing JPEGs.
+     * Parses the shared packaging manifest into atomic male/female sets (3–5 contiguous frames).
+     * When [packagedAssetNames] is set (unit tests / packaging audits), every referenced file
+     * must exist. Runtime passes null so we never AssetManager.list the ~7k-frame asset root.
      */
     fun parseManifest(
         json: String,
@@ -79,45 +79,53 @@ internal object ExerciseVisualResolver {
 
         val entries = mutableMapOf<String, GenderedExerciseFrames>()
         val duplicateIDs = mutableSetOf<String>()
-        document.exercises.orEmpty().forEach { record ->
-            val exerciseID = record.exerciseId?.takeIf { it.isNotBlank() } ?: return@forEach
-            val frameCount = record.frameCount?.takeIf { it in 3..5 } ?: return@forEach
-            val representative = record.representativeFrameIndex
-                ?.takeIf { it in 0 until frameCount }
-                ?: return@forEach
-            val format = when (record.format?.lowercase()) {
-                null, "svg" -> ExerciseVisualFormat.SVG
-                "png" -> ExerciseVisualFormat.PNG
-                else -> return@forEach
-            }
-            val extension = format.name.lowercase()
-            val maleNames = record.maleFrames
-                ?.takeIf { validFrameNames(it, exerciseID, "male", frameCount) }
-                ?: return@forEach
-            val femaleNames = record.femaleFrames
-                ?.takeIf { validFrameNames(it, exerciseID, "female", frameCount) }
-                ?: return@forEach
-            val malePaths = maleNames.map { "$it.$extension" }
-            val femalePaths = femaleNames.map { "$it.$extension" }
-            if (packagedAssetNames != null &&
-                !(malePaths + femalePaths).all(packagedAssetNames::contains)
-            ) {
-                return@forEach
-            }
-
+        for (record in document.exercises.orEmpty()) {
+            val frames = parseRecord(record, packagedAssetNames) ?: continue
+            val (exerciseID, gendered) = frames
             if (entries.containsKey(exerciseID)) {
                 duplicateIDs += exerciseID
             } else {
-                entries[exerciseID] = GenderedExerciseFrames(
-                    male = malePaths,
-                    female = femalePaths,
-                    format = format,
-                    representativeFrameIndex = representative
-                )
+                entries[exerciseID] = gendered
             }
         }
         duplicateIDs.forEach { entries.remove(it) }
         return entries
+    }
+
+    private fun parseRecord(
+        record: ManifestRecord,
+        packagedAssetNames: Collection<String>?
+    ): Pair<String, GenderedExerciseFrames>? {
+        val exerciseID = record.exerciseId?.takeIf { it.isNotBlank() } ?: return null
+        val frameCount = record.frameCount?.takeIf { it in 3..5 } ?: return null
+        val representative = record.representativeFrameIndex
+            ?.takeIf { it in 0 until frameCount }
+            ?: return null
+        val format = when (record.format?.lowercase()) {
+            null, "svg" -> ExerciseVisualFormat.SVG
+            "png" -> ExerciseVisualFormat.PNG
+            else -> return null
+        }
+        val extension = format.name.lowercase()
+        val maleNames = record.maleFrames
+            ?.takeIf { validFrameNames(it, exerciseID, "male", frameCount) }
+            ?: return null
+        val femaleNames = record.femaleFrames
+            ?.takeIf { validFrameNames(it, exerciseID, "female", frameCount) }
+            ?: return null
+        val malePaths = maleNames.map { "$it.$extension" }
+        val femalePaths = femaleNames.map { "$it.$extension" }
+        if (packagedAssetNames != null &&
+            !(malePaths + femalePaths).all(packagedAssetNames::contains)
+        ) {
+            return null
+        }
+        return exerciseID to GenderedExerciseFrames(
+            male = malePaths,
+            female = femalePaths,
+            format = format,
+            representativeFrameIndex = representative
+        )
     }
 
     private fun validFrameNames(
@@ -140,18 +148,16 @@ internal object ExerciseVisualResolver {
         gender: Gender,
         authoredFrames: Map<String, GenderedExerciseFrames>
     ): ExerciseVisual {
-        val visualKey = resolveVisualKey(item, authoredFrames)
-        val authoredSet = authoredFrames[visualKey]
-        val frames = authoredSet?.forGender(gender)
-        return if (frames.isNullOrEmpty()) {
-            ExerciseVisual.jpeg(item.imagePaths)
-        } else {
-            ExerciseVisual(
-                framePaths = frames,
-                format = authoredSet.format,
-                representativeFrameIndex = authoredSet.representativeFrameIndex
-            )
+        val authoredSet = authoredFrames[resolveVisualKey(item, authoredFrames)]
+        val frames = authoredSet?.forGender(gender).orEmpty()
+        if (authoredSet == null || frames.isEmpty()) {
+            return ExerciseVisual.jpeg(item.imagePaths)
         }
+        return ExerciseVisual(
+            framePaths = frames,
+            format = authoredSet.format,
+            representativeFrameIndex = authoredSet.representativeFrameIndex
+        )
     }
 
     private fun resolveVisualKey(

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/AnimatedExerciseImage.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/AnimatedExerciseImage.kt
@@ -1,5 +1,6 @@
 package com.apoorvdarshan.calorietracker.ui.workouts
 
+import android.content.Context
 import android.provider.Settings
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -14,13 +15,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ColorMatrix
@@ -31,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import coil.decode.SvgDecoder
+import coil.imageLoader
 import coil.request.ImageRequest
 import com.apoorvdarshan.calorietracker.data.ExerciseRepository
 import com.apoorvdarshan.calorietracker.data.ExerciseVisual
@@ -40,10 +40,11 @@ import com.apoorvdarshan.calorietracker.services.FoodImageStore
 import kotlinx.coroutines.delay
 
 /**
- * Cycling exercise visual — the Android analog of the iOS `AnimatedExerciseVisual`.
- * Legacy JPEGs keep their cropped, muted treatment; authored SVG/PNG sequences render
- * uncropped and in their original colors. Honors the system "remove animations" setting
- * and shows a meaningful representative frame instead of freezing at the standing pose.
+ * Cycling exercise visual — Android analog of iOS `AnimatedExerciseVisual`.
+ * Legacy JPEGs stay cropped/muted; authored SVG/PNG sequences render uncropped
+ * in original colors. Honors system "remove animations" and freezes on the
+ * representative frame. Composes only the visible frame (optional next-frame
+ * Coil prefetch) so list rows do not decode every PNG up front.
  */
 private val ExerciseImageFilter: ColorFilter = run {
     val saturation = ColorMatrix().apply { setToSaturation(0.19f) }
@@ -73,29 +74,12 @@ fun AnimatedExerciseImage(
     val imagePaths = visual.framePaths
 
     if (imagePaths.isEmpty()) {
-        Box(
-            modifier.background(
-                Brush.linearGradient(listOf(colors.panel, colors.card, colors.accent.copy(alpha = 0.12f)))
-            ),
-            contentAlignment = Alignment.Center
-        ) {
-            Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                Icon(Icons.Filled.FitnessCenter, null, tint = colors.charcoal, modifier = Modifier.size(36.dp))
-                if (!fallbackLabel.isNullOrBlank()) {
-                    Text(
-                        fallbackLabel.uppercase(),
-                        color = colors.charcoal,
-                        fontSize = 12.sp,
-                        fontWeight = FontWeight.Bold,
-                        letterSpacing = 1.2.sp
-                    )
-                }
-            }
-        }
+        ExerciseImagePlaceholder(modifier, colors, fallbackLabel)
         return
     }
 
     val context = LocalContext.current
+    val imageStore = remember(context) { FoodImageStore(context) }
     val animationsEnabled = remember {
         Settings.Global.getFloat(context.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1f) != 0f
     }
@@ -110,43 +94,79 @@ fun AnimatedExerciseImage(
             index = representativeIndex
             return@LaunchedEffect
         }
-        if (imagePaths.size > 1) {
-            while (true) {
-                delay(850)
-                index = (index + 1) % imagePaths.size
-            }
+        if (imagePaths.size <= 1) return@LaunchedEffect
+        while (true) {
+            delay(850)
+            index = (index + 1) % imagePaths.size
         }
     }
 
+    val visiblePath = imagePaths[index]
+    val prefetchPath = imagePaths
+        .takeIf { shouldAnimate && it.size > 1 }
+        ?.let { it[(index + 1) % it.size] }
+
+    LaunchedEffect(prefetchPath, visual.format) {
+        val path = prefetchPath ?: return@LaunchedEffect
+        context.imageLoader.enqueue(exerciseImageRequest(context, imageStore, path, visual.format))
+    }
+
+    val isJpeg = visual.format == ExerciseVisualFormat.JPEG
     Box(modifier.background(colors.background)) {
-        imagePaths.forEachIndexed { i, path ->
-            key(path, visual.format) {
-                val model = remember(path, visual.format) {
-                    val localFile = if (UserExercise.isUserPhotoFilename(path)) {
-                        FoodImageStore(context).file(path).takeIf { it.isFile }
-                    } else {
-                        null
-                    }
-                    val dataSource = localFile ?: ExerciseRepository.imageAssetUri(path)
-                    if (visual.format == ExerciseVisualFormat.SVG) {
-                        ImageRequest.Builder(context)
-                            .data(dataSource)
-                            .decoderFactory(SvgDecoder.Factory())
-                            .build()
-                    } else {
-                        dataSource
-                    }
-                }
-                AsyncImage(
-                    model = model,
-                    contentDescription = null,
-                    contentScale = if (visual.format == ExerciseVisualFormat.JPEG) contentScale else ContentScale.Fit,
-                    colorFilter = if (visual.format == ExerciseVisualFormat.JPEG) ExerciseImageFilter else null,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .alpha(if (i == index) 1f else 0f)
+        AsyncImage(
+            model = remember(visiblePath, visual.format) {
+                exerciseImageRequest(context, imageStore, visiblePath, visual.format)
+            },
+            contentDescription = null,
+            contentScale = if (isJpeg) contentScale else ContentScale.Fit,
+            colorFilter = if (isJpeg) ExerciseImageFilter else null,
+            modifier = Modifier.fillMaxSize()
+        )
+    }
+}
+
+@Composable
+private fun ExerciseImagePlaceholder(
+    modifier: Modifier,
+    colors: WorkoutsColors,
+    fallbackLabel: String?
+) {
+    Box(
+        modifier.background(
+            Brush.linearGradient(listOf(colors.panel, colors.card, colors.accent.copy(alpha = 0.12f)))
+        ),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Icon(Icons.Filled.FitnessCenter, null, tint = colors.charcoal, modifier = Modifier.size(36.dp))
+            if (!fallbackLabel.isNullOrBlank()) {
+                Text(
+                    fallbackLabel.uppercase(),
+                    color = colors.charcoal,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Bold,
+                    letterSpacing = 1.2.sp
                 )
             }
         }
     }
+}
+
+private fun exerciseImageRequest(
+    context: Context,
+    imageStore: FoodImageStore,
+    path: String,
+    format: ExerciseVisualFormat
+): ImageRequest {
+    val localFile = path
+        .takeIf { UserExercise.isUserPhotoFilename(it) }
+        ?.let { imageStore.file(it).takeIf { file -> file.isFile } }
+    val builder = ImageRequest.Builder(context)
+        .data(localFile ?: ExerciseRepository.imageAssetUri(path))
+        .memoryCacheKey(path)
+        .diskCacheKey(path)
+    if (format == ExerciseVisualFormat.SVG) {
+        builder.decoderFactory(SvgDecoder.Factory())
+    }
+    return builder.build()
 }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutsScreen.kt
@@ -46,11 +46,11 @@ import androidx.compose.material.icons.filled.SwapVert
 import androidx.compose.material.icons.filled.Tag
 import androidx.compose.material.icons.filled.SportsGymnastics
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -63,6 +63,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
@@ -77,30 +78,45 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.graphics.ColorFilter
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import com.apoorvdarshan.calorietracker.AppContainer
 import com.apoorvdarshan.calorietracker.R
+import com.apoorvdarshan.calorietracker.data.ExerciseItem
+import com.apoorvdarshan.calorietracker.data.ExerciseRepository
+import com.apoorvdarshan.calorietracker.data.ExerciseSort
+import com.apoorvdarshan.calorietracker.data.ExerciseVisual
 import com.apoorvdarshan.calorietracker.models.WorkoutTabMode
 import com.apoorvdarshan.calorietracker.models.WorkoutWeightUnit
 import com.apoorvdarshan.calorietracker.ui.components.FudGlassSurface
 import com.apoorvdarshan.calorietracker.ui.navigation.BottomNavScrollPadding
 import com.apoorvdarshan.calorietracker.ui.theme.AppColors
-import com.apoorvdarshan.calorietracker.ui.workouts.AnimatedExerciseImage
-import com.apoorvdarshan.calorietracker.data.ExerciseItem
-import com.apoorvdarshan.calorietracker.data.ExerciseRepository
-import com.apoorvdarshan.calorietracker.data.ExerciseSort
-import com.apoorvdarshan.calorietracker.data.ExerciseVisual
-import com.apoorvdarshan.calorietracker.ui.workouts.WorkoutsViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 @Composable
 fun WorkoutsScreen(container: AppContainer, modifier: Modifier = Modifier) {
     val context = LocalContext.current
-    val baseRepository = remember { ExerciseRepository.get(context) }
+    var catalog by remember { mutableStateOf(ExerciseRepository.peek()) }
+    LaunchedEffect(Unit) {
+        catalog = catalog ?: withContext(Dispatchers.IO) { ExerciseRepository.get(context) }
+    }
+    val loadedCatalog = catalog
+    if (loadedCatalog == null) {
+        Box(
+            modifier
+                .fillMaxSize()
+                .background(workoutsColors().background)
+                .statusBarsPadding(),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator(color = AppColors.Calorie, modifier = Modifier.size(36.dp))
+        }
+        return
+    }
     val workoutState by container.workoutRepository.state.collectAsState(initial = com.apoorvdarshan.calorietracker.models.WorkoutPersistedState())
-    val repo = remember(baseRepository, workoutState.customActivities, workoutState.userExercises) {
-        baseRepository.includingActivities(workoutState.customActivities + workoutState.userExercises)
+    val repo = remember(loadedCatalog, workoutState.customActivities, workoutState.userExercises) {
+        loadedCatalog.includingActivities(workoutState.customActivities + workoutState.userExercises)
     }
     var showCreateUserExercise by remember { mutableStateOf(false) }
     var editingUserExerciseId by remember { mutableStateOf<String?>(null) }
@@ -127,7 +143,7 @@ fun WorkoutsScreen(container: AppContainer, modifier: Modifier = Modifier) {
     UserExerciseEditorSheet(
         visible = showCreateUserExercise || editingUserExerciseId != null,
         existingItemId = editingUserExerciseId,
-        catalog = baseRepository,
+        catalog = loadedCatalog,
         workoutRepository = container.workoutRepository,
         imageStore = container.imageStore,
         existingTemplate = editingUserExerciseId?.let { id ->

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutsViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutsViewModel.kt
@@ -26,10 +26,12 @@ import com.apoorvdarshan.calorietracker.models.OutdoorActivitySettings
 import com.apoorvdarshan.calorietracker.models.WorkoutWeightUnit
 import com.apoorvdarshan.calorietracker.services.FoodImageStore
 import com.apoorvdarshan.calorietracker.ui.home.OutdoorActivityKind
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import java.util.UUID
 
@@ -79,7 +81,8 @@ data class WorkoutDiaryUiState(
  */
 class WorkoutsViewModel(app: Application) : AndroidViewModel(app) {
     private val prefs = app.getSharedPreferences("fudai_workouts", Context.MODE_PRIVATE)
-    private val exerciseRepository = ExerciseRepository.get(app)
+    /** Peek only in the ctor — never call [ExerciseRepository.get] on the main thread. */
+    private var exerciseRepository: ExerciseRepository? = ExerciseRepository.peek()
     private var workoutRepository: WorkoutRepository? = null
     private var exerciseImageStore: FoodImageStore? = null
     private var repositoryJob: Job? = null
@@ -92,6 +95,22 @@ class WorkoutsViewModel(app: Application) : AndroidViewModel(app) {
 
     var diaryUiState by mutableStateOf(WorkoutDiaryUiState())
         private set
+
+    init {
+        if (exerciseRepository == null) {
+            viewModelScope.launch {
+                ensureExerciseRepository()
+                rebuildDiaryState()
+            }
+        }
+    }
+
+    private suspend fun ensureExerciseRepository(): ExerciseRepository {
+        exerciseRepository?.let { return it }
+        return withContext(Dispatchers.IO) {
+            ExerciseRepository.get(getApplication()).also { exerciseRepository = it }
+        }
+    }
 
     private val _searchInput = mutableStateOf(prefs.getString(K_SEARCH, "") ?: "")
     private val _debouncedSearch = mutableStateOf(_searchInput.value)
@@ -349,7 +368,8 @@ class WorkoutsViewModel(app: Application) : AndroidViewModel(app) {
                 OutdoorActivityKind.WALKING -> OutdoorActivitySettings.WALKING_EXERCISE_ID
                 OutdoorActivityKind.RUNNING -> OutdoorActivitySettings.RUNNING_EXERCISE_ID
             }
-            val item = exerciseRepository.exercises.firstOrNull { it.id == exerciseId } ?: return@launch
+            val catalog = ensureExerciseRepository()
+            val item = catalog.exercises.firstOrNull { it.id == exerciseId } ?: return@launch
             repository.logQuickCardio(item, minutes, date)
             repository.calculateBurn(
                 date = date,
@@ -435,11 +455,14 @@ class WorkoutsViewModel(app: Application) : AndroidViewModel(app) {
             }
             .toList()
         val preferences = latestPersistedState.preferences
-        val splitGroups = WorkoutSplitGroup.selectionGroups(
-            split = preferences.split,
-            availablePrimaryMuscles = exerciseRepository.availablePrimaryMuscles,
-            availableSecondaryMuscles = exerciseRepository.availableSecondaryMuscles
-        )
+        val catalog = exerciseRepository
+        val splitGroups = catalog?.let {
+            WorkoutSplitGroup.selectionGroups(
+                split = preferences.split,
+                availablePrimaryMuscles = it.availablePrimaryMuscles,
+                availableSecondaryMuscles = it.availableSecondaryMuscles
+            )
+        }.orEmpty()
         val storedSplit = prefs.getString(K_SPLIT_IDENTIFIER, null)
         if (storedSplit != preferences.split.name) {
             splitGroupTitles = emptySet()

--- a/ios/calorietracker/Models/HostedAIConstants.swift
+++ b/ios/calorietracker/Models/HostedAIConstants.swift
@@ -77,7 +77,7 @@ enum HostedAIConstants {
 
     /// Shared app secret — set the same value in Worker env `FUD_HOSTED_AI_APP_SECRET`.
     /// v1 client-side gating; rotate with a worker + app update together.
-    static let hostedAIAppSecret = "fud-hosted-v1-dev-placeholder"
+    static let hostedAIAppSecret = "ceFjlmDVmRQqAWB900qNv6uFahLGJekHpT1bvo1xsuM"
 
     static let maxHostedImages = 3
 }

--- a/services/hosted-ai/README.md
+++ b/services/hosted-ai/README.md
@@ -47,7 +47,7 @@ Quota (daily pool + credit bank) is enforced **on device** before each hosted ca
 
 ## Hosted limits
 
-- Model pinned to `gemini-2.0-flash-lite` (worker constant; update when Flash-Lite GA name changes)
+- Model pinned to `gemini-3.5-flash-lite` (worker constant; update when Flash-Lite GA name changes)
 - Max **3** images per hosted vision request (BYOK allows up to 10)
 - Voice food in Hosted mode = **2** actions (STT + LLM)
 

--- a/web/hosted-ai-api.ts
+++ b/web/hosted-ai-api.ts
@@ -10,7 +10,7 @@
 
 export const HOSTED_AI_API_PREFIX = "/api/hosted-ai/v1";
 
-const HOSTED_GEMINI_MODEL = "gemini-2.0-flash-lite";
+const HOSTED_GEMINI_MODEL = "gemini-3.5-flash-lite";
 const MAX_HOSTED_IMAGES = 3;
 const MAX_PROMPT_CHARS = 120_000;
 const MAX_SYSTEM_INSTRUCTION_CHARS = 32_000;


### PR DESCRIPTION
## Summary
- Match iOS `hostedAIAppSecret` to Cloudflare Worker `FUD_HOSTED_AI_APP_SECRET`

## Test plan
- [ ] Hosted generate call authenticates against fud-ai.app
- [ ] Sandbox subscribe still loads Plus/Pro offerings


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the production hosted-AI credential into the iOS client, updates the hosted Worker to Gemini 3.5 Flash-Lite, and includes Android workout-loading and exercise-image performance improvements.

- Warms the Android exercise catalog asynchronously and displays loading state until it is available.
- Reduces exercise animation composition to the visible frame with next-frame prefetching.
- Refactors exercise visual manifest parsing and workout ViewModel catalog initialization.
- Replaces the iOS hosted-AI placeholder with the Worker credential.
- Updates the hosted Gemini model and corresponding operational documentation.
- The embedded credential is not a secure authorization boundary because all additional entitlement and quota inputs remain client-controlled.

<h3>Confidence Score: 3/5</h3>

This PR is not safe to merge until hosted-AI authorization no longer depends on a shared credential extractable from the iOS application.

The shipped bearer credential, client-controlled plan header, and absence of server-side entitlement or quota verification together allow unauthorized callers to consume paid Gemini and Deepgram resources.

**Files Needing Attention:** ios/calorietracker/Models/HostedAIConstants.swift, web/hosted-ai-api.ts

<details open><summary><h3>Security Review</h3></summary>

The production hosted-AI bearer credential is embedded in the iOS application and can be extracted and reused. Since the Worker trusts client-controlled identity and plan headers without server-side entitlement or quota verification, unauthorized callers can consume paid Gemini and Deepgram resources.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ios/calorietracker/Models/HostedAIConstants.swift | Replaces the development placeholder with a production bearer credential that cannot remain secret in a distributed client. |
| web/hosted-ai-api.ts | Updates the Gemini model while retaining authentication based on the extractable shared credential and unverified client plan headers. |
| services/hosted-ai/README.md | Documents the updated model and confirms that entitlement and quota enforcement remain client-side. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/data/ExerciseRepository.kt | Adds asynchronous singleton warming and avoids expensive runtime enumeration of exercise assets. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/AnimatedExerciseImage.kt | Renders one animation frame at a time and prefetches the next through Coil. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutsScreen.kt | Loads the exercise catalog off the main thread and gates workout content behind a progress state. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/workouts/WorkoutsViewModel.kt | Avoids synchronous catalog initialization and loads the repository on an IO dispatcher when necessary. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant A as Untrusted app/client
    participant W as Hosted-AI Worker
    participant G as Gemini/Deepgram
    A->>W: Bearer embedded shared secret
    A->>W: Arbitrary user ID and plus/pro headers
    W->>W: Compare secret and validate header shape
    Note over W: No server-side entitlement or quota verification
    W->>G: Request using server API key
    G-->>W: Hosted AI response
    W-->>A: Response
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20apoorvdarshan%2Ffud-ai%20PR%20%23279%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=279&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aios%2Fcalorietracker%2FModels%2FHostedAIConstants.swift%3A80%0A**Production%20credential%20is%20extractable**%0A%0AThe%20production%20Worker%20bearer%20credential%20is%20compiled%20into%20the%20iOS%20app%20and%20sent%20with%20each%20hosted-AI%20request%2C%20so%20any%20app%20user%20can%20extract%20and%20reuse%20it.%20The%20Worker%20accepts%20that%20credential%20with%20arbitrary%20client-supplied%20user%20and%20Plus%2FPro%20headers%2C%20without%20server-side%20entitlement%20or%20quota%20checks.%20This%20lets%20an%20attacker%20impersonate%20a%20Pro%20user%20and%20make%20unmetered%20Gemini%20or%20Deepgram%20requests%20at%20the%20service%20operator's%20expense.%20Authentication%20and%20metering%20need%20to%20rely%20on%20server-verifiable%20user%20credentials%20instead%20of%20a%20shared%20mobile-app%20secret.%0A%0A**How%20this%20was%20verified%3A**%20The%20iOS%20client%20sends%20this%20constant%20as%20its%20bearer%20token%2C%20and%20the%20Worker%20authorizes%20upstream%20AI%20operations%20using%20only%20that%20token%20and%20unverified%20client-controlled%20identity%20and%20plan%20headers.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=279&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22apoorvdarshan%2Ffud-ai%22%20on%20the%20existing%20branch%20%22fix%2Fhosted-ai-app-secret%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fhosted-ai-app-secret%22.%0A%0A%23%23%23%20Issue%201%0Aios%2Fcalorietracker%2FModels%2FHostedAIConstants.swift%3A80%0A**Production%20credential%20is%20extractable**%0A%0AThe%20production%20Worker%20bearer%20credential%20is%20compiled%20into%20the%20iOS%20app%20and%20sent%20with%20each%20hosted-AI%20request%2C%20so%20any%20app%20user%20can%20extract%20and%20reuse%20it.%20The%20Worker%20accepts%20that%20credential%20with%20arbitrary%20client-supplied%20user%20and%20Plus%2FPro%20headers%2C%20without%20server-side%20entitlement%20or%20quota%20checks.%20This%20lets%20an%20attacker%20impersonate%20a%20Pro%20user%20and%20make%20unmetered%20Gemini%20or%20Deepgram%20requests%20at%20the%20service%20operator's%20expense.%20Authentication%20and%20metering%20need%20to%20rely%20on%20server-verifiable%20user%20credentials%20instead%20of%20a%20shared%20mobile-app%20secret.%0A%0A**How%20this%20was%20verified%3A**%20The%20iOS%20client%20sends%20this%20constant%20as%20its%20bearer%20token%2C%20and%20the%20Worker%20authorizes%20upstream%20AI%20operations%20using%20only%20that%20token%20and%20unverified%20client-controlled%20identity%20and%20plan%20headers.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=279&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aios%2Fcalorietracker%2FModels%2FHostedAIConstants.swift%3A80%0A**Production%20credential%20is%20extractable**%0A%0AThe%20production%20Worker%20bearer%20credential%20is%20compiled%20into%20the%20iOS%20app%20and%20sent%20with%20each%20hosted-AI%20request%2C%20so%20any%20app%20user%20can%20extract%20and%20reuse%20it.%20The%20Worker%20accepts%20that%20credential%20with%20arbitrary%20client-supplied%20user%20and%20Plus%2FPro%20headers%2C%20without%20server-side%20entitlement%20or%20quota%20checks.%20This%20lets%20an%20attacker%20impersonate%20a%20Pro%20user%20and%20make%20unmetered%20Gemini%20or%20Deepgram%20requests%20at%20the%20service%20operator's%20expense.%20Authentication%20and%20metering%20need%20to%20rely%20on%20server-verifiable%20user%20credentials%20instead%20of%20a%20shared%20mobile-app%20secret.%0A%0A**How%20this%20was%20verified%3A**%20The%20iOS%20client%20sends%20this%20constant%20as%20its%20bearer%20token%2C%20and%20the%20Worker%20authorizes%20upstream%20AI%20operations%20using%20only%20that%20token%20and%20unverified%20client-controlled%20identity%20and%20plan%20headers.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=279&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
ios/calorietracker/Models/HostedAIConstants.swift:80
**Production credential is extractable**

The production Worker bearer credential is compiled into the iOS app and sent with each hosted-AI request, so any app user can extract and reuse it. The Worker accepts that credential with arbitrary client-supplied user and Plus/Pro headers, without server-side entitlement or quota checks. This lets an attacker impersonate a Pro user and make unmetered Gemini or Deepgram requests at the service operator's expense. Authentication and metering need to rely on server-verifiable user credentials instead of a shared mobile-app secret.

**How this was verified:** The iOS client sends this constant as its bearer token, and the Worker authorizes upstream AI operations using only that token and unverified client-controlled identity and plan headers.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Switch hosted AI worker to gemini-3.5-fl..."](https://github.com/apoorvdarshan/fud-ai/commit/47796558b59570c10dc7a9bde78dc6b7a87b9d0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63402729)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Exercise content now begins loading during app startup, reducing wait times when opening workouts.
  - Workout screens display a loading indicator while exercise content is retrieved.
  - Exercise animations now show the active frame smoothly while preloading the next frame for improved performance.

- **Improvements**
  - Workout logging remains responsive while exercise data loads in the background.
  - Hosted AI requests now use the updated Flash-Lite model.

- **Documentation**
  - Updated hosted AI model information to match the current service configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->