### PR TITLE
Watch Home: water as 4th pillar

### DIFF
--- a/ios/FudAIWatchApp/WatchNutritionView.swift
+++ b/ios/FudAIWatchApp/WatchNutritionView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 /// Mini iPhone-Home for the wrist: the speedometer calorie gauge on top and the
-/// user's 4 selected nutrients as vertical fill bars beneath, all tinted with
-/// the theme gradient synced from the phone (Fud Pink by default).
+/// user's Home nutrient pillars beneath (Water is the locked 4th pillar when
+/// tracking is enabled — same as iPhone), tinted with the theme gradient.
 struct WatchNutritionView: View {
     @EnvironmentObject private var receiver: WatchSnapshotReceiver
     @State private var showsWaterLogger = false
@@ -14,38 +14,31 @@ struct WatchNutritionView: View {
         ]
     }
 
-    private var showsWater: Bool {
-        receiver.snapshot.waterIsEnabled
-    }
-
     var body: some View {
-        VStack(spacing: showsWater ? 3 : 6) {
+        VStack(spacing: 6) {
             WatchCalorieGauge(
                 eaten: receiver.snapshot.calories,
                 remaining: receiver.snapshot.caloriesRemaining,
                 progress: receiver.snapshot.calorieProgress,
-                gradient: themeGradient,
-                compact: showsWater
+                gradient: themeGradient
             )
 
-            HStack(alignment: .top, spacing: showsWater ? 4 : 6) {
+            HStack(alignment: .top, spacing: 6) {
                 ForEach(receiver.snapshot.displayedHomeNutrients) { nutrient in
-                    WatchNutrientBar(
-                        nutrient: nutrient,
-                        gradient: themeGradient,
-                        compact: showsWater
-                    )
+                    if nutrient.id == "water" {
+                        Button {
+                            showsWaterLogger = true
+                        } label: {
+                            WatchNutrientBar(nutrient: nutrient, gradient: themeGradient)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Add water")
+                        .accessibilityValue("\(nutrient.displayValue) of \(nutrient.displayGoal)\(nutrient.unit)")
+                        .accessibilityHint("Opens quick water amounts")
+                    } else {
+                        WatchNutrientBar(nutrient: nutrient, gradient: themeGradient)
+                    }
                 }
-            }
-
-            if showsWater {
-                Button {
-                    showsWaterLogger = true
-                } label: {
-                    WatchWaterProgress(snapshot: receiver.snapshot, gradient: themeGradient)
-                }
-                .buttonStyle(.plain)
-                .padding(.top, 2)
             }
         }
         .padding(.horizontal, 4)
@@ -57,72 +50,6 @@ struct WatchNutritionView: View {
             WatchWaterLogView(gradient: themeGradient)
                 .environmentObject(receiver)
         }
-    }
-}
-
-/// A compact extension of the existing nutrition dashboard. It only appears
-/// when Water Tracking is enabled on the paired iPhone and uses the same unit,
-/// goal, current total, and theme gradient as the phone.
-private struct WatchWaterProgress: View {
-    let snapshot: WidgetSnapshot
-    let gradient: [Color]
-
-    private var valueText: String {
-        "\(snapshot.waterDisplayValue(snapshot.waterCurrent)) / \(snapshot.waterDisplayValue(snapshot.waterGoal)) \(snapshot.waterUnitSymbol)"
-    }
-
-    var body: some View {
-        HStack(spacing: 5) {
-            Image(systemName: "drop.fill")
-                .font(.system(size: 10, weight: .bold))
-                .foregroundStyle(
-                    LinearGradient(colors: gradient, startPoint: .top, endPoint: .bottom)
-                )
-
-            Text("Water")
-                .font(.system(size: 10, weight: .semibold, design: .rounded))
-
-            GeometryReader { proxy in
-                ZStack(alignment: .leading) {
-                    Capsule()
-                        .fill((gradient.first ?? .pink).opacity(0.15))
-
-                    Capsule()
-                        .fill(LinearGradient(colors: gradient, startPoint: .leading, endPoint: .trailing))
-                        .frame(width: proxy.size.width * snapshot.waterProgress)
-                        .shadow(color: (gradient.first ?? .pink).opacity(0.35), radius: 2)
-                }
-            }
-            .frame(height: 5)
-
-            Text(valueText)
-                .font(.system(size: 9, weight: .bold, design: .rounded).monospacedDigit())
-                .foregroundStyle(
-                    LinearGradient(colors: gradient, startPoint: .leading, endPoint: .trailing)
-                )
-                .lineLimit(1)
-                .minimumScaleFactor(0.65)
-
-            Image(systemName: "plus.circle.fill")
-                .font(.system(size: 12, weight: .bold))
-                .foregroundStyle(
-                    LinearGradient(colors: gradient, startPoint: .topLeading, endPoint: .bottomTrailing)
-                )
-        }
-        .padding(.horizontal, 7)
-        .frame(height: 28)
-        .background(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill((gradient.first ?? .pink).opacity(0.08))
-        )
-        .overlay {
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke((gradient.first ?? .pink).opacity(0.14), lineWidth: 0.5)
-        }
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Add water")
-        .accessibilityValue(valueText)
-        .accessibilityHint("Opens quick water amounts")
     }
 }
 
@@ -205,10 +132,9 @@ private struct WatchCalorieGauge: View {
     let remaining: Int
     let progress: Double
     let gradient: [Color]
-    let compact: Bool
 
-    private var diameter: CGFloat { compact ? 112 : 132 }
-    private var lineWidth: CGFloat { compact ? 8 : 9 }
+    private let diameter: CGFloat = 132
+    private let lineWidth: CGFloat = 9
 
     private var dashedStroke: StrokeStyle {
         StrokeStyle(lineWidth: lineWidth, lineCap: .butt, dash: [2.5, 3.8])
@@ -232,7 +158,7 @@ private struct WatchCalorieGauge: View {
 
             VStack(spacing: 0) {
                 Text("\(eaten)")
-                    .font(.system(size: compact ? 27 : 30, weight: .bold, design: .rounded))
+                    .font(.system(size: 30, weight: .bold, design: .rounded))
                     .foregroundStyle(
                         LinearGradient(colors: gradient, startPoint: .topLeading, endPoint: .bottomTrailing)
                     )
@@ -244,7 +170,7 @@ private struct WatchCalorieGauge: View {
                     Image(systemName: "flame.fill")
                         .font(.system(size: 9, weight: .semibold))
                     Text("\(remaining) left")
-                        .font(.system(size: compact ? 11 : 12, weight: .semibold, design: .rounded))
+                        .font(.system(size: 12, weight: .semibold, design: .rounded))
                 }
                 .foregroundStyle(gradient.first ?? .pink)
                 .lineLimit(1)
@@ -263,15 +189,14 @@ private struct WatchCalorieGauge: View {
 private struct WatchNutrientBar: View {
     let nutrient: WidgetNutrientValue
     let gradient: [Color]
-    let compact: Bool
 
     private let barWidth: CGFloat = 10
-    private var barHeight: CGFloat { compact ? 30 : 42 }
+    private let barHeight: CGFloat = 42
 
     var body: some View {
-        VStack(spacing: compact ? 3 : 4) {
+        VStack(spacing: 4) {
             Text(nutrient.displayValue)
-                .font(.system(size: compact ? 12 : 13, weight: .bold, design: .rounded).monospacedDigit())
+                .font(.system(size: 13, weight: .bold, design: .rounded).monospacedDigit())
                 .foregroundStyle(
                     LinearGradient(colors: gradient, startPoint: .top, endPoint: .bottom)
                 )

--- a/ios/FudAIWatchApp/WatchSnapshotReceiver.swift
+++ b/ios/FudAIWatchApp/WatchSnapshotReceiver.swift
@@ -10,6 +10,12 @@ final class WatchSnapshotReceiver: NSObject, ObservableObject, WCSessionDelegate
 
     override init() {
         super.init()
+        #if targetEnvironment(simulator)
+        // Simulator has no paired iPhone sync — always seed placeholder nutrition
+        // (calories / macros / water ON) so the full Watch UI can be reviewed.
+        WidgetSnapshot.write(.placeholder)
+        snapshot = .placeholder
+        #endif
         activate()
     }
 

--- a/ios/FudAIWatchApp/WidgetSnapshot.swift
+++ b/ios/FudAIWatchApp/WidgetSnapshot.swift
@@ -125,11 +125,12 @@ struct WidgetSnapshot: Codable, Equatable {
             protein: 84, proteinGoal: 150,
             carbs: 132, carbsGoal: 220,
             fat: 42, fatGoal: 70,
+            // Match iPhone Home: up to 3 selectable nutrients; water is injected
+            // as the locked 4th pillar when tracking is enabled.
             homeNutrients: [
                 WidgetNutrientValue(id: "protein", label: "Protein", shortLabel: "P", unit: "g", iconName: "fork.knife", value: 84, goal: 150),
                 WidgetNutrientValue(id: "carbs", label: "Carbs", shortLabel: "C", unit: "g", iconName: "leaf", value: 132, goal: 220),
                 WidgetNutrientValue(id: "fat", label: "Fat", shortLabel: "F", unit: "g", iconName: "drop.fill", value: 42, goal: 70),
-                WidgetNutrientValue(id: "fiber", label: "Fiber", shortLabel: "Fi", unit: "g", iconName: "leaf.fill", value: 18.2, goal: 34),
             ],
             waterTrackingEnabled: true,
             waterCurrentMl: 1_250,
@@ -156,18 +157,41 @@ struct WidgetSnapshot: Codable, Equatable {
         )
     }
 
-    /// The 4 nutrient cards to render, matching the iPhone Home selection.
-    /// Legacy snapshots (no homeNutrients) yield the four default nutrients.
+    /// The nutrient pillars to render, matching iPhone Home: up to 4 selected
+    /// nutrients, or 3 + a locked Water pillar when Water Tracking is enabled.
     var displayedHomeNutrients: [WidgetNutrientValue] {
-        if let homeNutrients, !homeNutrients.isEmpty {
-            return Array(homeNutrients.prefix(4))
+        let selected = homeNutrients?.filter { !$0.id.isEmpty && $0.id != "water" } ?? []
+        var merged: [WidgetNutrientValue] = []
+        for nutrient in selected.isEmpty ? defaultHomeNutrients : selected {
+            guard !merged.contains(where: { $0.id == nutrient.id }) else { continue }
+            merged.append(nutrient)
+            if merged.count == (waterIsEnabled ? 3 : 4) { break }
         }
-        return [
+        if waterIsEnabled { merged.append(waterHomeNutrient) }
+        return merged
+    }
+
+    private var defaultHomeNutrients: [WidgetNutrientValue] {
+        [
             WidgetNutrientValue(id: "protein", label: "Protein", shortLabel: "P", unit: "g", iconName: "fork.knife", value: protein, goal: Double(proteinGoal)),
             WidgetNutrientValue(id: "carbs", label: "Carbs", shortLabel: "C", unit: "g", iconName: "leaf", value: carbs, goal: Double(carbsGoal)),
             WidgetNutrientValue(id: "fat", label: "Fat", shortLabel: "F", unit: "g", iconName: "drop.fill", value: fat, goal: Double(fatGoal)),
             WidgetNutrientValue(id: "fiber", label: "Fiber", shortLabel: "Fi", unit: "g", iconName: "leaf.fill", value: 0, goal: 34),
         ]
+    }
+
+    private var waterHomeNutrient: WidgetNutrientValue {
+        let usesFluidOunces = waterUnitRaw == "floz"
+        let divisor = usesFluidOunces ? 29.5735295625 : 1
+        return WidgetNutrientValue(
+            id: "water",
+            label: "Water",
+            shortLabel: "W",
+            unit: usesFluidOunces ? " fl oz" : "ml",
+            iconName: "drop.fill",
+            value: Double(waterCurrent) / divisor,
+            goal: Double(waterGoal) / divisor
+        )
     }
 
     var caloriesRemaining: Int { max(0, calorieGoal - calories) }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns Watch Home with iPhone when water tracking is enabled: water appears as the locked 4th pillar (replacing the bottom strip), and tapping the pillar opens water logging. Also seeds the Watch simulator with placeholder nutrition data so Home can be exercised without a paired phone.

## Commits

1. **Seed Watch simulator with placeholder nutrition including water** (`3ab4c753`)
   - Adds simulator-only placeholder snapshot data in `WatchSnapshotReceiver.swift` so Watch Home renders meaningful nutrition (including water) during development.

2. **Show water as the locked 4th Watch Home pillar** (`be2298b6`)
   - Matches iPhone Home behavior: when water tracking is on, removes the bottom strip and injects Water into `displayedHomeNutrients`.
   - Tapping the water pillar opens the log flow.
   - Refactors `WatchNutritionView.swift` and extends `WidgetSnapshot.swift` to support the pillar layout.

## Files changed

- `ios/FudAIWatchApp/WatchNutritionView.swift`
- `ios/FudAIWatchApp/WatchSnapshotReceiver.swift`
- `ios/FudAIWatchApp/WidgetSnapshot.swift`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1ea58d6-de60-4040-9cc8-f41fedbc4513?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1ea58d6-de60-4040-9cc8-f41fedbc4513&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves enabled water tracking into the Watch Home nutrient row as a tappable fourth pillar and adds simulator placeholder data.
- Selects up to three configured nutrients before appending the locked water pillar.
- Opens the existing quick-water logger from the water pillar.
- Restores the full-size calorie gauge and nutrient-bar layout after removing the old water strip.
- Seeds Watch simulator launches with placeholder nutrition and water data.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with non-blocking simulator-state preservation and milliliter-formatting issues worth correcting.

The water pillar composition and logging path follow the established contract, but simulator launches overwrite valid persisted data and metric water goals concatenate the number and unit without spacing.

**Files Needing Attention:** ios/FudAIWatchApp/WatchSnapshotReceiver.swift, ios/FudAIWatchApp/WidgetSnapshot.swift

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ios/FudAIWatchApp/WatchNutritionView.swift | Replaces the separate water strip with a tappable water nutrient pillar and restores the non-compact layout. |
| ios/FudAIWatchApp/WatchSnapshotReceiver.swift | Seeds simulator state with placeholder data, but currently overwrites persisted simulator snapshots on launch. |
| ios/FudAIWatchApp/WidgetSnapshot.swift | Composes selected nutrient pillars with optional locked water data and adds water-unit conversion. |

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20apoorvdarshan%2Ffud-ai%20PR%20%23288%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=288&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aios%2FFudAIWatchApp%2FWatchSnapshotReceiver.swift%3A16-17%0A**Simulator%20State%20Is%20Overwritten**%0A%0AEvery%20Watch%20simulator%20launch%20replaces%20the%20snapshot%20already%20loaded%20from%20disk%20with%20%60.placeholder%60.%20Simulator%20builds%20support%20receiving%20real%20snapshots%2C%20and%20water%20logging%20also%20persists%20optimistic%20updates%20locally%2C%20so%20relaunching%20without%20an%20immediately%20available%20application%20context%20discards%20that%20state%20and%20shows%20seed%20data%20until%20another%20successful%20sync.%20Seed%20the%20placeholder%20only%20when%20no%20valid%20persisted%20snapshot%20is%20available.%0A%0A%23%23%23%20Issue%202%0Aios%2FFudAIWatchApp%2FWidgetSnapshot.swift%3A190%0A**Milliliter%20Unit%20Loses%20Spacing**%0A%0AThe%20metric%20water%20nutrient%20uses%20%60%22ml%22%60%20without%20a%20leading%20space%2C%20while%20the%20pillar%20directly%20concatenates%20the%20goal%20and%20unit.%20This%20displays%20values%20such%20as%20%60%2F2000ml%60%20and%20produces%20the%20accessibility%20phrase%20%601250%20of%202000ml%60%3B%20the%20fluid-ounce%20form%20remains%20separated%20because%20its%20unit%20includes%20a%20leading%20space.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20unit%3A%20usesFluidOunces%20%3F%20%22%20fl%20oz%22%20%3A%20%22%20ml%22%2C%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=288&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22apoorvdarshan%2Ffud-ai%22%20on%20the%20existing%20branch%20%22cursor%2Fwatch-sim-placeholder-seed%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fwatch-sim-placeholder-seed%22.%0A%0A%23%23%23%20Issue%201%0Aios%2FFudAIWatchApp%2FWatchSnapshotReceiver.swift%3A16-17%0A**Simulator%20State%20Is%20Overwritten**%0A%0AEvery%20Watch%20simulator%20launch%20replaces%20the%20snapshot%20already%20loaded%20from%20disk%20with%20%60.placeholder%60.%20Simulator%20builds%20support%20receiving%20real%20snapshots%2C%20and%20water%20logging%20also%20persists%20optimistic%20updates%20locally%2C%20so%20relaunching%20without%20an%20immediately%20available%20application%20context%20discards%20that%20state%20and%20shows%20seed%20data%20until%20another%20successful%20sync.%20Seed%20the%20placeholder%20only%20when%20no%20valid%20persisted%20snapshot%20is%20available.%0A%0A%23%23%23%20Issue%202%0Aios%2FFudAIWatchApp%2FWidgetSnapshot.swift%3A190%0A**Milliliter%20Unit%20Loses%20Spacing**%0A%0AThe%20metric%20water%20nutrient%20uses%20%60%22ml%22%60%20without%20a%20leading%20space%2C%20while%20the%20pillar%20directly%20concatenates%20the%20goal%20and%20unit.%20This%20displays%20values%20such%20as%20%60%2F2000ml%60%20and%20produces%20the%20accessibility%20phrase%20%601250%20of%202000ml%60%3B%20the%20fluid-ounce%20form%20remains%20separated%20because%20its%20unit%20includes%20a%20leading%20space.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20unit%3A%20usesFluidOunces%20%3F%20%22%20fl%20oz%22%20%3A%20%22%20ml%22%2C%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=288&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aios%2FFudAIWatchApp%2FWatchSnapshotReceiver.swift%3A16-17%0A**Simulator%20State%20Is%20Overwritten**%0A%0AEvery%20Watch%20simulator%20launch%20replaces%20the%20snapshot%20already%20loaded%20from%20disk%20with%20%60.placeholder%60.%20Simulator%20builds%20support%20receiving%20real%20snapshots%2C%20and%20water%20logging%20also%20persists%20optimistic%20updates%20locally%2C%20so%20relaunching%20without%20an%20immediately%20available%20application%20context%20discards%20that%20state%20and%20shows%20seed%20data%20until%20another%20successful%20sync.%20Seed%20the%20placeholder%20only%20when%20no%20valid%20persisted%20snapshot%20is%20available.%0A%0A%23%23%23%20Issue%202%0Aios%2FFudAIWatchApp%2FWidgetSnapshot.swift%3A190%0A**Milliliter%20Unit%20Loses%20Spacing**%0A%0AThe%20metric%20water%20nutrient%20uses%20%60%22ml%22%60%20without%20a%20leading%20space%2C%20while%20the%20pillar%20directly%20concatenates%20the%20goal%20and%20unit.%20This%20displays%20values%20such%20as%20%60%2F2000ml%60%20and%20produces%20the%20accessibility%20phrase%20%601250%20of%202000ml%60%3B%20the%20fluid-ounce%20form%20remains%20separated%20because%20its%20unit%20includes%20a%20leading%20space.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20unit%3A%20usesFluidOunces%20%3F%20%22%20fl%20oz%22%20%3A%20%22%20ml%22%2C%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=288&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
ios/FudAIWatchApp/WatchSnapshotReceiver.swift:16-17
**Simulator State Is Overwritten**

Every Watch simulator launch replaces the snapshot already loaded from disk with `.placeholder`. Simulator builds support receiving real snapshots, and water logging also persists optimistic updates locally, so relaunching without an immediately available application context discards that state and shows seed data until another successful sync. Seed the placeholder only when no valid persisted snapshot is available.

### Issue 2
ios/FudAIWatchApp/WidgetSnapshot.swift:190
**Milliliter Unit Loses Spacing**

The metric water nutrient uses `"ml"` without a leading space, while the pillar directly concatenates the goal and unit. This displays values such as `/2000ml` and produces the accessibility phrase `1250 of 2000ml`; the fluid-ounce form remains separated because its unit includes a leading space.

```suggestion
            unit: usesFluidOunces ? " fl oz" : " ml",
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Show water as the locked 4th Watch Home ..."](https://github.com/apoorvdarshan/fud-ai/commit/be2298b6c6014ce258a35cf37de96f2e673eef39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63518970)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->