### PR TITLE
Fix iOS FoodImageStore thumbnailFolderURL bind

### DIFF
--- a/ios/calorietracker/Services/FoodImageStore.swift
+++ b/ios/calorietracker/Services/FoodImageStore.swift
@@ -176,7 +176,8 @@ struct FoodImageStore {
     }
 
     private func writeThumbnail(_ image: UIImage, filename: String) {
-        guard let thumbFolderURL, let data = image.jpegData(compressionQuality: 0.76) else { return }
+        guard let thumbFolderURL = thumbnailFolderURL,
+              let data = image.jpegData(compressionQuality: 0.76) else { return }
         let url = thumbFolderURL.appendingPathComponent(filename)
         try? data.write(to: url, options: .atomic)
     }


### PR DESCRIPTION
## Summary
- Fixes Release compile error from #282: `writeThumbnail` referenced `thumbFolderURL` without binding `thumbnailFolderURL`.

## Test plan
- [x] `xcodebuild` Release for device compiles past FoodImageStore.swift


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the iOS Release compilation failure in `FoodImageStore.writeThumbnail` by explicitly binding the thumbnail directory property to the local URL used for writes.
- Correctly binds `thumbnailFolderURL` as `thumbFolderURL`.
- Preserves existing thumbnail encoding and atomic-write behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the corrected binding targets the intended property and introduces no behavioral regression.

The change is a narrowly scoped compile fix that retains the existing early-return, JPEG encoding, path construction, and atomic-write semantics.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ios/calorietracker/Services/FoodImageStore.swift | Explicitly binds the existing optional thumbnail-folder property, resolving the compile error without changing runtime behavior. |

<sub>Reviews (1): Last reviewed commit: ["Fix iOS Release build: bind thumbnailFol..."](https://github.com/apoorvdarshan/fud-ai/commit/16b87b3b08d1b55bf89a2c4f5e57fbe2d0297fb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63408107)</sub>

<!-- /greptile_comment -->