### PR TITLE
Smooth Android meal sheets, Coach photos, and startup

### DIFF
--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/FudAIApp.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/FudAIApp.kt
@@ -74,6 +74,7 @@ class FudAIApp : Application() {
         // Older Android builds removed food rows without removing their JPEGs.
         // Prune only unreferenced files; logged foods, saved meals, and pending
         // analysis drafts remain untouched.
+        appScope.launch { container.imageStore.cleanupLegacyThumbnailDirectory() }
         appScope.launch { container.foodRepository.pruneOrphanedImages() }
         appScope.launch { container.weeklyChallengeRepository.retryPendingRemoteDeletion() }
         container.prefs.mealSchedule

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/MainActivity.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/MainActivity.kt
@@ -33,12 +33,19 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+
+private data class StartupPrefs(
+    val startOnboarding: Boolean,
+    val appearance: String,
+    val themeColorKey: String
+)
 
 open class MainActivity : ComponentActivity() {
     // Shared-meal deep link (issue #107). Non-empty -> the confirm sheet is shown over the app.
     private var pendingSharedMeals by mutableStateOf<List<FoodEntry>>(emptyList())
     private var pendingQuickAction by mutableStateOf<QuickActionRequest?>(null)
+    private var startupPrefs by mutableStateOf<StartupPrefs?>(null)
+    private var contentReady by mutableStateOf(false)
 
     /** Decode a `fudai://add-meal` link (if that's what launched us) into pending meals. */
     private fun handleShareIntent(intent: Intent?) {
@@ -104,13 +111,16 @@ open class MainActivity : ComponentActivity() {
             }
         }
 
+        val container = (application as FudAIApp).container
+
         // Support --reset-onboarding launch flag (parallel to iOS CLAUDE.md convention).
         if (intent?.getBooleanExtra("reset_onboarding", false) == true) {
-            runBlocking { (application as FudAIApp).container.prefs.setOnboardingCompleted(false) }
+            lifecycleScope.launch {
+                container.prefs.setOnboardingCompleted(false)
+            }
             intent.removeExtra("reset_onboarding")
         }
 
-        val container = (application as FudAIApp).container
         // A fudai://add-meal link may have cold-launched us.
         handleShareIntent(intent)
         handleQuickActionIntent(intent)
@@ -124,27 +134,29 @@ open class MainActivity : ComponentActivity() {
                 .collect { QuickActionShortcutManager.update(this@MainActivity, it) }
         }
 
-        val startOnboarding = runBlocking { !container.prefs.hasCompletedOnboarding.first() }
-        val initialAppearance = runBlocking { container.prefs.appearanceMode.first() }
-        val initialThemeColorKey = runBlocking { container.prefs.appThemeColor.first() }
-
-        // Hold the splash on screen until the saved profile has loaded from
-        // DataStore so Home doesn't briefly render its 2000/150/220/70 fallback
-        // goal numbers before snapping to the user's real targets. Onboarding
-        // doesn't show those numbers, so we let the splash dismiss immediately
-        // in that case.
-        var contentReady = startOnboarding
-        splashScreen.setKeepOnScreenCondition { !contentReady }
-        if (!startOnboarding) {
-            lifecycleScope.launch {
+        // Hold the splash on screen until startup prefs and (when needed) the saved
+        // profile have loaded from DataStore so Home doesn't briefly render its
+        // 2000/150/220/70 fallback goal numbers before snapping to real targets.
+        splashScreen.setKeepOnScreenCondition { startupPrefs == null || !contentReady }
+        lifecycleScope.launch {
+            val startOnboarding = !container.prefs.hasCompletedOnboarding.first()
+            startupPrefs = StartupPrefs(
+                startOnboarding = startOnboarding,
+                appearance = container.prefs.appearanceMode.first(),
+                themeColorKey = container.prefs.appThemeColor.first()
+            )
+            if (startOnboarding) {
+                contentReady = true
+            } else {
                 container.profileRepository.profile.first { it != null }
                 contentReady = true
             }
         }
 
         setContent {
-            val appearance by container.prefs.appearanceMode.collectAsState(initial = initialAppearance)
-            val themeColorKey by container.prefs.appThemeColor.collectAsState(initial = initialThemeColorKey)
+            val startup = startupPrefs ?: return@setContent
+            val appearance by container.prefs.appearanceMode.collectAsState(initial = startup.appearance)
+            val themeColorKey by container.prefs.appThemeColor.collectAsState(initial = startup.themeColorKey)
             val themeColor = AppThemeColor.fromKey(themeColorKey)
             val systemDark = isSystemInDarkTheme()
             val darkTheme = when (appearance) {
@@ -159,7 +171,7 @@ open class MainActivity : ComponentActivity() {
                 ) {
                     FudAINavHost(
                         container = container,
-                        startOnboarding = startOnboarding,
+                        startOnboarding = startup.startOnboarding,
                         quickActionRequest = pendingQuickAction,
                         onQuickActionHandled = { requestID ->
                             if (pendingQuickAction?.id == requestID) pendingQuickAction = null

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/PreferencesStore.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/PreferencesStore.kt
@@ -33,8 +33,10 @@ import com.apoorvdarshan.calorietracker.backup.CloudBackupValue
 import com.apoorvdarshan.calorietracker.models.WaterUnit
 import com.apoorvdarshan.calorietracker.models.WorkoutPersistedState
 import com.apoorvdarshan.calorietracker.ui.theme.AppThemeColor
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -984,7 +986,7 @@ class PreferencesStore(
         prefs[Keys.FOOD_ENTRIES]?.let {
             runCatching { json.decodeFromString(ListSerializer(FoodEntry.serializer()), it) }.getOrNull()
         } ?: emptyList()
-    }
+    }.flowOn(Dispatchers.Default)
 
     suspend fun setFoodEntries(entries: List<FoodEntry>) {
         ds.edit { it[Keys.FOOD_ENTRIES] = json.encodeToString(ListSerializer(FoodEntry.serializer()), entries) }
@@ -1139,7 +1141,7 @@ class PreferencesStore(
         prefs[Keys.CHAT_HISTORY]?.let {
             runCatching { json.decodeFromString(ListSerializer(ChatMessage.serializer()), it) }.getOrNull()
         } ?: emptyList()
-    }
+    }.flowOn(Dispatchers.Default)
 
     suspend fun setChatHistory(history: List<ChatMessage>) {
         ds.edit { it[Keys.CHAT_HISTORY] = json.encodeToString(ListSerializer(ChatMessage.serializer()), history) }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/FoodImageStore.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/FoodImageStore.kt
@@ -17,23 +17,22 @@ import java.util.UUID
  * the DataStore blob (which would otherwise inflate past quick-read limits).
  */
 class FoodImageStore private constructor(
-    rootDir: File,
+    private val filesRoot: File,
     cleanupLegacyThumbnails: Boolean
 ) {
-    private val dir: File = File(rootDir, DIR_NAME).apply { mkdirs() }
-    private val thumbnailDir: File = File(rootDir, THUMBNAIL_DIR_NAME).apply { mkdirs() }
+    private val dir: File = File(filesRoot, DIR_NAME).apply { mkdirs() }
+    private val thumbnailDir: File = File(filesRoot, THUMBNAIL_DIR_NAME).apply { mkdirs() }
     private val thumbnailCache = object : LruCache<String, Bitmap>(THUMBNAIL_CACHE_KB) {
         override fun sizeOf(key: String, value: Bitmap): Int = value.byteCount / 1024
     }
 
     constructor(context: Context) : this(context.filesDir, cleanupLegacyThumbnails = true)
 
-    init {
-        if (cleanupLegacyThumbnails) {
-            // Legacy thumbnails lost EXIF orientation during compression. Rebuild them
-            // lazily in the new cache directory; original photos remain byte-identical.
-            runCatching { File(rootDir, "fudai-food-thumbnails").deleteRecursively() }
-        }
+    /** One-time cleanup of the pre-v2 thumbnail cache directory. Safe to call repeatedly. */
+    fun cleanupLegacyThumbnailDirectory() {
+        // Legacy thumbnails lost EXIF orientation during compression. Rebuild them
+        // lazily in the new cache directory; original photos remain byte-identical.
+        runCatching { File(filesRoot, LEGACY_THUMBNAIL_DIR_NAME).deleteRecursively() }
     }
 
     /** Writes the bitmap as JPEG (quality 80) under a new filename. Returns filename or null. */
@@ -162,6 +161,7 @@ class FoodImageStore private constructor(
 
     companion object {
         private const val DIR_NAME = "fudai-food-images"
+        private const val LEGACY_THUMBNAIL_DIR_NAME = "fudai-food-thumbnails"
         private const val THUMBNAIL_DIR_NAME = "fudai-food-thumbnails-v2"
         private const val THUMBNAIL_MAX_DIMENSION = 320
         const val VIEWER_MAX_DIMENSION = 2048

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/coach/CoachScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/coach/CoachScreen.kt
@@ -77,6 +77,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -122,7 +123,10 @@ import com.apoorvdarshan.calorietracker.ui.navigation.BottomNavDockedControlPadd
 import com.apoorvdarshan.calorietracker.ui.theme.AppColors
 import java.io.ByteArrayOutputStream
 import java.util.Base64
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * Verbatim port of struct ChatView in
@@ -145,6 +149,7 @@ fun CoachScreen(container: AppContainer) {
     val listState = rememberLazyListState()
     var showResetConfirm by remember { mutableStateOf(false) }
     val ctx = LocalContext.current
+    val scope = rememberCoroutineScope()
     val focusManager = LocalFocusManager.current
     val keyboard = LocalSoftwareKeyboardController.current
 
@@ -168,8 +173,12 @@ fun CoachScreen(container: AppContainer) {
         ActivityResultContracts.PickVisualMedia()
     ) { uri: Uri? ->
         if (uri != null) {
-            val bytes = ctx.contentResolver.openInputStream(uri)?.use { it.readBytes() }
-            if (bytes != null) attachedImageBytes = resizedJpeg(bytes, maxDimension = 1800, quality = 86) ?: bytes
+            scope.launch {
+                val bytes = withContext(Dispatchers.IO) {
+                    ctx.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+                } ?: return@launch
+                attachedImageBytes = resizedJpeg(bytes, maxDimension = 1800, quality = 86) ?: bytes
+            }
         }
     }
 
@@ -192,12 +201,14 @@ fun CoachScreen(container: AppContainer) {
         val trimmed = (textOverride ?: input).trim()
         if (trimmed.isEmpty() && image == null) return
         if (ui.sending) return
-        val imageForAi = image?.let { resizedJpeg(it, maxDimension = 1600, quality = 78) ?: it }
-        val thumbnail = image?.let { resizedJpeg(it, maxDimension = 700, quality = 68) ?: it }
         hideKeyboard()
         input = ""
         attachedImageBytes = null
-        vm.send(trimmed, imageBytes = imageForAi, thumbnailBytes = thumbnail)
+        scope.launch {
+            val imageForAi = image?.let { resizedJpeg(it, maxDimension = 1600, quality = 78) ?: it }
+            val thumbnail = image?.let { resizedJpeg(it, maxDimension = 700, quality = 68) ?: it }
+            vm.send(trimmed, imageBytes = imageForAi, thumbnailBytes = thumbnail)
+        }
     }
 
     // Inline (WhatsApp-style) voice recorder — records with whatever STT provider
@@ -336,7 +347,9 @@ fun CoachScreen(container: AppContainer) {
         InAppCameraCaptureDialog(
             onCapture = { bytes ->
                 showCameraCapture = false
-                attachedImageBytes = resizedJpeg(bytes, maxDimension = 1800, quality = 86) ?: bytes
+                scope.launch {
+                    attachedImageBytes = resizedJpeg(bytes, maxDimension = 1800, quality = 86) ?: bytes
+                }
             },
             onDismiss = { showCameraCapture = false }
         )
@@ -704,11 +717,13 @@ private fun Bubble(content: String, isUser: Boolean, attachmentImageBase64: Stri
         }
         Column(Modifier.padding(horizontal = 16.dp, vertical = 11.dp)) {
             attachmentImageBase64?.let { encoded ->
-                val bitmap = remember(encoded) {
-                    runCatching {
-                        val bytes = Base64.getDecoder().decode(encoded)
-                        FoodImageDecoder.decode(bytes)
-                    }.getOrNull()
+                val bitmap by produceState<Bitmap?>(initialValue = null, encoded) {
+                    value = withContext(Dispatchers.IO) {
+                        runCatching {
+                            val bytes = Base64.getDecoder().decode(encoded)
+                            FoodImageDecoder.decode(bytes, COACH_BUBBLE_IMAGE_MAX_DIMENSION)
+                        }.getOrNull()
+                    }
                 }
                 if (bitmap != null) {
                     Image(
@@ -851,7 +866,11 @@ private fun InputBar(
             .padding(start = 4.dp, end = 5.dp, top = 4.dp, bottom = 4.dp),
     ) {
         attachedImageBytes?.let { bytes ->
-            val bitmap = remember(bytes) { FoodImageDecoder.decode(bytes) }
+            val bitmap by produceState<Bitmap?>(initialValue = null, bytes) {
+                value = withContext(Dispatchers.IO) {
+                    FoodImageDecoder.decode(bytes, COACH_COMPOSER_PREVIEW_MAX_DIMENSION)
+                }
+            }
             if (bitmap != null) {
                 Box(
                     modifier = Modifier
@@ -1036,13 +1055,17 @@ private fun SendButton(canSend: Boolean, onClick: () -> Unit) {
     }
 }
 
-private fun resizedJpeg(bytes: ByteArray, maxDimension: Int, quality: Int): ByteArray? {
-    val scaled = FoodImageDecoder.decode(bytes, maxDimension) ?: return null
-    return ByteArrayOutputStream().use { out ->
-        scaled.compress(Bitmap.CompressFormat.JPEG, quality.coerceIn(1, 100), out)
-        out.toByteArray()
+private suspend fun resizedJpeg(bytes: ByteArray, maxDimension: Int, quality: Int): ByteArray? =
+    withContext(Dispatchers.Default) {
+        val scaled = FoodImageDecoder.decode(bytes, maxDimension) ?: return@withContext null
+        ByteArrayOutputStream().use { out ->
+            scaled.compress(Bitmap.CompressFormat.JPEG, quality.coerceIn(1, 100), out)
+            out.toByteArray()
+        }
     }
-}
+
+private const val COACH_BUBBLE_IMAGE_MAX_DIMENSION = 700
+private const val COACH_COMPOSER_PREVIEW_MAX_DIMENSION = 280
 
 // ── Markdown rendering for Coach replies ────────────────────────────────
 // Lightweight renderer for the formatting the Coach actually emits: #/##/### headings,

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/coach/CoachScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/coach/CoachScreen.kt
@@ -725,9 +725,9 @@ private fun Bubble(content: String, isUser: Boolean, attachmentImageBase64: Stri
                         }.getOrNull()
                     }
                 }
-                if (bitmap != null) {
+                bitmap?.let { attachmentBitmap ->
                     Image(
-                        bitmap = bitmap.asImageBitmap(),
+                        bitmap = attachmentBitmap.asImageBitmap(),
                         contentDescription = null,
                         contentScale = ContentScale.Crop,
                         modifier = Modifier
@@ -866,12 +866,12 @@ private fun InputBar(
             .padding(start = 4.dp, end = 5.dp, top = 4.dp, bottom = 4.dp),
     ) {
         attachedImageBytes?.let { bytes ->
-            val bitmap by produceState<Bitmap?>(initialValue = null, bytes) {
-                value = withContext(Dispatchers.IO) {
+            val previewBitmap by produceState<Bitmap?>(initialValue = null, bytes) {
+                this.value = withContext(Dispatchers.IO) {
                     FoodImageDecoder.decode(bytes, COACH_COMPOSER_PREVIEW_MAX_DIMENSION)
                 }
             }
-            if (bitmap != null) {
+            previewBitmap?.let { attachmentBitmap ->
                 Box(
                     modifier = Modifier
                         .padding(start = 10.dp, end = 10.dp, top = 8.dp, bottom = 4.dp)
@@ -879,7 +879,7 @@ private fun InputBar(
                         .clip(RoundedCornerShape(16.dp))
                 ) {
                     Image(
-                        bitmap = bitmap.asImageBitmap(),
+                        bitmap = attachmentBitmap.asImageBitmap(),
                         contentDescription = null,
                         contentScale = ContentScale.Crop,
                         modifier = Modifier.fillMaxSize()

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/ContextNoteSheet.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/ContextNoteSheet.kt
@@ -36,9 +36,12 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -113,11 +116,15 @@ fun MultiPhotoCaptureSheet(
                 contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 20.dp)
             ) {
                 itemsIndexed(imageBytesList, key = { index, bytes -> "$index-${bytes.size}" }) { index, bytes ->
-                    val bitmap = remember(bytes) { FoodImageDecoder.decode(bytes, 720) }
+                    val bitmap by produceState<android.graphics.Bitmap?>(initialValue = null, bytes) {
+                        value = withContext(Dispatchers.IO) {
+                            FoodImageDecoder.decode(bytes, 720)
+                        }
+                    }
                     Box {
                         if (bitmap != null) {
                             androidx.compose.foundation.Image(
-                                bitmap = bitmap.asImageBitmap(),
+                                bitmap = bitmap!!.asImageBitmap(),
                                 contentDescription = "Photo ${index + 1}",
                                 contentScale = ContentScale.Crop,
                                 modifier = Modifier

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/EditFoodEntrySheet.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/EditFoodEntrySheet.kt
@@ -418,7 +418,7 @@ fun EditFoodEntrySheet(
                         return@LaunchedEffect
                     }
                     viewerBitmaps = withContext(Dispatchers.IO) {
-                        visibleFilenames.map { filename ->
+                        visibleFilenames.mapNotNull { filename ->
                             container.imageStore.loadForViewer(filename)
                                 ?: container.imageStore.loadForViewer(filename, GALLERY_MAX_DIMENSION)
                         }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/EditFoodEntrySheet.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/EditFoodEntrySheet.kt
@@ -45,10 +45,14 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -117,7 +121,8 @@ fun EditFoodEntrySheet(
     var currentBaseEntry by remember(entry) { mutableStateOf(entry) }
     // Stage removals separately so tapping × does not reset the other editor fields.
     var removedImageFilenames by remember(entry) { mutableStateOf(emptySet<String>()) }
-    var previewPhotos by remember { mutableStateOf<Pair<List<Bitmap>, Int>?>(null) }
+    var previewPhotoIndex by remember { mutableStateOf<Int?>(null) }
+    var viewerBitmaps by remember { mutableStateOf<List<Bitmap>?>(null) }
     var noteText by remember(entry) { mutableStateOf(entry.customNote ?: "") }
     var isReprocessing by remember { mutableStateOf(false) }
     var errorText by remember { mutableStateOf<String?>(null) }
@@ -392,11 +397,33 @@ fun EditFoodEntrySheet(
             ) {
             // Swipeable originals gallery OR 80sp emoji fallback — centered.
             item {
-                val photos = remember(currentBaseEntry.allImageFilenames) {
-                    currentBaseEntry.allImageFilenames.mapNotNull { filename ->
-                        container.imageStore.load(filename)?.let { filename to it }
+                val visibleFilenames = remember(currentBaseEntry.allImageFilenames, removedImageFilenames) {
+                    currentBaseEntry.allImageFilenames.filter { it !in removedImageFilenames }
+                }
+                val photos by produceState<List<Pair<String, Bitmap>>>(
+                    initialValue = emptyList(),
+                    visibleFilenames
+                ) {
+                    value = withContext(Dispatchers.IO) {
+                        visibleFilenames.mapNotNull { filename ->
+                            container.imageStore.loadForViewer(filename, GALLERY_MAX_DIMENSION)
+                                ?.let { filename to it }
+                        }
                     }
-                }.filterNot { (filename, _) -> filename in removedImageFilenames }
+                }
+                LaunchedEffect(previewPhotoIndex, visibleFilenames) {
+                    val index = previewPhotoIndex
+                    if (index == null) {
+                        viewerBitmaps = null
+                        return@LaunchedEffect
+                    }
+                    viewerBitmaps = withContext(Dispatchers.IO) {
+                        visibleFilenames.map { filename ->
+                            container.imageStore.loadForViewer(filename)
+                                ?: container.imageStore.loadForViewer(filename, GALLERY_MAX_DIMENSION)
+                        }
+                    }
+                }
                 Box(
                     Modifier.fillMaxWidth().padding(vertical = 8.dp),
                     contentAlignment = Alignment.Center
@@ -412,9 +439,7 @@ fun EditFoodEntrySheet(
                                         modifier = Modifier
                                             .size(240.dp)
                                             .clip(RoundedCornerShape(20.dp))
-                                            .clickable {
-                                                previewPhotos = photos.map { it.second } to index
-                                            }
+                                            .clickable { previewPhotoIndex = index }
                                     )
                                     IconButton(
                                         onClick = { removedImageFilenames = removedImageFilenames + filename },
@@ -828,12 +853,35 @@ fun EditFoodEntrySheet(
             onDismiss = { ingredientEditor = null }
         )
     }
-    previewPhotos?.let { (bitmaps, index) ->
-        FullScreenImageViewer(
-            bitmaps = bitmaps,
-            initialIndex = index,
-            onDismiss = { previewPhotos = null }
-        )
+    previewPhotoIndex?.let { index ->
+        val images = viewerBitmaps
+        if (images == null) {
+            androidx.compose.ui.window.Dialog(
+                onDismissRequest = { previewPhotoIndex = null },
+                properties = androidx.compose.ui.window.DialogProperties(
+                    dismissOnBackPress = true,
+                    dismissOnClickOutside = false
+                )
+            ) {
+                Box(
+                    Modifier
+                        .size(96.dp)
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(Color.Black.copy(alpha = 0.72f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(color = Color.White, modifier = Modifier.size(36.dp))
+                }
+            }
+        } else if (images.isNotEmpty()) {
+            FullScreenImageViewer(
+                bitmaps = images,
+                initialIndex = index.coerceIn(0, images.lastIndex),
+                onDismiss = { previewPhotoIndex = null }
+            )
+        }
     }
 }
+
+private const val GALLERY_MAX_DIMENSION = 720
 

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodResultSheet.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/FoodResultSheet.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import androidx.compose.ui.window.Dialog
@@ -121,9 +122,14 @@ fun FoodResultSheet(
     ) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val thumbnails = remember(imageBytesList) {
-        imageBytesList.mapIndexedNotNull { sourceIndex, bytes ->
-            FoodImageDecoder.decode(bytes, 720)?.let { sourceIndex to it }
+    val thumbnails by produceState<List<Pair<Int, android.graphics.Bitmap>>>(
+        initialValue = emptyList(),
+        imageBytesList
+    ) {
+        value = withContext(Dispatchers.IO) {
+            imageBytesList.mapIndexedNotNull { sourceIndex, bytes ->
+                FoodImageDecoder.decode(bytes, 720)?.let { sourceIndex to it }
+            }
         }
     }
     val state = rememberModalBottomSheetState(

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt
@@ -23,7 +23,11 @@ import com.apoorvdarshan.calorietracker.ui.components.autoSaveMealPhotoIfEnabled
 import com.apoorvdarshan.calorietracker.services.ai.AiError
 import com.apoorvdarshan.calorietracker.services.ai.FoodAnalysis
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -113,6 +117,14 @@ data class HomeUiState(
     fun isFavorite(entry: FoodEntry): Boolean = entry.favoriteKey in favoriteKeys
 }
 
+private data class HomeDayFilterInputs(
+    val profile: UserProfile?,
+    val entries: List<FoodEntry>,
+    val favoriteKeys: Set<String>,
+    val sortOrder: String?,
+    val day: LocalDate
+)
+
 internal class FoodSubmissionGate {
     private val active = AtomicBoolean(false)
 
@@ -146,18 +158,22 @@ private val _stepsRefreshEpoch = MutableStateFlow(0)
             container.prefs.foodLogSortOrder,
             _selectedDate
         ) { p, entries, favKeys, sortOrder, day ->
-            val zone = ZoneId.systemDefault()
-            val dayEntries = entries
-                .filter { it.timestamp.atZone(zone).toLocalDate() == day }
-                .sortedByDescending { it.timestamp }
-            _ui.value.copy(
-                profile = p,
-                date = day,
-                todayEntries = dayEntries,
-                foodLogSortOrder = FoodLogSortOrder.fromStorage(sortOrder),
-                favoriteKeys = favKeys
-            )
+            HomeDayFilterInputs(p, entries, favKeys, sortOrder, day)
         }
+            .map { (p, entries, favKeys, sortOrder, day) ->
+                val zone = ZoneId.systemDefault()
+                val dayEntries = entries
+                    .filter { it.timestamp.atZone(zone).toLocalDate() == day }
+                    .sortedByDescending { it.timestamp }
+                _ui.value.copy(
+                    profile = p,
+                    date = day,
+                    todayEntries = dayEntries,
+                    foodLogSortOrder = FoodLogSortOrder.fromStorage(sortOrder),
+                    favoriteKeys = favKeys
+                )
+            }
+            .flowOn(Dispatchers.Default)
             .onEach { _ui.value = it }
             .launchIn(viewModelScope)
 
@@ -902,9 +918,11 @@ viewModelScope.launch {
         )
     }
 
-    private fun restorePendingDraft(draft: PendingFoodAnalysisDraft) {
-        val bytesList = (listOfNotNull(draft.imageFilename) + draft.additionalImageFilenames).mapNotNull {
-            runCatching { container.imageStore.file(it).readBytes() }.getOrNull()
+    private suspend fun restorePendingDraft(draft: PendingFoodAnalysisDraft) {
+        val bytesList = withContext(Dispatchers.IO) {
+            (listOfNotNull(draft.imageFilename) + draft.additionalImageFilenames).mapNotNull {
+                runCatching { container.imageStore.file(it).readBytes() }.getOrNull()
+            }
         }
         _ui.value = _ui.value.copy(
             analyzing = false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Invisible Android smoothness pass — moves image decode/resize and heavy JSON work off the main thread. No UI redesign; sheets and Coach look identical once loaded. Analysis results, save behavior, and Coach message content are unchanged.

**Meal sheets**
- `EditFoodEntrySheet`: gallery loads ~720px thumbs via `loadForViewer` on `Dispatchers.IO`; full-res only when opening the fullscreen viewer (with loading spinner)
- `FoodResultSheet`: photo decode moved from `remember()` to `produceState` on IO
- `MultiPhotoCaptureSheet` (`ContextNoteSheet.kt`): same async decode pattern

**Coach**
- Chat bubble attachments decode on IO with 700px max dimension
- Composer preview decodes on IO with 280px max dimension
- Photo picker, camera capture, and send-path `resizedJpeg` run on `Default`/`IO` instead of blocking the UI thread

**Cold start / diary decode**
- `MainActivity`: removed three `runBlocking` prefs reads; startup prefs load async while splash holds the first frame
- `HomeViewModel.restorePendingDraft`: `readBytes` on IO
- `FoodImageStore`: legacy thumbnail folder cleanup deferred to existing `FudAIApp` `appScope` background job
- `PreferencesStore.foodEntries` and `chatHistory`: `.flowOn(Dispatchers.Default)` so kotlinx.serialization does not run on the UI collector
- `HomeViewModel` day-filter of the full food list: `.flowOn(Dispatchers.Default)`

## Test plan

- [ ] Cold start: app launches without jank; splash dismisses once prefs/profile are ready; Home goals do not flash fallback numbers
- [ ] Edit existing meal with photos: gallery shows thumbs (brief empty state OK); tap opens fullscreen viewer; remove/save/delete unchanged
- [ ] Log meal from camera (single + multi-photo): review sheet gallery appears; fullscreen viewer works; log/save behavior unchanged
- [ ] Coach: attach photo from library/camera — composer preview appears; send with image; scroll history — bubble images render; reset chat still works
- [ ] Kill app mid-review with pending draft — reopen Home; draft restores with photos
- [ ] Large diary (many entries): scroll Home day list — no main-thread stalls when switching days
- [ ] Regression: favorites, reprocess, What-If, and share meal flows unchanged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85c8556a-bd7c-46ff-a134-6bc58a8bf504?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85c8556a-bd7c-46ff-a134-6bc58a8bf504&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves image decoding, resizing, JSON deserialization, diary filtering, file reads, and startup preference loading away from the Android main thread.

- Adds asynchronous startup preference loading while holding the splash screen until startup state is ready.
- Moves Coach attachment preparation and previews into coroutines.
- Loads meal-sheet thumbnails and fullscreen images asynchronously at bounded dimensions.
- Moves large preference deserialization and diary filtering onto background dispatchers.
- Defers legacy thumbnail cleanup to the application scope.
- The new concurrency introduces ordering and lost-update risks in startup, Home state aggregation, and Coach attachment handling.

<h3>Confidence Score: 1/5</h3>

This PR is not safe to merge until startup reset ordering, Home UI-state serialization, and Coach attachment job ownership and ordering are corrected.

Four concrete concurrency failures can skip a requested onboarding reset, overwrite active Home state, silently discard a Coach message after its composer is cleared, or attach an older photo after a newer selection.

**Files Needing Attention:** android/app/src/main/java/com/apoorvdarshan/calorietracker/MainActivity.kt, android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt, android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/coach/CoachScreen.kt

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/src/main/java/com/apoorvdarshan/calorietracker/MainActivity.kt | Replaces blocking startup reads with asynchronous loading, but no longer sequences the onboarding reset before the corresponding startup read. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt | Offloads diary filtering and pending-draft file reads, but the filter pipeline can overwrite concurrent UI-state changes with a stale snapshot. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/coach/CoachScreen.kt | Moves attachment decoding and resizing off-main, while introducing cancellation and request-ordering failures around sending and selecting photos. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/EditFoodEntrySheet.kt | Adds bounded asynchronous gallery loading and full-resolution viewer loading with a spinner. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/data/PreferencesStore.kt | Moves food-entry and chat-history deserialization upstream onto the Default dispatcher. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/services/FoodImageStore.kt | Exposes idempotent legacy-thumbnail cleanup so application startup can schedule it in the background. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Activity as MainActivity
    participant Store as DataStore
    participant Home as HomeViewModel
    participant Coach as CoachScreen
    participant VM as CoachViewModel

    opt reset_onboarding flag
      Activity->>Store: Launch asynchronous reset
    end
    par Startup loading
      Activity->>Store: Read onboarding and theme preferences
      Store-->>Activity: Startup preferences
    and Home filtering
      Home->>Home: Filter entries on Dispatchers.Default
      Home->>Home: Assign copied UI state on Main
    and Coach photo send
      User->>Coach: Send photo
      Coach->>Coach: Clear composer
      Coach->>Coach: Resize in composition-bound scope
      Coach->>VM: send(...)
    end
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20apoorvdarshan%2Ffud-ai%20PR%20%23281%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=281&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2FMainActivity.kt%3A117-120%0A**Onboarding%20Reset%20Can%20Race**%0A%0AThe%20reset%20write%20now%20runs%20in%20one%20coroutine%2C%20while%20startup%20immediately%20launches%20another%20coroutine%20that%20reads%20%60hasCompletedOnboarding%60.%20Because%20the%20DataStore%20edit%20can%20suspend%20and%20is%20not%20awaited%2C%20startup%20can%20read%20the%20previous%20completed%20state%20and%20skip%20onboarding.%20The%20reset%20then%20takes%20effect%20only%20on%20a%20later%20app%20launch.%0A%0A%23%23%23%20Issue%202%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fhome%2FHomeViewModel.kt%3A163-177%0A**Background%20Snapshot%20Overwrites%20State**%0A%0AThis%20pipeline%20reads%20%60_ui.value%60%20on%20%60Dispatchers.Default%60%2C%20copies%20the%20entire%20state%2C%20and%20later%20assigns%20that%20snapshot%20on%20the%20main%20thread.%20If%20another%20coroutine%20updates%20the%20state%20in%20between%E2%80%94such%20as%20when%20starting%20analysis%2C%20restoring%20a%20draft%2C%20or%20changing%20save%20or%20error%20state%E2%80%94the%20later%20assignment%20restores%20stale%20field%20values%20and%20can%20erase%20that%20update.%0A%0A%23%23%23%20Issue%203%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fcoach%2FCoachScreen.kt%3A205-210%0A**Navigation%20Can%20Drop%20Messages**%0A%0AThe%20text%20and%20attachment%20are%20cleared%20before%20image%20preprocessing%20finishes%2C%20but%20preprocessing%20runs%20in%20the%20composable's%20%60rememberCoroutineScope%60.%20If%20the%20user%20switches%20away%20from%20Coach%20during%20resizing%2C%20disposal%20cancels%20the%20coroutine%20before%20%60vm.send%60%20is%20called%2C%20so%20the%20already-cleared%20message%20is%20silently%20lost.%0A%0A%23%23%23%20Issue%204%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fcoach%2FCoachScreen.kt%3A176-181%0A**Attachment%20Jobs%20Race**%0A%0APicker%20and%20camera%20callbacks%20launch%20independent%20resize%20jobs%20that%20write%20the%20same%20%60attachedImageBytes%60%20state%20without%20canceling%20or%20identifying%20older%20requests.%20If%20a%20second%20photo%20is%20selected%20before%20the%20first%20resize%20finishes%2C%20the%20older%20job%20can%20complete%20last%20and%20replace%20the%20newer%20photo.%20A%20resize%20already%20in%20progress%20can%20also%20restore%20an%20attachment%20after%20sending%20has%20cleared%20the%20composer.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=281&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22apoorvdarshan%2Ffud-ai%22%20on%20the%20existing%20branch%20%22cursor%2Fandroid-sheets-coach-startup-8516%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fandroid-sheets-coach-startup-8516%22.%0A%0A%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2FMainActivity.kt%3A117-120%0A**Onboarding%20Reset%20Can%20Race**%0A%0AThe%20reset%20write%20now%20runs%20in%20one%20coroutine%2C%20while%20startup%20immediately%20launches%20another%20coroutine%20that%20reads%20%60hasCompletedOnboarding%60.%20Because%20the%20DataStore%20edit%20can%20suspend%20and%20is%20not%20awaited%2C%20startup%20can%20read%20the%20previous%20completed%20state%20and%20skip%20onboarding.%20The%20reset%20then%20takes%20effect%20only%20on%20a%20later%20app%20launch.%0A%0A%23%23%23%20Issue%202%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fhome%2FHomeViewModel.kt%3A163-177%0A**Background%20Snapshot%20Overwrites%20State**%0A%0AThis%20pipeline%20reads%20%60_ui.value%60%20on%20%60Dispatchers.Default%60%2C%20copies%20the%20entire%20state%2C%20and%20later%20assigns%20that%20snapshot%20on%20the%20main%20thread.%20If%20another%20coroutine%20updates%20the%20state%20in%20between%E2%80%94such%20as%20when%20starting%20analysis%2C%20restoring%20a%20draft%2C%20or%20changing%20save%20or%20error%20state%E2%80%94the%20later%20assignment%20restores%20stale%20field%20values%20and%20can%20erase%20that%20update.%0A%0A%23%23%23%20Issue%203%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fcoach%2FCoachScreen.kt%3A205-210%0A**Navigation%20Can%20Drop%20Messages**%0A%0AThe%20text%20and%20attachment%20are%20cleared%20before%20image%20preprocessing%20finishes%2C%20but%20preprocessing%20runs%20in%20the%20composable's%20%60rememberCoroutineScope%60.%20If%20the%20user%20switches%20away%20from%20Coach%20during%20resizing%2C%20disposal%20cancels%20the%20coroutine%20before%20%60vm.send%60%20is%20called%2C%20so%20the%20already-cleared%20message%20is%20silently%20lost.%0A%0A%23%23%23%20Issue%204%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fcoach%2FCoachScreen.kt%3A176-181%0A**Attachment%20Jobs%20Race**%0A%0APicker%20and%20camera%20callbacks%20launch%20independent%20resize%20jobs%20that%20write%20the%20same%20%60attachedImageBytes%60%20state%20without%20canceling%20or%20identifying%20older%20requests.%20If%20a%20second%20photo%20is%20selected%20before%20the%20first%20resize%20finishes%2C%20the%20older%20job%20can%20complete%20last%20and%20replace%20the%20newer%20photo.%20A%20resize%20already%20in%20progress%20can%20also%20restore%20an%20attachment%20after%20sending%20has%20cleared%20the%20composer.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=281&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2FMainActivity.kt%3A117-120%0A**Onboarding%20Reset%20Can%20Race**%0A%0AThe%20reset%20write%20now%20runs%20in%20one%20coroutine%2C%20while%20startup%20immediately%20launches%20another%20coroutine%20that%20reads%20%60hasCompletedOnboarding%60.%20Because%20the%20DataStore%20edit%20can%20suspend%20and%20is%20not%20awaited%2C%20startup%20can%20read%20the%20previous%20completed%20state%20and%20skip%20onboarding.%20The%20reset%20then%20takes%20effect%20only%20on%20a%20later%20app%20launch.%0A%0A%23%23%23%20Issue%202%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fhome%2FHomeViewModel.kt%3A163-177%0A**Background%20Snapshot%20Overwrites%20State**%0A%0AThis%20pipeline%20reads%20%60_ui.value%60%20on%20%60Dispatchers.Default%60%2C%20copies%20the%20entire%20state%2C%20and%20later%20assigns%20that%20snapshot%20on%20the%20main%20thread.%20If%20another%20coroutine%20updates%20the%20state%20in%20between%E2%80%94such%20as%20when%20starting%20analysis%2C%20restoring%20a%20draft%2C%20or%20changing%20save%20or%20error%20state%E2%80%94the%20later%20assignment%20restores%20stale%20field%20values%20and%20can%20erase%20that%20update.%0A%0A%23%23%23%20Issue%203%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fcoach%2FCoachScreen.kt%3A205-210%0A**Navigation%20Can%20Drop%20Messages**%0A%0AThe%20text%20and%20attachment%20are%20cleared%20before%20image%20preprocessing%20finishes%2C%20but%20preprocessing%20runs%20in%20the%20composable's%20%60rememberCoroutineScope%60.%20If%20the%20user%20switches%20away%20from%20Coach%20during%20resizing%2C%20disposal%20cancels%20the%20coroutine%20before%20%60vm.send%60%20is%20called%2C%20so%20the%20already-cleared%20message%20is%20silently%20lost.%0A%0A%23%23%23%20Issue%204%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fcoach%2FCoachScreen.kt%3A176-181%0A**Attachment%20Jobs%20Race**%0A%0APicker%20and%20camera%20callbacks%20launch%20independent%20resize%20jobs%20that%20write%20the%20same%20%60attachedImageBytes%60%20state%20without%20canceling%20or%20identifying%20older%20requests.%20If%20a%20second%20photo%20is%20selected%20before%20the%20first%20resize%20finishes%2C%20the%20older%20job%20can%20complete%20last%20and%20replace%20the%20newer%20photo.%20A%20resize%20already%20in%20progress%20can%20also%20restore%20an%20attachment%20after%20sending%20has%20cleared%20the%20composer.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=281&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
android/app/src/main/java/com/apoorvdarshan/calorietracker/MainActivity.kt:117-120
**Onboarding Reset Can Race**

The reset write now runs in one coroutine, while startup immediately launches another coroutine that reads `hasCompletedOnboarding`. Because the DataStore edit can suspend and is not awaited, startup can read the previous completed state and skip onboarding. The reset then takes effect only on a later app launch.

### Issue 2
android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt:163-177
**Background Snapshot Overwrites State**

This pipeline reads `_ui.value` on `Dispatchers.Default`, copies the entire state, and later assigns that snapshot on the main thread. If another coroutine updates the state in between—such as when starting analysis, restoring a draft, or changing save or error state—the later assignment restores stale field values and can erase that update.

### Issue 3
android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/coach/CoachScreen.kt:205-210
**Navigation Can Drop Messages**

The text and attachment are cleared before image preprocessing finishes, but preprocessing runs in the composable's `rememberCoroutineScope`. If the user switches away from Coach during resizing, disposal cancels the coroutine before `vm.send` is called, so the already-cleared message is silently lost.

### Issue 4
android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/coach/CoachScreen.kt:176-181
**Attachment Jobs Race**

Picker and camera callbacks launch independent resize jobs that write the same `attachedImageBytes` state without canceling or identifying older requests. If a second photo is selected before the first resize finishes, the older job can complete last and replace the newer photo. A resize already in progress can also restore an attachment after sending has cleared the composer.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Kotlin compile errors in Coach and E..."](https://github.com/apoorvdarshan/fud-ai/commit/7c08426fd893271e63b9e924ce12ce75f9913baa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63405919)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup responsiveness by loading preferences and preparing content without blocking the interface.
  * Prevented image processing and food-entry filtering from interrupting UI interactions.
  * Improved handling of photo previews, attachments, and full-screen image viewing with asynchronous loading.
  * Added a loading indicator while full-resolution images are prepared.
  * Cleaned up legacy food-thumbnail files during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->