### PR TITLE
Smooth iOS Workouts open and food photo thumbs

### DIFF
--- a/ios/calorietracker/ContentView.swift
+++ b/ios/calorietracker/ContentView.swift
@@ -3436,32 +3436,21 @@ struct FoodRow: View {
     var body: some View {
         HStack(spacing: 12) {
             // Thumbnail — tap opens full-screen viewer without opening edit.
-            if let imageData = entry.imageData, let uiImage = UIImage(data: imageData) {
+            if entry.imageFilename != nil || entry.imageData != nil {
                 Button {
-                    let images = entry.allImageData.compactMap(UIImage.init(data:))
-                    guard !images.isEmpty else { return }
-                    imagePreview = FullScreenImagePreview(images: images)
-                } label: {
-                    Image(uiImage: uiImage)
-                        .resizable()
-                        .scaledToFill()
-                        .frame(width: 56, height: 56)
-                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                .strokeBorder(AppColors.calorie.opacity(0.15), lineWidth: 1)
-                        )
-                        .overlay(alignment: .bottomTrailing) {
-                            if !entry.additionalImageData.isEmpty {
-                                Text("+\(entry.additionalImageData.count)")
-                                    .font(.caption2.weight(.bold))
-                                    .foregroundStyle(.white)
-                                    .padding(.horizontal, 6)
-                                    .padding(.vertical, 3)
-                                    .background(.black.opacity(0.65), in: Capsule())
-                                    .padding(4)
-                            }
+                    Task {
+                        let images = await FoodEntryPhotoLoader.viewerImages(for: entry)
+                        guard !images.isEmpty else { return }
+                        await MainActor.run {
+                            imagePreview = FullScreenImagePreview(images: images)
                         }
+                    }
+                } label: {
+                    FoodEntryThumbnailView(
+                        filename: entry.imageFilename,
+                        legacyData: entry.imageData,
+                        additionalCount: entry.listThumbnailAdditionalPhotoCount
+                    )
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("View full photo")

--- a/ios/calorietracker/Models/FoodEntry.swift
+++ b/ios/calorietracker/Models/FoodEntry.swift
@@ -550,13 +550,10 @@ struct FoodEntry: Identifiable, Codable {
         // FoodStore.loadEntries() migrates legacy rows to disk on first load so
         // subsequent saves shed the inline bytes and fit under the 4 MiB cap.
         imageFilename = try container.decodeIfPresent(String.self, forKey: .imageFilename)
-        if let filename = imageFilename {
-            imageData = FoodImageStore.shared.load(filename: filename)
-        } else {
-            imageData = try container.decodeIfPresent(Data.self, forKey: .imageData)
-        }
+        // Keep legacy inline bytes from JSON; disk-backed photos load lazily for list thumbs.
+        imageData = try container.decodeIfPresent(Data.self, forKey: .imageData)
         additionalImageFilenames = try container.decodeIfPresent([String].self, forKey: .additionalImageFilenames) ?? []
-        additionalImageData = additionalImageFilenames.compactMap { FoodImageStore.shared.load(filename: $0) }
+        additionalImageData = []
 
         emoji = try container.decodeIfPresent(String.self, forKey: .emoji)
         source = try container.decode(FoodSource.self, forKey: .source)
@@ -690,6 +687,14 @@ struct FoodEntry: Identifiable, Codable {
         var seen = Set<String>()
         return ((imageFilename.map { [$0] } ?? []) + additionalImageFilenames + ingredients.flatMap(\.allImageFilenames))
             .filter { seen.insert($0).inserted }
+    }
+
+    /// Count of extra photos for list-row "+N" badges without loading full JPEG bytes.
+    var listThumbnailAdditionalPhotoCount: Int {
+        if !additionalImageFilenames.isEmpty {
+            return additionalImageFilenames.count
+        }
+        return additionalImageData.count
     }
 
     /// New entry for the given log date (new id), copying nutrition and media from this entry.

--- a/ios/calorietracker/Models/FoodEntry.swift
+++ b/ios/calorietracker/Models/FoodEntry.swift
@@ -701,6 +701,7 @@ struct FoodEntry: Identifiable, Codable {
     /// Uses current time's meal type by default.
     func duplicatedForLogging(at logDate: Date, mealType: MealType = .currentMeal) -> FoodEntry {
         let resolvedMealType = mealType
+        let copiedPhotos = allImageData
         return FoodEntry(
             name: name,
             calories: calories,
@@ -708,9 +709,9 @@ struct FoodEntry: Identifiable, Codable {
             carbs: carbs,
             fat: fat,
             timestamp: logDate,
-            imageData: imageData,
+            imageData: copiedPhotos.first,
             imageFilename: nil,  // new id → new filename will be assigned on save
-            additionalImageData: additionalImageData,
+            additionalImageData: Array(copiedPhotos.dropFirst()),
             additionalImageFilenames: [],
             emoji: emoji,
             source: source,

--- a/ios/calorietracker/Services/ExerciseCatalogWarmup.swift
+++ b/ios/calorietracker/Services/ExerciseCatalogWarmup.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Preloads the bundled workout catalog off the main thread so the first Workouts
+/// tab open does not hitch on JSON decode + image lookup table construction.
+enum ExerciseCatalogWarmup {
+    private static let lock = NSLock()
+    private static var didStart = false
+
+    static func startIfNeeded() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !didStart else { return }
+        didStart = true
+
+        Task.detached(priority: .utility) {
+            _ = ExerciseLibraryService.shared
+            FreeExerciseDBAssetResolver.warmImageLookup()
+            FreeExerciseDBAssetResolver.warmVisualManifest()
+        }
+    }
+}

--- a/ios/calorietracker/Services/ExerciseLibraryService.swift
+++ b/ios/calorietracker/Services/ExerciseLibraryService.swift
@@ -142,3 +142,45 @@ struct ExerciseLibraryService {
         }
     }
 }
+
+struct ExerciseLibraryFilterRequest: Sendable {
+    let levels: Set<String>
+    let rawEquipment: Set<String>
+    let primaryMuscles: Set<String>
+    let secondaryMuscles: Set<String>
+    let forces: Set<String>
+    let mechanics: Set<String>
+    let categories: Set<String>
+    let sort: ExerciseLibrarySort
+    let searchText: String
+    let splitMuscles: Set<String>
+}
+
+enum ExerciseLibraryFilterEngine {
+    static func filter(
+        exercises: [ExerciseLibraryItem],
+        request: ExerciseLibraryFilterRequest
+    ) -> [ExerciseLibraryItem] {
+        let service = ExerciseLibraryService(exercises: exercises)
+        let filtered = service.filtered(
+            levels: request.levels,
+            rawEquipment: request.rawEquipment,
+            primaryMuscles: request.primaryMuscles,
+            secondaryMuscles: request.secondaryMuscles,
+            forces: request.forces,
+            mechanics: request.mechanics,
+            categories: request.categories,
+            sort: request.sort,
+            searchText: request.searchText
+        )
+
+        guard !request.splitMuscles.isEmpty else {
+            return filtered
+        }
+
+        return filtered.filter { item in
+            item.primaryMuscles.contains(where: request.splitMuscles.contains) ||
+                item.secondaryMuscles.contains(where: request.splitMuscles.contains)
+        }
+    }
+}

--- a/ios/calorietracker/Services/FoodImageStore.swift
+++ b/ios/calorietracker/Services/FoodImageStore.swift
@@ -1,4 +1,6 @@
 import Foundation
+import ImageIO
+import UIKit
 
 /// Disk-backed image store for `FoodEntry` photos.
 ///
@@ -14,8 +16,18 @@ import Foundation
 /// hundred bytes per entry — so UserDefaults stays well under its cap.
 struct FoodImageStore {
     static let shared = FoodImageStore()
+    static let thumbnailMaxDimension = 320
+    static let viewerMaxDimension = 2048
 
     private let folderName = "fudai-food-images"
+    private let thumbnailFolderName = "fudai-food-thumbnails-v2"
+
+    private let thumbnailCache: NSCache<NSString, UIImage> = {
+        let cache = NSCache<NSString, UIImage>()
+        cache.countLimit = 64
+        cache.totalCostLimit = 12 * 1_024 * 1_024
+        return cache
+    }()
 
     private var folderURL: URL? {
         guard let base = try? FileManager.default.url(
@@ -27,6 +39,25 @@ struct FoodImageStore {
         let url = base.appendingPathComponent(folderName, isDirectory: true)
         if !FileManager.default.fileExists(atPath: url.path) {
             try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        }
+        return url
+    }
+
+    private var thumbnailFolderURL: URL? {
+        guard let base = try? FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        ) else { return nil }
+        let url = base.appendingPathComponent(thumbnailFolderName, isDirectory: true)
+        if !FileManager.default.fileExists(atPath: url.path) {
+            try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        }
+        // Legacy thumbnails lost EXIF orientation during compression.
+        let legacyURL = base.appendingPathComponent("fudai-food-thumbnails", isDirectory: true)
+        if FileManager.default.fileExists(atPath: legacyURL.path) {
+            try? FileManager.default.removeItem(at: legacyURL)
         }
         return url
     }
@@ -50,6 +81,9 @@ struct FoodImageStore {
         let url = folderURL.appendingPathComponent(filename)
         do {
             try data.write(to: url, options: .atomic)
+            if let thumbnail = decodeImage(at: url, maxPixelSize: Self.thumbnailMaxDimension) {
+                writeThumbnail(thumbnail, filename: filename)
+            }
             return filename
         } catch {
             return nil
@@ -74,6 +108,38 @@ struct FoodImageStore {
         return try? Data(contentsOf: url)
     }
 
+    /// Bounded decode for list rows — avoids full-resolution JPEG decode on Home.
+    func loadThumbnail(filename: String, maxPixelSize: Int = thumbnailMaxDimension) -> UIImage? {
+        let cacheKey = "\(filename):\(maxPixelSize)" as NSString
+        if let cached = thumbnailCache.object(forKey: cacheKey) {
+            return cached
+        }
+
+        if let thumbFolderURL = thumbnailFolderURL {
+            let thumbURL = thumbFolderURL.appendingPathComponent(filename)
+            if FileManager.default.fileExists(atPath: thumbURL.path),
+               let image = decodeImage(at: thumbURL, maxPixelSize: maxPixelSize) {
+                thumbnailCache.setObject(image, forKey: cacheKey, cost: image.estimatedMemoryCost)
+                return image
+            }
+        }
+
+        guard let sourceURL = fileURL(for: filename),
+              let image = decodeImage(at: sourceURL, maxPixelSize: maxPixelSize) else {
+            return nil
+        }
+
+        writeThumbnail(image, filename: filename)
+        thumbnailCache.setObject(image, forKey: cacheKey, cost: image.estimatedMemoryCost)
+        return image
+    }
+
+    /// Bounded decode for full-screen viewer — original bytes stay untouched on disk.
+    func loadForViewer(filename: String, maxPixelSize: Int = viewerMaxDimension) -> UIImage? {
+        guard let sourceURL = fileURL(for: filename) else { return nil }
+        return decodeImage(at: sourceURL, maxPixelSize: maxPixelSize)
+    }
+
     /// On-disk URL for a stored filename, when the file exists.
     func fileURL(for filename: String) -> URL? {
         guard let folderURL else { return nil }
@@ -92,11 +158,54 @@ struct FoodImageStore {
         guard let folderURL else { return }
         let url = folderURL.appendingPathComponent(filename)
         try? FileManager.default.removeItem(at: url)
+        if let thumbFolderURL = thumbnailFolderURL {
+            let thumbURL = thumbFolderURL.appendingPathComponent(filename)
+            try? FileManager.default.removeItem(at: thumbURL)
+        }
+        evictThumbnailCache(for: filename)
     }
 
     /// Wipes the entire image folder (used by Delete All Data).
     func deleteAll() {
         guard let folderURL else { return }
         try? FileManager.default.removeItem(at: folderURL)
+        if let thumbFolderURL = thumbnailFolderURL {
+            try? FileManager.default.removeItem(at: thumbFolderURL)
+        }
+        thumbnailCache.removeAllObjects()
+    }
+
+    private func writeThumbnail(_ image: UIImage, filename: String) {
+        guard let thumbFolderURL, let data = image.jpegData(compressionQuality: 0.76) else { return }
+        let url = thumbFolderURL.appendingPathComponent(filename)
+        try? data.write(to: url, options: .atomic)
+    }
+
+    private func evictThumbnailCache(for filename: String) {
+        thumbnailCache.removeObject(forKey: "\(filename):\(Self.thumbnailMaxDimension)" as NSString)
+    }
+
+    private func decodeImage(at url: URL, maxPixelSize: Int) -> UIImage? {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+            return UIImage(contentsOfFile: url.path)
+        }
+
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+            kCGImageSourceCreateThumbnailWithTransform: true
+        ]
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+            return UIImage(contentsOfFile: url.path)
+        }
+        return UIImage(cgImage: cgImage)
+    }
+}
+
+private extension UIImage {
+    var estimatedMemoryCost: Int {
+        let pixelWidth = max(Int(size.width * scale), 1)
+        let pixelHeight = max(Int(size.height * scale), 1)
+        return pixelWidth * pixelHeight * 4
     }
 }

--- a/ios/calorietracker/Services/FreeExerciseDBAssetResolver.swift
+++ b/ios/calorietracker/Services/FreeExerciseDBAssetResolver.swift
@@ -248,16 +248,16 @@ struct FreeExerciseDBAssetResolver {
     }()
 
     private static let imageRecords: [FreeExerciseDBRecord] = {
-        guard
-            let url = exercisesJSONURL(),
-            let data = try? Data(contentsOf: url),
-            let records = try? JSONDecoder().decode([FreeExerciseDBRecord].self, from: data)
-        else {
-            return []
-        }
-
-        return records
+        FreeExerciseDBRecordsCache.records()
     }()
+
+    static func warmImageLookup() {
+        _ = imagePathsByName
+    }
+
+    static func warmVisualManifest() {
+        _ = bundledVisualManifest
+    }
 
     private static func imageURL(for relativePath: String) -> URL? {
         if UserExercise.isUserPhotoFilename(relativePath),

--- a/ios/calorietracker/Services/FreeExerciseDBLoader.swift
+++ b/ios/calorietracker/Services/FreeExerciseDBLoader.swift
@@ -1,12 +1,34 @@
 import Foundation
 
-struct FreeExerciseDBLoader {
-    static func load() -> [ExerciseLibraryItem] {
+enum FreeExerciseDBRecordsCache {
+    private static let lock = NSLock()
+    private static var cachedRecords: [FreeExerciseDBRecord]?
+
+    static func records() -> [FreeExerciseDBRecord] {
+        lock.lock()
+        defer { lock.unlock() }
+        if let cachedRecords {
+            return cachedRecords
+        }
+
         guard
             let url = FreeExerciseDBAssetResolver.exercisesJSONURL(),
             let data = try? Data(contentsOf: url),
             let records = try? JSONDecoder().decode([FreeExerciseDBRecord].self, from: data)
         else {
+            cachedRecords = []
+            return []
+        }
+
+        cachedRecords = records
+        return records
+    }
+}
+
+struct FreeExerciseDBLoader {
+    static func load() -> [ExerciseLibraryItem] {
+        let records = FreeExerciseDBRecordsCache.records()
+        guard !records.isEmpty else {
             return []
         }
 

--- a/ios/calorietracker/Stores/FoodStore.swift
+++ b/ios/calorietracker/Stores/FoodStore.swift
@@ -565,9 +565,6 @@ class FoodStore {
         let filenames = entry.allImageFilenames
         if entry.imageFilename == nil { entry.imageFilename = filenames.first }
         entry.additionalImageFilenames = filenames.filter { $0 != entry.imageFilename }
-        if entry.imageData == nil, let filename = entry.imageFilename {
-            entry.imageData = FoodImageStore.shared.load(filename: filename)
-        }
     }
 
     /// Used by deleteEntry / replaceAllEntries to decide whether the on-disk

--- a/ios/calorietracker/Stores/StrengthWorkoutStore.swift
+++ b/ios/calorietracker/Stores/StrengthWorkoutStore.swift
@@ -46,9 +46,25 @@ final class StrengthWorkoutStore {
 
     private var exerciseLibrarySourceFingerprint: Int {
         var hasher = Hasher()
-        hasher.combine(customActivities.map(\.itemID))
-        hasher.combine(userExercises.map(\.itemID))
+        for exercise in customActivities + userExercises {
+            combineLibrarySource(&hasher, exercise: exercise)
+        }
         return hasher.finalize()
+    }
+
+    private func combineLibrarySource(_ hasher: inout Hasher, exercise: StrengthPlannedExercise) {
+        let item = exercise.libraryItem
+        hasher.combine(item.id)
+        hasher.combine(item.name)
+        hasher.combine(item.rawLevel)
+        hasher.combine(item.imagePaths)
+        hasher.combine(item.force)
+        hasher.combine(item.mechanic)
+        hasher.combine(item.category)
+        hasher.combine(item.rawEquipment)
+        hasher.combine(item.primaryMuscles)
+        hasher.combine(item.secondaryMuscles)
+        hasher.combine(item.instructions)
     }
     var onWorkoutBurnUpserted: ((StrengthWorkoutSession) -> Void)?
     var onWorkoutBurnDeleted: ((UUID) -> Void)?

--- a/ios/calorietracker/Stores/StrengthWorkoutStore.swift
+++ b/ios/calorietracker/Stores/StrengthWorkoutStore.swift
@@ -24,13 +24,31 @@ final class StrengthWorkoutStore {
     private(set) var customActivities: [StrengthPlannedExercise] = []
     private(set) var userExercises: [StrengthPlannedExercise] = []
 
+    private var cachedExerciseLibrary: ExerciseLibraryService?
+    private var exerciseLibraryFingerprint: Int = 0
+
     var exerciseLibrary: ExerciseLibraryService {
+        let fingerprint = exerciseLibrarySourceFingerprint
+        if let cachedExerciseLibrary, fingerprint == exerciseLibraryFingerprint {
+            return cachedExerciseLibrary
+        }
+
         let base = ExerciseLibraryService.shared.exercises
         let known = Set(base.map(\.id))
         let mergedCustom = (customActivities + userExercises)
             .filter { !known.contains($0.itemID) }
             .map(\.libraryItem)
-        return ExerciseLibraryService(exercises: base + mergedCustom)
+        let merged = ExerciseLibraryService(exercises: base + mergedCustom)
+        cachedExerciseLibrary = merged
+        exerciseLibraryFingerprint = fingerprint
+        return merged
+    }
+
+    private var exerciseLibrarySourceFingerprint: Int {
+        var hasher = Hasher()
+        hasher.combine(customActivities.map(\.itemID))
+        hasher.combine(userExercises.map(\.itemID))
+        return hasher.finalize()
     }
     var onWorkoutBurnUpserted: ((StrengthWorkoutSession) -> Void)?
     var onWorkoutBurnDeleted: ((UUID) -> Void)?

--- a/ios/calorietracker/Views/AnimatedExerciseVisual.swift
+++ b/ios/calorietracker/Views/AnimatedExerciseVisual.swift
@@ -1,3 +1,4 @@
+import ImageIO
 import SwiftUI
 import UIKit
 
@@ -11,6 +12,8 @@ struct AnimatedExerciseVisual: View {
     var fillsWidth = true
     var allowsDerivedImageLookup = true
     var animatesFrames = true
+    /// When set, decoded frames are capped at this pixel dimension. Nil keeps full resolution.
+    var maxPixelSize: Int? = nil
     var fallbackSystemImage = "figure.strengthtraining.traditional"
     var fallbackTitle = String(localized: "Exercise")
     @Environment(ProfileStore.self) private var profileStore
@@ -21,7 +24,11 @@ struct AnimatedExerciseVisual: View {
 
         ZStack {
             if !visualAsset.frames.isEmpty {
-                ExerciseImageView(asset: visualAsset, animatesFrames: animatesFrames)
+                ExerciseImageView(
+                    asset: visualAsset,
+                    animatesFrames: animatesFrames,
+                    maxPixelSize: effectiveMaxPixelSize
+                )
             } else {
                 fallbackVisual
             }
@@ -33,6 +40,18 @@ struct AnimatedExerciseVisual: View {
             RoundedRectangle(cornerRadius: 20, style: .continuous)
                 .stroke(Color(uiColor: .separator).opacity(0.35), lineWidth: 0.5)
         )
+    }
+
+    private var effectiveMaxPixelSize: Int? {
+        if let maxPixelSize {
+            return maxPixelSize
+        }
+        // Detail heroes keep full quality; list/diary cells downsample to cell size.
+        if height >= 200 {
+            return nil
+        }
+        let scale = UIScreen.main.scale
+        return max(Int(ceil(height * scale)), 1)
     }
 
     private var resolvedVisualAsset: ExerciseVisualAsset {
@@ -101,12 +120,18 @@ struct AnimatedExerciseVisual: View {
 private struct ExerciseImageView: View {
     let asset: ExerciseVisualAsset
     let animatesFrames: Bool
+    let maxPixelSize: Int?
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var frameIndex = 0
-    @State private var frames: [UIImage] = []
+    @State private var displayedImage: UIImage?
 
     private var taskID: ExerciseImageTaskID {
-        ExerciseImageTaskID(asset: asset, animatesFrames: animatesFrames, reduceMotion: reduceMotion)
+        ExerciseImageTaskID(
+            asset: asset,
+            animatesFrames: animatesFrames,
+            reduceMotion: reduceMotion,
+            maxPixelSize: maxPixelSize
+        )
     }
 
     var body: some View {
@@ -115,33 +140,35 @@ private struct ExerciseImageView: View {
             // composite over scrolling content behind a sticky hero.
             Color.workoutBackground
 
-            if !frames.isEmpty {
-                ZStack {
-                    ForEach(frames.indices, id: \.self) { index in
-                        exerciseFrame(frames[index])
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                            .clipped()
-                            .opacity(index == frameIndex ? 1 : 0)
-                    }
-                }
+            if let displayedImage {
+                exerciseFrame(displayedImage)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .clipped()
             }
         }
         .task(id: taskID) {
-            frames = []
-            frameIndex = 0
+            displayedImage = nil
+            frameIndex = initialFrameIndex
+            displayedImage = await loadFrame(at: frameIndex)
+            guard animatesFrames, asset.frames.count > 1, !reduceMotion else { return }
 
-            let frameSources = frameSourcesToLoad
-            let loadedFrames = ExerciseImageCache.shared.images(for: frameSources)
-            guard !Task.isCancelled else { return }
-            if !loadedFrames.isEmpty {
-                frames = loadedFrames
-            }
-            guard animatesFrames, frames.count > 1, !reduceMotion else { return }
+            var prefetchedIndex = (frameIndex + 1) % asset.frames.count
+            var prefetchedImage = await loadFrame(at: prefetchedIndex)
 
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: 850_000_000)
                 guard !Task.isCancelled else { return }
-                frameIndex = (frameIndex + 1) % frames.count
+
+                if let prefetchedImage {
+                    displayedImage = prefetchedImage
+                    frameIndex = prefetchedIndex
+                } else {
+                    frameIndex = (frameIndex + 1) % asset.frames.count
+                    displayedImage = await loadFrame(at: frameIndex)
+                }
+
+                prefetchedIndex = (frameIndex + 1) % asset.frames.count
+                prefetchedImage = await loadFrame(at: prefetchedIndex)
             }
         }
     }
@@ -164,14 +191,23 @@ private struct ExerciseImageView: View {
         }
     }
 
-    private var frameSourcesToLoad: [ExerciseVisualFrame] {
-        guard !asset.frames.isEmpty else { return [] }
-        guard !animatesFrames || reduceMotion else { return asset.frames }
+    private var initialFrameIndex: Int {
+        guard !asset.frames.isEmpty else { return 0 }
+        if animatesFrames, !reduceMotion {
+            return 0
+        }
+        if asset.format == .jpeg {
+            return 0
+        }
+        return min(asset.representativeFrameIndex, asset.frames.count - 1)
+    }
 
-        let representativeIndex = asset.format == .jpeg
-            ? 0
-            : min(asset.representativeFrameIndex, asset.frames.count - 1)
-        return [asset.frames[representativeIndex]]
+    private func loadFrame(at index: Int) async -> UIImage? {
+        guard asset.frames.indices.contains(index) else { return nil }
+        let frame = asset.frames[index]
+        return await Task.detached(priority: .userInitiated) {
+            ExerciseImageCache.shared.image(for: frame, maxPixelSize: maxPixelSize)
+        }.value
     }
 }
 
@@ -179,6 +215,7 @@ private struct ExerciseImageTaskID: Equatable {
     let asset: ExerciseVisualAsset
     let animatesFrames: Bool
     let reduceMotion: Bool
+    let maxPixelSize: Int?
 }
 
 private final class ExerciseImageCache {
@@ -193,12 +230,8 @@ private final class ExerciseImageCache {
 
     private init() {}
 
-    func images(for frames: [ExerciseVisualFrame]) -> [UIImage] {
-        frames.compactMap { image(for: $0) }
-    }
-
-    private func image(for frame: ExerciseVisualFrame) -> UIImage? {
-        let cacheKey = frame.cacheKey
+    func image(for frame: ExerciseVisualFrame, maxPixelSize: Int?) -> UIImage? {
+        let cacheKey = frame.cacheKey(maxPixelSize: maxPixelSize)
         if let image = imagesByFrame.object(forKey: cacheKey) {
             return image
         }
@@ -206,9 +239,9 @@ private final class ExerciseImageCache {
         let image: UIImage?
         switch frame {
         case .file(let url):
-            image = UIImage(contentsOfFile: url.path)
+            image = Self.decodeImage(fromFileURL: url, maxPixelSize: maxPixelSize)
         case .imageAsset(let name):
-            image = UIImage(named: name)
+            image = Self.decodeAssetImage(named: name, maxPixelSize: maxPixelSize)
         }
 
         guard let image else {
@@ -218,15 +251,50 @@ private final class ExerciseImageCache {
         imagesByFrame.setObject(image, forKey: cacheKey, cost: image.estimatedMemoryCost)
         return image
     }
+
+    private static func decodeImage(fromFileURL url: URL, maxPixelSize: Int?) -> UIImage? {
+        guard let maxPixelSize, maxPixelSize > 0 else {
+            return UIImage(contentsOfFile: url.path)
+        }
+
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+            return UIImage(contentsOfFile: url.path)
+        }
+        return thumbnail(from: source, maxPixelSize: maxPixelSize)
+    }
+
+    private static func decodeAssetImage(named name: String, maxPixelSize: Int?) -> UIImage? {
+        guard let image = UIImage(named: name) else { return nil }
+        guard let maxPixelSize, maxPixelSize > 0 else { return image }
+
+        let longestEdge = max(image.size.width, image.size.height) * image.scale
+        guard longestEdge > CGFloat(maxPixelSize) else { return image }
+
+        let target = CGSize(width: maxPixelSize, height: maxPixelSize)
+        return image.preparingThumbnail(of: target) ?? image
+    }
+
+    private static func thumbnail(from source: CGImageSource, maxPixelSize: Int) -> UIImage? {
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+            kCGImageSourceCreateThumbnailWithTransform: true
+        ]
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+            return nil
+        }
+        return UIImage(cgImage: cgImage)
+    }
 }
 
 private extension ExerciseVisualFrame {
-    var cacheKey: NSString {
+    func cacheKey(maxPixelSize: Int?) -> NSString {
+        let pixelKey = maxPixelSize.map(String.init) ?? "full"
         switch self {
         case .file(let url):
-            return "file:\(url.standardizedFileURL.absoluteString)" as NSString
+            return "file:\(url.standardizedFileURL.absoluteString):\(pixelKey)" as NSString
         case .imageAsset(let name):
-            return "asset:\(name)" as NSString
+            return "asset:\(name):\(pixelKey)" as NSString
         }
     }
 }

--- a/ios/calorietracker/Views/AnimatedExerciseVisual.swift
+++ b/ios/calorietracker/Views/AnimatedExerciseVisual.swift
@@ -149,7 +149,10 @@ private struct ExerciseImageView: View {
         .task(id: taskID) {
             displayedImage = nil
             frameIndex = initialFrameIndex
-            displayedImage = await loadFrame(at: frameIndex)
+            if let firstFrame = await loadFrame(at: frameIndex) {
+                guard !Task.isCancelled else { return }
+                displayedImage = firstFrame
+            }
             guard animatesFrames, asset.frames.count > 1, !reduceMotion else { return }
 
             var prefetchedIndex = (frameIndex + 1) % asset.frames.count
@@ -160,11 +163,15 @@ private struct ExerciseImageView: View {
                 guard !Task.isCancelled else { return }
 
                 if let prefetchedImage {
+                    guard !Task.isCancelled else { return }
                     displayedImage = prefetchedImage
                     frameIndex = prefetchedIndex
                 } else {
                     frameIndex = (frameIndex + 1) % asset.frames.count
-                    displayedImage = await loadFrame(at: frameIndex)
+                    if let loaded = await loadFrame(at: frameIndex) {
+                        guard !Task.isCancelled else { return }
+                        displayedImage = loaded
+                    }
                 }
 
                 prefetchedIndex = (frameIndex + 1) % asset.frames.count

--- a/ios/calorietracker/Views/ChatView.swift
+++ b/ios/calorietracker/Views/ChatView.swift
@@ -766,7 +766,7 @@ private struct MarkdownMessageText: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            ForEach(parse(text)) { block in
+            ForEach(MarkdownMessageBlockCache.blocks(for: text)) { block in
                 switch block.kind {
                 case .heading(let level):
                     Text(inline(block.text))
@@ -809,17 +809,18 @@ private struct MarkdownMessageText: View {
         ))) ?? AttributedString(string)
     }
 
-    private struct Block: Identifiable {
+    struct Block: Identifiable, Equatable {
         enum Kind: Equatable { case heading(Int), bullet, numbered(String), code, paragraph }
-        let id = UUID()
+        let id: String
         let kind: Kind
         let text: String
     }
 
-    private func parse(_ raw: String) -> [Block] {
+    fileprivate static func parse(_ raw: String) -> [Block] {
         var blocks: [Block] = []
         let lines = raw.replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: "\n")
         var index = 0
+        var blockIndex = 0
         while index < lines.count {
             let trimmed = lines[index].trimmingCharacters(in: .whitespaces)
 
@@ -831,7 +832,9 @@ private struct MarkdownMessageText: View {
                     index += 1
                 }
                 index += 1 // skip the closing fence
-                blocks.append(Block(kind: .code, text: codeLines.joined(separator: "\n")))
+                let text = codeLines.joined(separator: "\n")
+                blocks.append(Block(id: "code-\(blockIndex)", kind: .code, text: text))
+                blockIndex += 1
                 continue
             }
 
@@ -839,32 +842,51 @@ private struct MarkdownMessageText: View {
 
             if let level = headingLevel(trimmed) {
                 let content = String(trimmed.drop(while: { $0 == "#" })).trimmingCharacters(in: .whitespaces)
-                blocks.append(Block(kind: .heading(level), text: content))
+                blocks.append(Block(id: "heading-\(blockIndex)", kind: .heading(level), text: content))
             } else if trimmed.hasPrefix("- ") || trimmed.hasPrefix("* ") || trimmed.hasPrefix("+ ") {
-                blocks.append(Block(kind: .bullet, text: String(trimmed.dropFirst(2)).trimmingCharacters(in: .whitespaces)))
+                blocks.append(Block(id: "bullet-\(blockIndex)", kind: .bullet, text: String(trimmed.dropFirst(2)).trimmingCharacters(in: .whitespaces)))
             } else if let (number, rest) = numberedItem(trimmed) {
-                blocks.append(Block(kind: .numbered(number), text: rest))
+                blocks.append(Block(id: "numbered-\(blockIndex)", kind: .numbered(number), text: rest))
             } else {
-                blocks.append(Block(kind: .paragraph, text: trimmed))
+                blocks.append(Block(id: "paragraph-\(blockIndex)", kind: .paragraph, text: trimmed))
             }
+            blockIndex += 1
             index += 1
         }
         return blocks
     }
 
-    private func headingLevel(_ string: String) -> Int? {
+    private static func headingLevel(_ string: String) -> Int? {
         let hashes = string.prefix(while: { $0 == "#" }).count
         guard hashes >= 1, hashes <= 3, string.dropFirst(hashes).first == " " else { return nil }
         return hashes
     }
 
-    private func numberedItem(_ string: String) -> (String, String)? {
+    private static func numberedItem(_ string: String) -> (String, String)? {
         guard let dotIndex = string.firstIndex(of: ".") else { return nil }
         let numberPart = string[string.startIndex..<dotIndex]
         guard !numberPart.isEmpty, numberPart.allSatisfy(\.isNumber),
               string[string.index(after: dotIndex)...].first == " " else { return nil }
         let rest = String(string[string.index(after: dotIndex)...]).trimmingCharacters(in: .whitespaces)
         return (String(numberPart), rest)
+    }
+}
+
+private enum MarkdownMessageBlockCache {
+    private static let cache: NSCache<NSString, NSArray> = {
+        let cache = NSCache<NSString, NSArray>()
+        cache.countLimit = 48
+        return cache
+    }()
+
+    static func blocks(for text: String) -> [MarkdownMessageText.Block] {
+        let key = text as NSString
+        if let cached = cache.object(forKey: key) as? [MarkdownMessageText.Block] {
+            return cached
+        }
+        let parsed = MarkdownMessageText.parse(text)
+        cache.setObject(parsed as NSArray, forKey: key)
+        return parsed
     }
 }
 

--- a/ios/calorietracker/Views/FoodEntryThumbnailView.swift
+++ b/ios/calorietracker/Views/FoodEntryThumbnailView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+import UIKit
+
+/// Downsampled food photo for list rows — mirrors Android `loadThumbnail`.
+struct FoodEntryThumbnailView: View {
+    let filename: String?
+    var legacyData: Data? = nil
+    var additionalCount: Int = 0
+    var size: CGFloat = 56
+    var maxPixelSize: Int = FoodImageStore.thumbnailMaxDimension
+    var showsAdditionalBadge = true
+
+    @State private var image: UIImage?
+
+    private var hasPhoto: Bool {
+        filename != nil || legacyData != nil
+    }
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: size, height: size)
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .strokeBorder(AppColors.calorie.opacity(0.15), lineWidth: 1)
+                    )
+                    .overlay(alignment: .bottomTrailing) {
+                        if showsAdditionalBadge, additionalCount > 0 {
+                            Text("+\(additionalCount)")
+                                .font(.caption2.weight(.bold))
+                                .foregroundStyle(.white)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 3)
+                                .background(.black.opacity(0.65), in: Capsule())
+                                .padding(4)
+                        }
+                    }
+            } else if hasPhoto {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(.ultraThinMaterial)
+                    .frame(width: size, height: size)
+            }
+        }
+        .task(id: loadTaskID) {
+            image = nil
+            if let legacyData, filename == nil {
+                image = UIImage(data: legacyData)
+                return
+            }
+            guard let filename else { return }
+            let loaded = await Task.detached(priority: .utility) {
+                FoodImageStore.shared.loadThumbnail(filename: filename, maxPixelSize: maxPixelSize)
+            }.value
+            guard !Task.isCancelled else { return }
+            image = loaded
+        }
+    }
+
+    private var loadTaskID: String {
+        "\(filename ?? "")|\(legacyData?.count ?? 0)|\(maxPixelSize)"
+    }
+}
+
+enum FoodEntryPhotoLoader {
+    static func viewerImages(for entry: FoodEntry) async -> [UIImage] {
+        await Task.detached(priority: .userInitiated) {
+            entry.allImageFilenames.compactMap { filename in
+                FoodImageStore.shared.loadForViewer(filename: filename)
+            }
+        }.value
+    }
+}

--- a/ios/calorietracker/Views/FoodEntryThumbnailView.swift
+++ b/ios/calorietracker/Views/FoodEntryThumbnailView.swift
@@ -68,9 +68,13 @@ struct FoodEntryThumbnailView: View {
 enum FoodEntryPhotoLoader {
     static func viewerImages(for entry: FoodEntry) async -> [UIImage] {
         await Task.detached(priority: .userInitiated) {
-            entry.allImageFilenames.compactMap { filename in
+            let fromFilenames = entry.allImageFilenames.compactMap { filename in
                 FoodImageStore.shared.loadForViewer(filename: filename)
             }
+            if !fromFilenames.isEmpty {
+                return fromFilenames
+            }
+            return entry.allImageData.compactMap(UIImage.init(data:))
         }.value
     }
 }

--- a/ios/calorietracker/Views/RecentsView.swift
+++ b/ios/calorietracker/Views/RecentsView.swift
@@ -191,16 +191,13 @@ private struct SavedMealRow: View {
     var body: some View {
         HStack(spacing: 12) {
             // Thumbnail
-            if let imageData = entry.imageData, let uiImage = UIImage(data: imageData) {
-                Image(uiImage: uiImage)
-                    .resizable()
-                    .scaledToFill()
-                    .frame(width: 56, height: 56)
-                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12, style: .continuous)
-                            .strokeBorder(AppColors.calorie.opacity(0.15), lineWidth: 1)
-                    )
+            if entry.imageFilename != nil || entry.imageData != nil {
+                FoodEntryThumbnailView(
+                    filename: entry.imageFilename,
+                    legacyData: entry.imageData,
+                    additionalCount: entry.listThumbnailAdditionalPhotoCount,
+                    showsAdditionalBadge: false
+                )
             } else if let emoji = entry.emoji {
                 Text(emoji)
                     .font(.system(size: 28))

--- a/ios/calorietracker/Views/WorkoutLogView.swift
+++ b/ios/calorietracker/Views/WorkoutLogView.swift
@@ -1023,7 +1023,8 @@ private struct WorkoutLogExerciseCard: View {
                         imagePaths: exercise.imagePaths,
                         height: 64,
                         fillsWidth: false,
-                        allowsDerivedImageLookup: false
+                        allowsDerivedImageLookup: false,
+                        animatesFrames: false
                     )
                     .frame(width: 64, height: 64)
                     .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))

--- a/ios/calorietracker/Views/WorkoutPreferencePickers.swift
+++ b/ios/calorietracker/Views/WorkoutPreferencePickers.swift
@@ -384,6 +384,7 @@ private struct WorkoutEquipmentImageTile: View {
                     imagePaths: option.imagePaths,
                     height: 96,
                     allowsDerivedImageLookup: false,
+                    animatesFrames: false,
                     fallbackSystemImage: "dumbbell.fill",
                     fallbackTitle: option.title
                 )

--- a/ios/calorietracker/Views/WorkoutsView.swift
+++ b/ios/calorietracker/Views/WorkoutsView.swift
@@ -51,6 +51,7 @@ private struct ExerciseLibraryBrowserView: View {
     @State private var searchText = ""
     @State private var debouncedSearchText = ""
     @State private var displayItems: [ExerciseLibraryItem] = []
+    @State private var filterGeneration = 0
     @State private var searchDebounceTask: Task<Void, Never>?
     @State private var filterPersistTask: Task<Void, Never>?
     @State private var selectedSplitGroupTitles: Set<String> = []
@@ -480,13 +481,17 @@ private struct ExerciseLibraryBrowserView: View {
     }
 
     private func refreshDisplayItems() {
+        filterGeneration += 1
+        let generation = filterGeneration
         let rawEquipmentSelection = effectiveRawEquipmentSelection
         guard !rawEquipmentSelection.isEmpty else {
             displayItems = []
             return
         }
 
-        let filtered = service.filtered(
+        let exercises = service.exercises
+        let splitMuscles = Set(selectedSplitGroups.flatMap(\.muscles))
+        let request = ExerciseLibraryFilterRequest(
             levels: selectedLevels,
             rawEquipment: rawEquipmentSelection,
             primaryMuscles: selectedPrimaryMuscles,
@@ -495,18 +500,16 @@ private struct ExerciseLibraryBrowserView: View {
             mechanics: selectedMechanics,
             categories: selectedCategories,
             sort: selectedSort,
-            searchText: debouncedSearchText
+            searchText: debouncedSearchText,
+            splitMuscles: splitMuscles
         )
 
-        if selectedSplitGroups.isEmpty {
-            displayItems = filtered
-            return
-        }
-
-        let selectedMuscles = Set(selectedSplitGroups.flatMap(\.muscles))
-        displayItems = filtered.filter { item in
-            item.primaryMuscles.contains(where: selectedMuscles.contains) ||
-                item.secondaryMuscles.contains(where: selectedMuscles.contains)
+        Task.detached(priority: .userInitiated) {
+            let filtered = ExerciseLibraryFilterEngine.filter(exercises: exercises, request: request)
+            await MainActor.run {
+                guard generation == filterGeneration else { return }
+                displayItems = filtered
+            }
         }
     }
 

--- a/ios/calorietracker/calorietrackerApp.swift
+++ b/ios/calorietracker/calorietrackerApp.swift
@@ -57,6 +57,7 @@ struct calorietrackerApp: App {
             UserDefaults.standard.removeObject(forKey: "hasCompletedOnboarding")
             UserDefaults.standard.removeObject(forKey: "userProfile")
         }
+        ExerciseCatalogWarmup.startIfNeeded()
     }
 
     var body: some Scene {

--- a/ios/calorietrackerTests/FoodPhotoRemovalTests.swift
+++ b/ios/calorietrackerTests/FoodPhotoRemovalTests.swift
@@ -237,6 +237,26 @@ struct FoodPhotoRemovalTests {
         }
     }
 
+    @Test func duplicatedForLoggingPreservesDiskBackedPhotos() throws {
+        try withStore { store, _ in
+            var meal = makeMeal()
+            meal.imageData = Data("primary-photo".utf8)
+            meal.additionalImageData = [Data("second-photo".utf8)]
+            store.replaceAllEntries([meal])
+            let saved = try #require(store.entries.first)
+            defer { saved.allImageFilenames.forEach { FoodImageStore.shared.delete(filename: $0) } }
+
+            var diskBacked = saved
+            diskBacked.imageData = nil
+            diskBacked.additionalImageData = []
+
+            let duplicated = diskBacked.duplicatedForLogging(at: Date())
+            #expect(duplicated.imageData == Data("primary-photo".utf8))
+            #expect(duplicated.additionalImageData == [Data("second-photo".utf8)])
+            #expect(duplicated.imageFilename == nil)
+        }
+    }
+
     private func makeMeal() -> FoodEntry {
         FoodEntry(
             name: "Rice and beans", calories: 270, protein: 12, carbs: 52, fat: 2,

--- a/ios/calorietrackerTests/UserExerciseStoreTests.swift
+++ b/ios/calorietrackerTests/UserExerciseStoreTests.swift
@@ -30,6 +30,29 @@ import Testing
         #expect(reloaded.exerciseLibrary.exercises.contains { $0.id == saved!.id })
     }
 
+    @Test func editingUserExerciseRefreshesExerciseLibraryCache() throws {
+        let defaults = UserDefaults(suiteName: "UserExerciseStoreCacheTests")!
+        defaults.removePersistentDomain(forName: "UserExerciseStoreCacheTests")
+        defer { defaults.removePersistentDomain(forName: "UserExerciseStoreCacheTests") }
+
+        let store = StrengthWorkoutStore(defaults: defaults, storageKey: "test.workout.cache")
+        let item = store.saveUserExercise(UserExerciseDraft(
+            name: "Old Name",
+            primaryMuscles: ["Chest"]
+        ))
+        let itemID = try #require(item?.id)
+        _ = store.exerciseLibrary
+
+        _ = store.saveUserExercise(UserExerciseDraft(
+            name: "New Name",
+            primaryMuscles: ["Back"]
+        ), existingItemID: itemID)
+
+        let updated = try #require(store.exerciseLibrary.exercises.first { $0.id == itemID })
+        #expect(updated.name == "New Name")
+        #expect(updated.primaryMuscles == ["Back"])
+    }
+
     @Test func deleteUserExerciseRemovesTemplate() throws {
         let defaults = UserDefaults(suiteName: "UserExerciseStoreDeleteTests")!
         defaults.removePersistentDomain(forName: "UserExerciseStoreDeleteTests")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Matches Android Workouts/Home smoothness on iOS without changing visible design or fitness/logging behavior.

### Workouts catalog warm (Android parity)
- **`ExerciseCatalogWarmup`** preloads `ExerciseLibraryService`, `FreeExerciseDBAssetResolver` image lookup, and the visual manifest off the main thread at app launch.
- **`FreeExerciseDBRecordsCache`** shares a single `exercises.json` decode between `FreeExerciseDBLoader` and `FreeExerciseDBAssetResolver` (no double-decode).

### Animated exercise visuals
- **`AnimatedExerciseVisual`** loads one frame at a time; prefetches the next only when animating (detail hero).
- List/diary/grid tiles use `animatesFrames: false` (Workout log cards, equipment picker tiles; library rows already did).
- Cell-sized frames are downsampled via ImageIO / `preparingThumbnail`; detail heroes keep full resolution.

### Workout store
- **`StrengthWorkoutStore.exerciseLibrary`** caches the merged catalog and rebuilds only when custom/user exercises change (fingerprint-based).

### Home / Saved Meals food thumbs
- **`FoodImageStore`** gains thumbnail disk cache + in-memory cache (320px thumbs, 2048px viewer), mirroring Android.
- **`FoodEntry`** no longer reads full JPEG bytes from disk at JSON decode; legacy inline bytes in JSON still decode.
- **`FoodEntryThumbnailView`** async-loads downsampled thumbs for **`FoodRow`** and **`SavedMealRow`**; full-screen preview loads viewer-quality bytes on tap.
- Backup/sync/share paths still use full originals via `FoodImageStore.load()` / `allImageData`.

### Optional polish
- **`ExerciseLibraryBrowserView`** filter/search runs off the main thread via `ExerciseLibraryFilterEngine`.
- Coach **`MarkdownMessageText`** caches parsed blocks with stable IDs.

## Test plan

- [ ] Cold-launch app, wait ~2s, open Workouts tab — first Library/Log open should feel instant (no JSON hitch).
- [ ] Workouts **Library**: scroll exercise list; thumbnails static (no frame cycling), correct representative frame.
- [ ] Open exercise **detail** hero — animation still cycles smoothly at full quality.
- [ ] Workouts **Log**: exercise cards show 64pt static thumbs; swipe actions still work.
- [ ] Settings → workout equipment image picker: grid tiles static, selection unchanged.
- [ ] **Home** with many photo-logged meals: scroll day list — no memory spike; 56pt thumbs appear quickly.
- [ ] Tap a food photo thumb → full-screen viewer loads all photos; pinch/zoom if supported.
- [ ] **Saved Meals / Recents**: thumbs match Home sizing.
- [ ] Log a new meal with photo → appears in Home with thumb; gallery export still works if enabled.
- [ ] iCloud backup + restore round-trip: original JPEGs intact (not replaced by thumbs).
- [ ] Coach chat: markdown messages render identically; scrolling long threads stays smooth on repeat.
- [ ] Create/edit custom exercise → library merge updates without stale filter results.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f914e09-8aee-42d9-94f7-972bdd7949bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f914e09-8aee-42d9-94f7-972bdd7949bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved food-photo thumbnails with loading placeholders and additional-photo badges.
  - Added more responsive exercise-library filtering, including split-muscle selections.
- **Performance Improvements**
  - Exercise data and visual assets now load faster through background preparation and caching.
  - Food photos and animated exercise visuals use more efficient, size-appropriate image loading.
  - Markdown chat content and workout libraries load more efficiently.
- **UI Updates**
  - Workout and equipment thumbnails now display as still images instead of animated frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces asynchronous, downsampled food-photo presentation and improves workout catalog, exercise-image, filtering, library-cache, and markdown rendering performance.
- Warms and shares the bundled exercise catalog and visual metadata.
- Downsamples exercise frames and food photos according to their presentation size.
- Caches merged exercise libraries and parsed markdown blocks.
- Moves exercise filtering off the main thread.
- Follow-up changes hydrate photos when duplicating meals, invalidate exercise caches after edits, guard canceled frame loads, and support inline-only photo viewing.

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because copied meals can duplicate ingredient photos and partially migrated meals can omit photos from the full-screen viewer.

The previous stale-cache, canceled-frame, inline-only viewer, and disk-backed duplication findings are addressed. However, the photo-hydration follow-up now treats ingredient images as top-level duplicate media, the viewer fallback drops inline photos whenever any disk filename resolves, and duplication performs synchronous full-resolution disk reads from UI actions.

**Files Needing Attention:** ios/calorietracker/Models/FoodEntry.swift, ios/calorietracker/Views/FoodEntryThumbnailView.swift

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ios/calorietracker/Models/FoodEntry.swift | Lazily decodes disk-backed photo metadata and hydrates photos for duplicated meals, but duplication includes ingredient photos and performs synchronous disk reads from UI actions. |
| ios/calorietracker/Views/FoodEntryThumbnailView.swift | Adds asynchronous thumbnails and viewer-quality loading, but mixed filename/inline entries can lose photos from the viewer result. |
| ios/calorietracker/Stores/StrengthWorkoutStore.swift | Caches the merged exercise library using a complete fingerprint of all output-affecting exercise fields. |
| ios/calorietracker/Views/AnimatedExerciseVisual.swift | Loads and downsamples frames incrementally while preventing canceled tasks from publishing stale decoded images. |
| ios/calorietracker/Services/FoodImageStore.swift | Adds bounded thumbnail and viewer decoding with memory and disk thumbnail caches. |
| ios/calorietracker/Views/WorkoutsView.swift | Moves exercise filtering into detached work and rejects stale generations before publishing results. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[FoodEntry row] --> B[Load downsampled thumbnail]
  A --> C[Tap photo]
  C --> D[Load viewer images]
  D --> E{Any filename resolved?}
  E -->|Yes| F[Current behavior: return resolved files only]
  E -->|No| G[Fall back to allImageData]
  H[Duplicate or re-log meal] --> I[Resolve allImageData synchronously]
  I --> J[Create new entry with inline photos]
  J --> K[FoodStore persists new image files]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20apoorvdarshan%2Ffud-ai%20PR%20%23282%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=282&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aios%2Fcalorietracker%2FModels%2FFoodEntry.swift%3A704%0A**Ingredient%20photos%20get%20duplicated**%0A%0AWhen%20a%20meal%20with%20ingredient%20photos%20is%20copied%20or%20re-logged%2C%20%60allImageData%60%20includes%20those%20ingredient%20photos%20as%20top-level%20media.%20The%20duplicate%20also%20retains%20the%20ingredients%20and%20their%20original%20photo%20filenames%2C%20so%20saving%20it%20stores%20the%20ingredient%20photos%20again%20as%20additional%20meal%20photos.%20This%20produces%20duplicate%20viewer%20and%20gallery%20content%20and%20creates%20unnecessary%20image%20files.%20Hydrate%20only%20the%20entry's%20primary%20and%20additional%20photos%20here.%0A%0A%23%23%23%20Issue%202%0Aios%2Fcalorietracker%2FViews%2FFoodEntryThumbnailView.swift%3A71-77%0A**Mixed%20photos%20disappear**%0A%0AWhen%20at%20least%20one%20filename%20resolves%2C%20this%20returns%20only%20the%20images%20loaded%20from%20filenames%20and%20skips%20all%20inline%20data.%20Partially%20migrated%20entries%20can%20have%20a%20primary%20filename%20alongside%20additional%20inline%20photos%2C%20so%20their%20full-screen%20viewer%20shows%20fewer%20photos%20than%20the%20entry%20contains.%20Merge%20the%20resolved%20filename%20images%20with%20the%20remaining%20inline%20images%20instead%20of%20using%20an%20all-or-nothing%20fallback.%0A%0A%23%23%23%20Issue%203%0Aios%2Fcalorietracker%2FModels%2FFoodEntry.swift%3A704%0A**Photo%20copy%20blocks%20UI**%0A%0ACopying%20or%20re-logging%20a%20disk-backed%20meal%20now%20calls%20%60allImageData%60%20directly%20from%20SwiftUI%20actions.%20That%20synchronously%20reads%20every%20full-resolution%20photo%20with%20%60Data%28contentsOf%3A%29%60%2C%20so%20meals%20with%20several%20photos%20can%20freeze%20the%20UI%20while%20the%20files%20load.%20Move%20the%20photo%20hydration%20off%20the%20main%20actor%20before%20constructing%20the%20duplicate.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=282&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22apoorvdarshan%2Ffud-ai%22%20on%20the%20existing%20branch%20%22cursor%2Fios-workouts-home-thumbs-86b7%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fios-workouts-home-thumbs-86b7%22.%0A%0A%23%23%23%20Issue%201%0Aios%2Fcalorietracker%2FModels%2FFoodEntry.swift%3A704%0A**Ingredient%20photos%20get%20duplicated**%0A%0AWhen%20a%20meal%20with%20ingredient%20photos%20is%20copied%20or%20re-logged%2C%20%60allImageData%60%20includes%20those%20ingredient%20photos%20as%20top-level%20media.%20The%20duplicate%20also%20retains%20the%20ingredients%20and%20their%20original%20photo%20filenames%2C%20so%20saving%20it%20stores%20the%20ingredient%20photos%20again%20as%20additional%20meal%20photos.%20This%20produces%20duplicate%20viewer%20and%20gallery%20content%20and%20creates%20unnecessary%20image%20files.%20Hydrate%20only%20the%20entry's%20primary%20and%20additional%20photos%20here.%0A%0A%23%23%23%20Issue%202%0Aios%2Fcalorietracker%2FViews%2FFoodEntryThumbnailView.swift%3A71-77%0A**Mixed%20photos%20disappear**%0A%0AWhen%20at%20least%20one%20filename%20resolves%2C%20this%20returns%20only%20the%20images%20loaded%20from%20filenames%20and%20skips%20all%20inline%20data.%20Partially%20migrated%20entries%20can%20have%20a%20primary%20filename%20alongside%20additional%20inline%20photos%2C%20so%20their%20full-screen%20viewer%20shows%20fewer%20photos%20than%20the%20entry%20contains.%20Merge%20the%20resolved%20filename%20images%20with%20the%20remaining%20inline%20images%20instead%20of%20using%20an%20all-or-nothing%20fallback.%0A%0A%23%23%23%20Issue%203%0Aios%2Fcalorietracker%2FModels%2FFoodEntry.swift%3A704%0A**Photo%20copy%20blocks%20UI**%0A%0ACopying%20or%20re-logging%20a%20disk-backed%20meal%20now%20calls%20%60allImageData%60%20directly%20from%20SwiftUI%20actions.%20That%20synchronously%20reads%20every%20full-resolution%20photo%20with%20%60Data%28contentsOf%3A%29%60%2C%20so%20meals%20with%20several%20photos%20can%20freeze%20the%20UI%20while%20the%20files%20load.%20Move%20the%20photo%20hydration%20off%20the%20main%20actor%20before%20constructing%20the%20duplicate.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=282&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aios%2Fcalorietracker%2FModels%2FFoodEntry.swift%3A704%0A**Ingredient%20photos%20get%20duplicated**%0A%0AWhen%20a%20meal%20with%20ingredient%20photos%20is%20copied%20or%20re-logged%2C%20%60allImageData%60%20includes%20those%20ingredient%20photos%20as%20top-level%20media.%20The%20duplicate%20also%20retains%20the%20ingredients%20and%20their%20original%20photo%20filenames%2C%20so%20saving%20it%20stores%20the%20ingredient%20photos%20again%20as%20additional%20meal%20photos.%20This%20produces%20duplicate%20viewer%20and%20gallery%20content%20and%20creates%20unnecessary%20image%20files.%20Hydrate%20only%20the%20entry's%20primary%20and%20additional%20photos%20here.%0A%0A%23%23%23%20Issue%202%0Aios%2Fcalorietracker%2FViews%2FFoodEntryThumbnailView.swift%3A71-77%0A**Mixed%20photos%20disappear**%0A%0AWhen%20at%20least%20one%20filename%20resolves%2C%20this%20returns%20only%20the%20images%20loaded%20from%20filenames%20and%20skips%20all%20inline%20data.%20Partially%20migrated%20entries%20can%20have%20a%20primary%20filename%20alongside%20additional%20inline%20photos%2C%20so%20their%20full-screen%20viewer%20shows%20fewer%20photos%20than%20the%20entry%20contains.%20Merge%20the%20resolved%20filename%20images%20with%20the%20remaining%20inline%20images%20instead%20of%20using%20an%20all-or-nothing%20fallback.%0A%0A%23%23%23%20Issue%203%0Aios%2Fcalorietracker%2FModels%2FFoodEntry.swift%3A704%0A**Photo%20copy%20blocks%20UI**%0A%0ACopying%20or%20re-logging%20a%20disk-backed%20meal%20now%20calls%20%60allImageData%60%20directly%20from%20SwiftUI%20actions.%20That%20synchronously%20reads%20every%20full-resolution%20photo%20with%20%60Data%28contentsOf%3A%29%60%2C%20so%20meals%20with%20several%20photos%20can%20freeze%20the%20UI%20while%20the%20files%20load.%20Move%20the%20photo%20hydration%20off%20the%20main%20actor%20before%20constructing%20the%20duplicate.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=282&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
ios/calorietracker/Models/FoodEntry.swift:704
**Ingredient photos get duplicated**

When a meal with ingredient photos is copied or re-logged, `allImageData` includes those ingredient photos as top-level media. The duplicate also retains the ingredients and their original photo filenames, so saving it stores the ingredient photos again as additional meal photos. This produces duplicate viewer and gallery content and creates unnecessary image files. Hydrate only the entry's primary and additional photos here.

### Issue 2
ios/calorietracker/Views/FoodEntryThumbnailView.swift:71-77
**Mixed photos disappear**

When at least one filename resolves, this returns only the images loaded from filenames and skips all inline data. Partially migrated entries can have a primary filename alongside additional inline photos, so their full-screen viewer shows fewer photos than the entry contains. Merge the resolved filename images with the remaining inline images instead of using an all-or-nothing fallback.

### Issue 3
ios/calorietracker/Models/FoodEntry.swift:704
**Photo copy blocks UI**

Copying or re-logging a disk-backed meal now calls `allImageData` directly from SwiftUI actions. That synchronously reads every full-resolution photo with `Data(contentsOf:)`, so meals with several photos can freeze the UI while the files load. Move the photo hydration off the main actor before constructing the duplicate.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix Greptile review: photo duplicate, li..."](https://github.com/apoorvdarshan/fud-ai/commit/2b6d56bbf5b5f0c3fdb82b24be9ce7f2b49d74bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63405924)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->