### PR TITLE
Add Instagram follow link in Settings About Community section

### DIFF
--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/about/AboutScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/about/AboutScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AlternateEmail
+import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Work
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.CheckCircle
@@ -209,6 +210,10 @@ fun AboutSettingsRows(category: AboutSettingsCategory) {
                 Hairline()
                 AboutRow(Icons.Filled.Work, stringResource(R.string.about_follow_linkedin)) {
                     open("https://www.linkedin.com/company/fud-ai-app")
+                }
+                Hairline()
+                AboutRow(Icons.Filled.CameraAlt, stringResource(R.string.about_follow_instagram)) {
+                    open("https://www.instagram.com/apoorvcodes/")
                 }
             }
 

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -615,6 +615,7 @@
     <string name="about_contact">اتصل بنا</string>
     <string name="about_follow_x">تابعنا على X</string>
     <string name="about_follow_linkedin">تابعنا على LinkedIn</string>
+    <string name="about_follow_instagram">تابعنا على Instagram</string>
     <string name="about_privacy">سياسة الخصوصية</string>
     <string name="about_terms">شروط الخدمة</string>
     <string name="about_category_app_updates">التطبيق والتحديثات</string>

--- a/android/app/src/main/res/values-az/strings.xml
+++ b/android/app/src/main/res/values-az/strings.xml
@@ -603,6 +603,7 @@
     <string name="about_contact">Bizimlə Əlaqə</string>
     <string name="about_follow_x">X-də İzlə</string>
     <string name="about_follow_linkedin">LinkedIn-də İzlə</string>
+    <string name="about_follow_instagram">Instagram-da İzlə</string>
     <string name="about_privacy">Məxfilik Siyasəti</string>
     <string name="about_terms">Xidmət Şərtləri</string>
     <string name="about_category_app_updates">Tətbiq və Yeniləmələr</string>

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -661,6 +661,7 @@
     <string name="about_contact">Kontaktuj nás</string>
     <string name="about_follow_x">Sledovat na X</string>
     <string name="about_follow_linkedin">Sledovat na LinkedInu</string>
+    <string name="about_follow_instagram">Sledovat na Instagramu</string>
     <string name="about_privacy">Zásady ochrany soukromí</string>
     <string name="about_terms">Podmínky služby</string>
     <string name="about_made_by">Vytvořil Apoorv Darshan</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -603,6 +603,7 @@
     <string name="about_contact">Kontakt</string>
     <string name="about_follow_x">Auf X folgen</string>
     <string name="about_follow_linkedin">Auf LinkedIn folgen</string>
+    <string name="about_follow_instagram">Auf Instagram folgen</string>
     <string name="about_privacy">Datenschutzrichtlinie</string>
     <string name="about_terms">Nutzungsbedingungen</string>
     <string name="about_category_app_updates">App &amp; Updates</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -604,6 +604,7 @@
     <string name="about_contact">Contáctanos</string>
     <string name="about_follow_x">Seguir en X</string>
     <string name="about_follow_linkedin">Seguir en LinkedIn</string>
+    <string name="about_follow_instagram">Seguir en Instagram</string>
     <string name="about_privacy">Política de privacidad</string>
     <string name="about_terms">Términos del servicio</string>
     <string name="about_category_app_updates">Aplicación y actualizaciones</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -604,6 +604,7 @@
     <string name="about_contact">Nous contacter</string>
     <string name="about_follow_x">Suivre sur X</string>
     <string name="about_follow_linkedin">Suivre sur LinkedIn</string>
+    <string name="about_follow_instagram">Suivre sur Instagram</string>
     <string name="about_privacy">Politique de confidentialité</string>
     <string name="about_terms">Conditions d\'utilisation</string>
     <string name="about_category_app_updates">Application et mises à jour</string>

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -603,6 +603,7 @@
     <string name="about_contact">संपर्क करें</string>
     <string name="about_follow_x">X पर फॉलो करें</string>
     <string name="about_follow_linkedin">LinkedIn पर फॉलो करें</string>
+    <string name="about_follow_instagram">Instagram पर फॉलो करें</string>
     <string name="about_privacy">गोपनीयता नीति</string>
     <string name="about_terms">सेवा की शर्तें</string>
     <string name="about_category_app_updates">ऐप और अपडेट</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -604,6 +604,7 @@
     <string name="about_contact">Contattaci</string>
     <string name="about_follow_x">Seguici su X</string>
     <string name="about_follow_linkedin">Segui su LinkedIn</string>
