### PR TITLE
Smooth Android food list photo thumbnails

### DIFF
--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/FoodImageStore.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/FoodImageStore.kt
@@ -11,6 +11,7 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Local food-photo cache. Port of iOS FoodImageStore.
@@ -27,6 +28,7 @@ class FoodImageStore private constructor(
     private val thumbnailCache = object : LruCache<String, Bitmap>(thumbnailCacheKb) {
         override fun sizeOf(key: String, value: Bitmap): Int = value.byteCount / 1024
     }
+    private val thumbnailLocks = ConcurrentHashMap<String, Any>()
 
     constructor(context: Context) : this(
         rootDir = context.filesDir,
@@ -72,19 +74,23 @@ class FoodImageStore private constructor(
         val key = "$filename:$maxDimension"
         thumbnailCache.get(key)?.takeUnless { it.isRecycled }?.let { return it }
 
-        val thumbFile = File(thumbnailDir, filename)
-        val bitmap = when {
-            thumbFile.exists() -> runCatching {
-                FoodImageDecoder.decode(thumbFile, maxDimension)
-            }.getOrNull()
-            else -> runCatching {
-                val fullFile = File(dir, filename)
-                FoodImageDecoder.decode(fullFile, maxDimension)?.also { writeThumbnail(filename, it) }
-            }.getOrNull()
-        }
+        synchronized(thumbnailLockFor(filename)) {
+            thumbnailCache.get(key)?.takeUnless { it.isRecycled }?.let { return it }
 
-        if (bitmap != null) thumbnailCache.put(key, bitmap)
-        return bitmap
+            val thumbFile = File(thumbnailDir, filename)
+            val bitmap = when {
+                thumbFile.exists() -> runCatching {
+                    FoodImageDecoder.decode(thumbFile, maxDimension)
+                }.getOrNull()
+                else -> runCatching {
+                    val fullFile = File(dir, filename)
+                    FoodImageDecoder.decode(fullFile, maxDimension)?.also { writeThumbnail(filename, it) }
+                }.getOrNull()
+            }
+
+            if (bitmap != null) thumbnailCache.put(key, bitmap)
+            return bitmap
+        }
     }
 
     /** Prefetch thumbnails into memory/disk cache. Call from a background dispatcher. */
@@ -162,11 +168,25 @@ class FoodImageStore private constructor(
 
     private fun writeThumbnail(filename: String, bitmap: Bitmap) {
         val thumb = bitmap.scaledToMaxDimension(THUMBNAIL_MAX_DIMENSION)
-        FileOutputStream(File(thumbnailDir, filename)).use { out ->
-            thumb.compress(Bitmap.CompressFormat.JPEG, 76, out)
+        val target = File(thumbnailDir, filename)
+        val temp = File(thumbnailDir, "$filename.${UUID.randomUUID()}.tmp")
+        try {
+            FileOutputStream(temp).use { out ->
+                thumb.compress(Bitmap.CompressFormat.JPEG, 76, out)
+            }
+            if (!temp.renameTo(target)) {
+                temp.copyTo(target, overwrite = true)
+                temp.delete()
+            }
+            thumbnailCache.put("$filename:$THUMBNAIL_MAX_DIMENSION", thumb)
+        } catch (e: Exception) {
+            temp.delete()
+            throw e
         }
-        thumbnailCache.put("$filename:$THUMBNAIL_MAX_DIMENSION", thumb)
     }
+
+    private fun thumbnailLockFor(filename: String): Any =
+        thumbnailLocks.getOrPut(filename) { Any() }
 
     private fun evictThumbnails(filename: String) {
         for (key in thumbnailCache.snapshot().keys) {

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/FoodImageStore.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/services/FoodImageStore.kt
@@ -1,5 +1,6 @@
 package com.apoorvdarshan.calorietracker.services
 
+import android.app.ActivityManager
 import android.content.Context
 import android.graphics.Bitmap
 import android.util.LruCache
@@ -18,15 +19,20 @@ import java.util.UUID
  */
 class FoodImageStore private constructor(
     rootDir: File,
-    cleanupLegacyThumbnails: Boolean
+    cleanupLegacyThumbnails: Boolean,
+    thumbnailCacheKb: Int
 ) {
     private val dir: File = File(rootDir, DIR_NAME).apply { mkdirs() }
     private val thumbnailDir: File = File(rootDir, THUMBNAIL_DIR_NAME).apply { mkdirs() }
-    private val thumbnailCache = object : LruCache<String, Bitmap>(THUMBNAIL_CACHE_KB) {
+    private val thumbnailCache = object : LruCache<String, Bitmap>(thumbnailCacheKb) {
         override fun sizeOf(key: String, value: Bitmap): Int = value.byteCount / 1024
     }
 
-    constructor(context: Context) : this(context.filesDir, cleanupLegacyThumbnails = true)
+    constructor(context: Context) : this(
+        rootDir = context.filesDir,
+        cleanupLegacyThumbnails = true,
+        thumbnailCacheKb = thumbnailCacheKbFor(context)
+    )
 
     init {
         if (cleanupLegacyThumbnails) {
@@ -79,6 +85,14 @@ class FoodImageStore private constructor(
 
         if (bitmap != null) thumbnailCache.put(key, bitmap)
         return bitmap
+    }
+
+    /** Prefetch thumbnails into memory/disk cache. Call from a background dispatcher. */
+    fun warmThumbnails(filenames: Collection<String>) {
+        filenames.asSequence()
+            .filter { it.isNotBlank() }
+            .distinct()
+            .forEach { loadThumbnail(it) }
     }
 
     fun file(filename: String): File = File(dir, filename)
@@ -165,10 +179,24 @@ class FoodImageStore private constructor(
         private const val THUMBNAIL_DIR_NAME = "fudai-food-thumbnails-v2"
         private const val THUMBNAIL_MAX_DIMENSION = 320
         const val VIEWER_MAX_DIMENSION = 2048
-        private const val THUMBNAIL_CACHE_KB = 12 * 1024
+        private const val THUMBNAIL_CACHE_KB_DEFAULT = 12 * 1024
+
+        fun thumbnailCacheKbFor(context: Context): Int {
+            val memoryClass =
+                (context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager).memoryClass
+            return when {
+                memoryClass <= 128 -> 4 * 1024
+                memoryClass <= 192 -> 8 * 1024
+                else -> THUMBNAIL_CACHE_KB_DEFAULT
+            }
+        }
 
         @VisibleForTesting
         fun forTests(baseDir: File): FoodImageStore =
-            FoodImageStore(baseDir.apply { mkdirs() }, cleanupLegacyThumbnails = false)
+            FoodImageStore(
+                baseDir.apply { mkdirs() },
+                cleanupLegacyThumbnails = false,
+                thumbnailCacheKb = THUMBNAIL_CACHE_KB_DEFAULT
+            )
     }
 }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/FoodThumbnailState.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/FoodThumbnailState.kt
@@ -1,0 +1,39 @@
+package com.apoorvdarshan.calorietracker.ui.components
+
+import android.graphics.Bitmap
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import com.apoorvdarshan.calorietracker.services.FoodImageStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/** Loads a food photo thumbnail off the composition thread; shows null until ready. */
+@Composable
+fun rememberFoodThumbnail(
+    imageStore: FoodImageStore,
+    filename: String?,
+): Bitmap? {
+    val bitmap by produceState<Bitmap?>(initialValue = null, filename, imageStore) {
+        value = filename?.let { name ->
+            withContext(Dispatchers.IO) {
+                imageStore.loadThumbnail(name)
+            }
+        }
+    }
+    return bitmap
+}
+
+/** Loads the first available thumbnail from [filenames] off the composition thread. */
+@Composable
+fun rememberFoodThumbnail(
+    imageStore: FoodImageStore,
+    filenames: List<String>,
+): Bitmap? {
+    val bitmap by produceState<Bitmap?>(initialValue = null, filenames, imageStore) {
+        value = withContext(Dispatchers.IO) {
+            filenames.firstNotNullOfOrNull { imageStore.loadThumbnail(it) }
+        }
+    }
+    return bitmap
+}

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/FoodThumbnailState.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/FoodThumbnailState.kt
@@ -15,6 +15,7 @@ fun rememberFoodThumbnail(
     filename: String?,
 ): Bitmap? {
     val bitmap by produceState<Bitmap?>(initialValue = null, filename, imageStore) {
+        value = null
         value = filename?.let { name ->
             withContext(Dispatchers.IO) {
                 imageStore.loadThumbnail(name)
@@ -31,6 +32,7 @@ fun rememberFoodThumbnail(
     filenames: List<String>,
 ): Bitmap? {
     val bitmap by produceState<Bitmap?>(initialValue = null, filenames, imageStore) {
+        value = null
         value = withContext(Dispatchers.IO) {
             filenames.firstNotNullOfOrNull { imageStore.loadThumbnail(it) }
         }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt
@@ -175,6 +175,7 @@ import com.apoorvdarshan.calorietracker.models.WaterUnit
 import com.apoorvdarshan.calorietracker.services.ai.FoodAnalysis
 import com.apoorvdarshan.calorietracker.ui.components.InAppCameraCaptureDialog
 import com.apoorvdarshan.calorietracker.ui.components.FullScreenImageViewer
+import com.apoorvdarshan.calorietracker.ui.components.rememberFoodThumbnail
 import com.apoorvdarshan.calorietracker.ui.components.MacroCard
 import com.apoorvdarshan.calorietracker.ui.components.DateWheelPicker
 import com.apoorvdarshan.calorietracker.ui.components.FudGlassDialog
@@ -2409,9 +2410,7 @@ private fun FoodRow(
     val container = (ctx.applicationContext as com.apoorvdarshan.calorietracker.FudAIApp).container
     val scope = rememberCoroutineScope()
     val hasPhotos = entry.allImageFilenames.isNotEmpty()
-    val bitmap = remember(entry.allImageFilenames) {
-        entry.allImageFilenames.firstNotNullOfOrNull { container.imageStore.loadThumbnail(it) }
-    }
+    val bitmap = rememberFoodThumbnail(container.imageStore, entry.allImageFilenames)
     var previewPhotos by remember { mutableStateOf<Pair<List<android.graphics.Bitmap>, Int>?>(null) }
     var isLoadingPreview by remember { mutableStateOf(false) }
     // iOS layout: large 76dp square thumb · column with (Name + heart on left,

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import java.time.Instant
 import java.time.LocalDate
@@ -133,6 +134,8 @@ private val _stepsRefreshEpoch = MutableStateFlow(0)
     private val _burnRefreshTick = MutableStateFlow(0)
     private var retryAction: (() -> Unit)? = null
     private val foodSubmissionGate = FoodSubmissionGate()
+    private var thumbnailPrefetchJob: Job? = null
+    private var lastPrefetchedFilenames: Set<String>? = null
 
     /** Re-read Health Connect energy after resume or other external invalidation. */
     fun bumpBurnRefresh() {
@@ -161,10 +164,15 @@ private val _stepsRefreshEpoch = MutableStateFlow(0)
         }
             .onEach { state ->
                 _ui.value = state
-                viewModelScope.launch(Dispatchers.IO) {
-                    container.imageStore.warmThumbnails(
-                        state.todayEntries.flatMap { it.allImageFilenames }
-                    )
+                val filenames = state.todayEntries
+                    .flatMap { it.allImageFilenames }
+                    .filter { it.isNotBlank() }
+                    .toSet()
+                if (filenames == lastPrefetchedFilenames) return@onEach
+                lastPrefetchedFilenames = filenames
+                thumbnailPrefetchJob?.cancel()
+                thumbnailPrefetchJob = viewModelScope.launch(Dispatchers.IO) {
+                    container.imageStore.warmThumbnails(filenames)
                 }
             }
             .launchIn(viewModelScope)

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt
@@ -23,6 +23,7 @@ import com.apoorvdarshan.calorietracker.ui.components.autoSaveMealPhotoIfEnabled
 import com.apoorvdarshan.calorietracker.services.ai.AiError
 import com.apoorvdarshan.calorietracker.services.ai.FoodAnalysis
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -158,7 +159,14 @@ private val _stepsRefreshEpoch = MutableStateFlow(0)
                 favoriteKeys = favKeys
             )
         }
-            .onEach { _ui.value = it }
+            .onEach { state ->
+                _ui.value = state
+                viewModelScope.launch(Dispatchers.IO) {
+                    container.imageStore.warmThumbnails(
+                        state.todayEntries.flatMap { it.allImageFilenames }
+                    )
+                }
+            }
             .launchIn(viewModelScope)
 
         container.prefs.homeTopNutrients

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/MealIngredientsUi.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/MealIngredientsUi.kt
@@ -7,7 +7,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import com.apoorvdarshan.calorietracker.FudAIApp
 import com.apoorvdarshan.calorietracker.services.FoodImageStore
+import com.apoorvdarshan.calorietracker.ui.components.rememberFoodThumbnail
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -61,8 +63,13 @@ internal fun MealIngredientsCard(
     ingredients: List<MealIngredient>,
     onEdit: (Int) -> Unit,
     onAdd: () -> Unit = {},
-    addMenu: (@Composable () -> Unit)? = null
+    addMenu: (@Composable () -> Unit)? = null,
+    imageStore: FoodImageStore? = null
 ) {
+    val context = LocalContext.current
+    val store = imageStore ?: remember(context) {
+        (context.applicationContext as FudAIApp).container.imageStore
+    }
     SheetPillCard {
         if (ingredients.isEmpty()) {
             Text(
@@ -82,11 +89,7 @@ internal fun MealIngredientsCard(
                     verticalArrangement = Arrangement.spacedBy(5.dp)
                 ) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
-                        val context = LocalContext.current
-                        val store = remember(context) { FoodImageStore(context) }
-                        val thumbnail = remember(ingredient.imageFilename) {
-                            ingredient.imageFilename?.let { store.loadThumbnail(it) }
-                        }
+                        val thumbnail = rememberFoodThumbnail(store, ingredient.imageFilename)
                         if (thumbnail != null) {
                             Image(thumbnail.asImageBitmap(), contentDescription = null,
                                 modifier = Modifier.size(44.dp).clip(RoundedCornerShape(10.dp)),

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/SavedMealsSheet.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/SavedMealsSheet.kt
@@ -82,6 +82,7 @@ import com.apoorvdarshan.calorietracker.data.FrequentFoodGroup
 import com.apoorvdarshan.calorietracker.models.FoodEntry
 import com.apoorvdarshan.calorietracker.models.MacroValueFormatter
 import com.apoorvdarshan.calorietracker.services.FoodImageStore
+import com.apoorvdarshan.calorietracker.ui.components.rememberFoodThumbnail
 import com.apoorvdarshan.calorietracker.ui.theme.AppColors
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
@@ -644,7 +645,7 @@ private fun SavedMealRow(
 @Composable
 private fun Thumbnail(emoji: String?, imageFilename: String?, imageStore: FoodImageStore) {
     val shape = RoundedCornerShape(12.dp)
-    val bitmap = remember(imageFilename) { imageFilename?.let { imageStore.loadThumbnail(it) } }
+    val bitmap = rememberFoodThumbnail(imageStore, imageFilename)
 
     Box(
         Modifier


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes scroll hitching on low-RAM Android devices (~3GB) when the home food diary lists many photo meals.

**Root cause:** `FoodRow`, `SavedMealsSheet.Thumbnail`, and `MealIngredientsUi` called `FoodImageStore.loadThumbnail()` inside `remember { }` on the composition/main thread. Cache misses triggered file I/O and JPEG decode under the user's finger while scrolling.

**Changes:**
- Added `rememberFoodThumbnail()` composable helper using `produceState` + `Dispatchers.IO` — shows the same emoji/placeholder until the bitmap is ready, then the same 56–76dp cropped thumb.
- Updated `FoodRow` (Home diary), `SavedMealsSheet.Thumbnail`, and `MealIngredientsUi` to use async loading.
- `MealIngredientsUi` now reuses the app-scoped `FoodImageStore` (shared LRU) instead of creating a new store per row.
- `HomeViewModel` prefetches today's diary thumbnails on IO after entries update (`FoodImageStore.warmThumbnails`).
- `FoodImageStore` in-memory LRU sized from `ActivityManager.memoryClass` (4 MB ≤128, 8 MB ≤192, 12 MB otherwise) — same thumb appearance, less memory pressure on low-RAM phones.

No visible design changes. Food logging, edit, and camera flows untouched.

## Test plan

- [ ] On a ~3GB Android phone, log 15+ meals with photos for today
- [ ] Scroll the Home food diary rapidly — verify no frame drops / jank; thumbs fade in from emoji placeholder
- [ ] Confirm thumb size (76dp Home, 56dp Saved Meals) and crop unchanged once loaded
- [ ] Tap a photo row → full-screen viewer still loads correctly
- [ ] Open Saved Meals → Recents/Favorites with photos scroll smoothly
- [ ] Open a multi-ingredient meal sheet → ingredient thumbs load without blocking scroll
- [ ] Switch diary days → thumbs for the new day prefetch and appear smoothly
- [ ] Verify emoji-only entries still show emoji immediately (no regression)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29d8515e-ab14-4c6a-85bd-881e52ba1202?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29d8515e-ab14-4c6a-85bd-881e52ba1202&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved food thumbnail loading with asynchronous loading and support for trying multiple image sources.
  - Food thumbnails now prefetch in the background for faster display.
  - Thumbnail caching adjusts to device memory for improved performance and reliability.
  - Ingredient image components can reuse a shared image store for more consistent thumbnail handling.
  - Thumbnail updates are handled more reliably during simultaneous loading and interrupted saves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves food-thumbnail loading and prefetching off the UI thread, shares the application-scoped image cache across food views, coordinates concurrent thumbnail generation, and sizes the in-memory cache according to Android device memory.
- Adds asynchronous Compose thumbnail state for single and multiple image sources.
- Prefetches distinct thumbnails for the selected diary day and cancels superseded prefetch jobs.
- Serializes thumbnail generation per filename and uses temporary files before replacement.
- Updates Home, Saved Meals, and ingredient rows to use shared asynchronous thumbnail loading.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with only the previously reported non-blocking lifetime growth of the thumbnail lock map still outstanding.

No new actionable failures were found. The earlier stale-thumbnail, concurrent-write, and accumulating-prefetch findings are fixed, while the existing thumbnail-lock finding remains unresolved because thumbnailLocks still permanently retains one entry for every filename passed to thumbnailLockFor.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/src/main/java/com/apoorvdarshan/calorietracker/services/FoodImageStore.kt | Adds memory-aware caching, per-filename synchronization, atomic thumbnail writes, and prefetch support; the previously reported unbounded lock map remains. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/components/FoodThumbnailState.kt | Introduces lifecycle-aware asynchronous thumbnail loaders that clear stale state when their keys change. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeScreen.kt | Replaces synchronous diary-row thumbnail decoding with the asynchronous helper. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/HomeViewModel.kt | Prefetches distinct selected-day thumbnail sets on IO while cancelling superseded work. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/MealIngredientsUi.kt | Loads ingredient thumbnails asynchronously through the shared application image store. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/home/SavedMealsSheet.kt | Replaces synchronous saved-meal thumbnail decoding with asynchronous loading. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Food row enters composition] --> B[Show emoji or placeholder]
  B --> C[rememberFoodThumbnail]
  C --> D[Load on Dispatchers.IO]
  D --> E{Memory or disk cache hit?}
  E -->|Yes| F[Publish bitmap state]
  E -->|No| G[Lock by filename]
  G --> H[Decode original and write temporary thumbnail]
  H --> I[Rename thumbnail and populate LRU]
  I --> F
  F --> J[Render cropped thumbnail]
  K[Home state update] --> L[Distinct filename set]
  L --> M[Cancel superseded prefetch]
  M --> D
```

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;cursor/android-food-thumb-..."](https://github.com/apoorvdarshan/fud-ai/commit/0c7cd840d55a69e6595e3a9d59ea3adc2ae13219) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63405927)</sub>

<!-- /greptile_comment -->