+    <string name="about_follow_instagram">Segui su Instagram</string>
     <string name="about_privacy">Informativa sulla privacy</string>
     <string name="about_terms">Termini di servizio</string>
     <string name="about_category_app_updates">App e aggiornamenti</string>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -602,6 +602,7 @@
     <string name="about_contact">お問い合わせ</string>
     <string name="about_follow_x">Xでフォロー</string>
     <string name="about_follow_linkedin">LinkedInでフォロー</string>
+    <string name="about_follow_instagram">Instagramでフォロー</string>
     <string name="about_privacy">プライバシーポリシー</string>
     <string name="about_terms">利用規約</string>
     <string name="about_category_app_updates">アプリとアップデート</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -602,6 +602,7 @@
     <string name="about_contact">문의하기</string>
     <string name="about_follow_x">X에서 팔로우</string>
     <string name="about_follow_linkedin">LinkedIn에서 팔로우</string>
+    <string name="about_follow_instagram">Instagram에서 팔로우</string>
     <string name="about_privacy">개인정보 처리방침</string>
     <string name="about_terms">서비스 약관</string>
     <string name="about_category_app_updates">앱 및 업데이트</string>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -603,6 +603,7 @@
     <string name="about_contact">Neem contact op</string>
     <string name="about_follow_x">Volg op X</string>
     <string name="about_follow_linkedin">Volg op LinkedIn</string>
+    <string name="about_follow_instagram">Volg op Instagram</string>
     <string name="about_privacy">Privacybeleid</string>
     <string name="about_terms">Servicevoorwaarden</string>
     <string name="about_category_app_updates">App &amp; updates</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -609,6 +609,7 @@
     <string name="about_contact">Kontakt</string>
     <string name="about_follow_x">Obserwuj na X</string>
     <string name="about_follow_linkedin">Obserwuj na LinkedIn</string>
+    <string name="about_follow_instagram">Obserwuj na Instagram</string>
     <string name="about_privacy">Polityka prywatności</string>
     <string name="about_terms">Warunki korzystania</string>
     <string name="about_category_app_updates">Aplikacja i aktualizacje</string>

--- a/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -604,6 +604,7 @@
     <string name="about_contact">Fale conosco</string>
     <string name="about_follow_x">Seguir no X</string>
     <string name="about_follow_linkedin">Seguir no LinkedIn</string>
+    <string name="about_follow_instagram">Seguir no Instagram</string>
     <string name="about_privacy">Política de privacidade</string>
     <string name="about_terms">Termos de serviço</string>
     <string name="about_category_app_updates">App e atualizações</string>

--- a/android/app/src/main/res/values-ro/strings.xml
+++ b/android/app/src/main/res/values-ro/strings.xml
@@ -606,6 +606,7 @@
     <string name="about_contact">Contactează-ne</string>
     <string name="about_follow_x">Urmărește pe X</string>
     <string name="about_follow_linkedin">Urmărește pe LinkedIn</string>
+    <string name="about_follow_instagram">Urmărește pe Instagram</string>
     <string name="about_privacy">Politica de confidențialitate</string>
     <string name="about_terms">Termenii serviciului</string>
     <string name="about_category_app_updates">Aplicație și actualizări</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -609,6 +609,7 @@
     <string name="about_contact">Связаться с нами</string>
     <string name="about_follow_x">Подписаться в X</string>
     <string name="about_follow_linkedin">Подписаться в LinkedIn</string>
+    <string name="about_follow_instagram">Подписаться в Instagram</string>
     <string name="about_privacy">Политика конфиденциальности</string>
     <string name="about_terms">Условия использования</string>
     <string name="about_category_app_updates">Приложение и обновления</string>

--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -911,6 +911,7 @@
     <string name="about_contact">Зв\'язатися з нами</string>
     <string name="about_follow_x">Стежити в X</string>
     <string name="about_follow_linkedin">Стежити в LinkedIn</string>
+    <string name="about_follow_instagram">Стежити в Instagram</string>
     <string name="about_privacy">Політика конфіденційності</string>
     <string name="about_terms">Умови використання</string>
     <string name="about_litert_notices">Сповіщення сторонніх компонентів LiteRT-LM</string>

--- a/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -602,6 +602,7 @@
     <string name="about_contact">联系我们</string>
     <string name="about_follow_x">在 X 上关注</string>
     <string name="about_follow_linkedin">在 LinkedIn 上关注</string>
+    <string name="about_follow_instagram">在 Instagram 上关注</string>
     <string name="about_privacy">隐私政策</string>
     <string name="about_terms">服务条款</string>
     <string name="about_category_app_updates">应用与更新</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -904,6 +904,7 @@
     <string name="about_contact">Contact Us</string>
     <string name="about_follow_x">Follow on X</string>
     <string name="about_follow_linkedin">Follow on LinkedIn</string>
+    <string name="about_follow_instagram">Follow on Instagram</string>
     <string name="about_privacy">Privacy Policy</string>
     <string name="about_terms">Terms of Service</string>
     <string name="about_litert_notices">LiteRT-LM third-party notices</string>

--- a/ios/calorietracker/ContentView.swift
+++ b/ios/calorietracker/ContentView.swift
@@ -452,6 +452,16 @@ private struct AboutSettingsSections: View {
                     }
                 }
                 .tint(.primary)
+
+                Link(destination: URL(string: "https://www.instagram.com/apoorvcodes/")!) {
+                    Label {
+                        Text("Follow on Instagram")
+                    } icon: {
+                        Image(systemName: "camera.fill")
+                            .foregroundStyle(AppColors.calorie)
+                    }
+                }
+                .tint(.primary)
                 }
                 .listRowBackground(AppColors.appCard)
 

--- a/ios/calorietrackerUITests/calorietrackerUITests.swift
+++ b/ios/calorietrackerUITests/calorietrackerUITests.swift
@@ -149,7 +149,7 @@ final class calorietrackerUITests: XCTestCase {
             XCTAssertTrue(action.waitForExistence(timeout: 3), "Missing \(expectedAction) in \(title)")
 
             if identifier == "community" {
-                XCTAssertFalse(app.staticTexts["Follow on Instagram"].exists)
+                XCTAssertTrue(app.staticTexts["Follow on Instagram"].exists)
                 XCTAssertTrue(app.staticTexts["Follow on LinkedIn"].exists)
             }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Follow on Instagram** row for [@apoorvcodes](https://www.instagram.com/apoorvcodes/) in Settings → About → **Community**, matching the existing X and LinkedIn rows on both platforms.

## Changes

### iOS
- Added a third `Link` in the Community section of `ContentView.swift`
- Title: "Follow on Instagram"
- URL: https://www.instagram.com/apoorvcodes/
- Icon: `camera.fill` (consistent with existing SF Symbol pattern)

### Android
- Added an `AboutRow` after LinkedIn in `AboutScreen.kt`
- Uses `Icons.Filled.CameraAlt` and `about_follow_instagram` string resource
- URL: https://www.instagram.com/apoorvcodes/

### Localizations
- Added `about_follow_instagram` to `values/strings.xml` and all 17 existing locale files that already had `about_follow_x` / `about_follow_linkedin`

### Tests
- Updated iOS UI test to assert the Instagram row is present in the Community section

## Notes
- X and LinkedIn links are unchanged
- No build config or unrelated code touched
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db208a7e-7597-4683-8f2b-e998ae7fe611?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db208a7e-7597-4683-8f2b-e998ae7fe611&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an Instagram community link to the About settings on Android and iOS.
- Uses the established platform-specific social-link row patterns.
- Adds the Android label to the base resources and all 17 existing translations.
- Updates the iOS UI test to expect the new Community row.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, security, or repository-rule issues identified.

Both platform implementations follow established link patterns, Android localization coverage is complete, and the updated test reflects the newly added row.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/about/AboutScreen.kt | Adds a localized Instagram row using the existing external-link behavior. |
| android/app/src/main/res/values/strings.xml | Defines the default English label, with matching additions across all existing localized resources. |
| ios/calorietracker/ContentView.swift | Adds an Instagram link to the Community section using the same structure as the existing social links. |
| ios/calorietrackerUITests/calorietrackerUITests.swift | Updates the Community UI assertion to require the Instagram label. |

<sub>Reviews (1): Last reviewed commit: ["Add Instagram follow link in Settings Ab..."](https://github.com/apoorvdarshan/fud-ai/commit/8fc68a38a711d46fda30ad439c32bbadda7d0c8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63410416)</sub>

<!-- /greptile_comment -->