### PR TITLE
Fix Android onboarding BYOK Continue + Hosted AI coming soon

### DIFF
--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/onboarding/OnboardingScreen.kt
@@ -311,26 +311,33 @@ fun OnboardingScreen(container: AppContainer, onComplete: () -> Unit) {
                 }
             }
             else -> {
-                // iOS continueButton: full-width inverse-coloured capsule.
-                Button(
-                    onClick = { vm.next() },
-                    enabled = ui.canAdvance,
-                    shape = RoundedCornerShape(28.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.onBackground,
-                        contentColor = MaterialTheme.colorScheme.background
-                    ),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 24.dp)
-                        .padding(bottom = 36.dp)
-                        .height(54.dp)
-                ) {
-                    Text(
-                        stringResource(R.string.action_continue),
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold
-                    )
+                // iOS hides the provider-step CTA on the choice screen; BYOK shows Continue once valid.
+                val showContinue = ui.step != OnboardingStep.PROVIDER ||
+                    ui.aiPhase != OnboardingAiPhase.CHOICE
+                if (showContinue) {
+                    Button(
+                        onClick = { vm.next() },
+                        enabled = ui.canAdvance,
+                        shape = RoundedCornerShape(28.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.onBackground,
+                            contentColor = MaterialTheme.colorScheme.background
+                        ),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 24.dp)
+                            .padding(bottom = 36.dp)
+                            .height(54.dp)
+                    ) {
+                        Text(
+                            stringResource(R.string.action_continue),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    }
+                } else {
+                    // Reserve footer height so the choice cards don't jump when BYOK opens.
+                    Spacer(Modifier.height(54.dp + 36.dp))
                 }
             }
         }
@@ -1297,19 +1304,12 @@ private fun AiAccessChoiceSection(onSelectByok: () -> Unit) {
         )
         AiAccessChoiceCard(
             icon = Icons.Outlined.AutoAwesome,
-            title = stringResource(R.string.onboarding_ai_hosted_ios_card_title),
-            subtitle = stringResource(R.string.onboarding_ai_hosted_ios_card_subtitle),
-            badge = null,
+            title = stringResource(R.string.onboarding_ai_hosted_card_title),
+            subtitle = stringResource(R.string.onboarding_ai_hosted_card_subtitle),
+            badge = stringResource(R.string.onboarding_ai_hosted_badge),
             highlighted = false,
             enabled = false,
             onClick = {}
-        )
-        Text(
-            stringResource(R.string.onboarding_ai_hosted_ios_note),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
-            textAlign = androidx.compose.ui.text.style.TextAlign.Center,
-            modifier = Modifier.padding(top = 4.dp)
         )
     }
 }
@@ -1354,13 +1354,18 @@ private fun AiAccessChoiceCard(
                     )
                     badge?.let {
                         Spacer(Modifier.width(8.dp))
+                        val badgeColor = if (enabled) {
+                            AppColors.Calorie
+                        } else {
+                            MaterialTheme.colorScheme.onBackground.copy(alpha = 0.45f)
+                        }
                         Text(
                             it,
                             style = MaterialTheme.typography.labelSmall,
                             fontWeight = FontWeight.Bold,
-                            color = AppColors.Calorie,
+                            color = badgeColor,
                             modifier = Modifier
-                                .background(AppColors.Calorie.copy(alpha = 0.12f), RoundedCornerShape(999.dp))
+                                .background(badgeColor.copy(alpha = 0.12f), RoundedCornerShape(999.dp))
                                 .padding(horizontal = 8.dp, vertical = 3.dp)
                         )
                     }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/onboarding/OnboardingScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -88,6 +90,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -1346,30 +1349,7 @@ private fun AiAccessChoiceCard(
             )
             Spacer(Modifier.width(14.dp))
             Column(Modifier.weight(1f)) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        title,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold
-                    )
-                    badge?.let {
-                        Spacer(Modifier.width(8.dp))
-                        val badgeColor = if (enabled) {
-                            AppColors.Calorie
-                        } else {
-                            MaterialTheme.colorScheme.onBackground.copy(alpha = 0.45f)
-                        }
-                        Text(
-                            it,
-                            style = MaterialTheme.typography.labelSmall,
-                            fontWeight = FontWeight.Bold,
-                            color = badgeColor,
-                            modifier = Modifier
-                                .background(badgeColor.copy(alpha = 0.12f), RoundedCornerShape(999.dp))
-                                .padding(horizontal = 8.dp, vertical = 3.dp)
-                        )
-                    }
-                }
+                AiAccessChoiceTitleRow(title = title, badge = badge, enabled = enabled)
                 Spacer(Modifier.height(6.dp))
                 Text(
                     subtitle,
@@ -1389,6 +1369,52 @@ private fun AiAccessChoiceCard(
             }
         }
     }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun AiAccessChoiceTitleRow(
+    title: String,
+    badge: String?,
+    enabled: Boolean
+) {
+    // Title ellipsizes when long; badge stays a single-line pill. FlowRow drops the badge to the
+    // next line when the row is too tight instead of letter-wrapping inside the pill.
+    FlowRow(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        itemVerticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            title,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+        badge?.let { AiAccessChoiceBadge(text = it, enabled = enabled) }
+    }
+}
+
+@Composable
+private fun AiAccessChoiceBadge(text: String, enabled: Boolean) {
+    val badgeColor = if (enabled) {
+        AppColors.Calorie
+    } else {
+        MaterialTheme.colorScheme.onBackground.copy(alpha = 0.45f)
+    }
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.Bold,
+        color = badgeColor,
+        maxLines = 1,
+        softWrap = false,
+        modifier = Modifier
+            .background(badgeColor.copy(alpha = 0.12f), RoundedCornerShape(999.dp))
+            .padding(horizontal = 8.dp, vertical = 3.dp)
+    )
 }
 
 @Composable

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/onboarding/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/onboarding/OnboardingViewModel.kt
@@ -67,15 +67,23 @@ data class OnboardingState(
     /** PLAN_READY is the final step (the old Rate-fud review step was removed). */
     val isLastStep: Boolean get() = step == OnboardingStep.PLAN_READY
 
+    /** True once BYOK fields satisfy the same gate as pre-choice onboarding. */
+    val byokSetupComplete: Boolean
+        get() = !aiProvider.requiresApiKey || apiKey.trim().isNotEmpty()
+
     /** AI is required for goal calculation, so BYOK users must enter an API key before leaving
      *  the provider step (Ollama needs none). All other steps advance freely. */
     val canAdvance: Boolean get() = when (step) {
         OnboardingStep.PROVIDER -> when (aiPhase) {
             OnboardingAiPhase.CHOICE -> false
-            OnboardingAiPhase.BYOK -> !aiProvider.requiresApiKey || apiKey.trim().isNotEmpty()
+            OnboardingAiPhase.BYOK -> byokSetupComplete
         }
         else -> true
     }
+
+    /** When returning to the provider step, reopen BYOK if the user already configured it. */
+    fun aiPhaseForProviderStep(): OnboardingAiPhase =
+        if (byokSetupComplete) OnboardingAiPhase.BYOK else OnboardingAiPhase.CHOICE
 
     fun buildProfile(): UserProfile = UserProfile(
         gender = gender,
@@ -138,14 +146,13 @@ class OnboardingViewModel(private val container: AppContainer) : ViewModel() {
         _ui.value = _ui.value.copy(healthConnectEnabled = v)
     }
     fun setAiProvider(p: AIProvider) {
-        // Persist immediately so the Building Plan AI call (which runs before onboarding
-        // completes) can resolve the provider/model. Reset to the provider's default model and
-        // reload that provider's stored key.
+        // Update state synchronously so a slow prefs write can't overwrite a key the user typed
+        // while the picker was open. Persist in the background for the Building Plan AI call.
+        val existing = container.keyStore.apiKey(p) ?: ""
+        _ui.value = _ui.value.copy(aiProvider = p, aiModel = p.defaultModel, apiKey = existing)
         viewModelScope.launch {
             container.prefs.setSelectedAIProvider(p)
             container.prefs.setSelectedAIModel(p.defaultModel)
-            val existing = container.keyStore.apiKey(p) ?: ""
-            _ui.value = _ui.value.copy(aiProvider = p, aiModel = p.defaultModel, apiKey = existing)
         }
     }
     fun setAiModel(m: String) {
@@ -161,7 +168,20 @@ class OnboardingViewModel(private val container: AppContainer) : ViewModel() {
     }
 
     fun selectByokSetup() {
+        // Flip to BYOK immediately so the form and Continue CTA can react; hydrate from prefs/keystore next.
         _ui.value = _ui.value.copy(aiPhase = OnboardingAiPhase.BYOK)
+        viewModelScope.launch {
+            val provider = container.prefs.selectedAIProvider.first()
+            val storedModel = container.prefs.selectedAIModel.first()
+            val existing = container.keyStore.apiKey(provider) ?: ""
+            val current = _ui.value
+            if (current.aiPhase != OnboardingAiPhase.BYOK) return@launch
+            _ui.value = current.copy(
+                aiProvider = provider,
+                aiModel = provider.supportedModelOrDefault(storedModel),
+                apiKey = existing.ifEmpty { current.apiKey }
+            )
+        }
     }
     /** The single Imperial|Metric segmented control writes BOTH unit prefs coherently:
      *  Imperial -> ftin + lbs, Metric -> cm + kg. */
@@ -218,17 +238,29 @@ class OnboardingViewModel(private val container: AppContainer) : ViewModel() {
         // PLAN_READY's previous ordinal is BUILDING_PLAN, which auto-reruns AI and can
         // overwrite edited targets — skip it and return to PROVIDER instead.
         if (_ui.value.step == OnboardingStep.PLAN_READY) {
-            _ui.value = _ui.value.copy(step = OnboardingStep.PROVIDER, aiPhase = OnboardingAiPhase.CHOICE)
+            val state = _ui.value
+            _ui.value = state.copy(
+                step = OnboardingStep.PROVIDER,
+                aiPhase = state.aiPhaseForProviderStep()
+            )
             return
         }
         val prevStep = OnboardingStep.values().getOrNull(_ui.value.step.ordinal - 1) ?: return
         if (prevStep == OnboardingStep.BUILDING_PLAN) {
-            _ui.value = _ui.value.copy(step = OnboardingStep.PROVIDER, aiPhase = OnboardingAiPhase.CHOICE)
+            val state = _ui.value
+            _ui.value = state.copy(
+                step = OnboardingStep.PROVIDER,
+                aiPhase = state.aiPhaseForProviderStep()
+            )
             return
         }
         _ui.value = _ui.value.copy(
             step = prevStep,
-            aiPhase = if (prevStep == OnboardingStep.PROVIDER) OnboardingAiPhase.CHOICE else _ui.value.aiPhase
+            aiPhase = if (prevStep == OnboardingStep.PROVIDER) {
+                _ui.value.aiPhaseForProviderStep()
+            } else {
+                _ui.value.aiPhase
+            }
         )
     }
 

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -266,9 +266,9 @@
     <string name="onboarding_ai_byok_card_title">أحضر مفتاحك الخاص</string>
     <string name="onboarding_ai_byok_card_subtitle">مجاني للأبد — غير محدود على مفتاحك. Gemini وOpenAI وGroq والمزيد.</string>
     <string name="onboarding_ai_byok_badge">موصى به</string>
-    <string name="onboarding_ai_hosted_ios_card_title">الذكاء الاصطناعي المستضاف على iOS</string>
-    <string name="onboarding_ai_hosted_ios_card_subtitle">اشتراكات Plus/Pro متاحة على iPhone وiPad. Android يستخدم BYOK.</string>
-    <string name="onboarding_ai_hosted_ios_note">لا يوجد اشتراك في Play Store — اربط مفتاح الذكاء الاصطناعي الخاص بك للمتابعة.</string>
+    <string name="onboarding_ai_hosted_card_title">الذكاء الاصطناعي المستضاف</string>
+    <string name="onboarding_ai_hosted_card_subtitle">خطط Plus أو Pro مع أرصدة ذكاء اصطناعي يومية — لا حاجة لمفتاح API.</string>
+    <string name="onboarding_ai_hosted_badge">قريبًا</string>
     <string name="onboarding_provider_title">إعداد الذكاء الاصطناعي الخاص بك</string>
     <string name="onboarding_provider_subtitle">أضف مفتاح مزود الذكاء الاصطناعي الخاص بك — التطبيق يبقى مجانيًا.</string>
     <string name="onboarding_provider_recommended_title">موصى به: Google Gemini</string>

--- a/android/app/src/main/res/values-az/strings.xml
+++ b/android/app/src/main/res/values-az/strings.xml
@@ -262,9 +262,9 @@
     <string name="onboarding_ai_byok_card_title">Öz Açarınızı Gətirin</string>
     <string name="onboarding_ai_byok_card_subtitle">Həmişəlik pulsuz — açarınızda limitsiz. Gemini, OpenAI, Groq və s.</string>
     <string name="onboarding_ai_byok_badge">Tövsiyə olunur</string>
-    <string name="onboarding_ai_hosted_ios_card_title">iOS-da Host edilmiş AI</string>
-    <string name="onboarding_ai_hosted_ios_card_subtitle">Plus/Pro abunəlikləri iPhone və iPad-də mövcuddur. Android BYOK istifadə edir.</string>
-    <string name="onboarding_ai_hosted_ios_note">Play Store abunəliyi yoxdur — davam etmək üçün öz AI açarınızı qoşun.</string>
+    <string name="onboarding_ai_hosted_card_title">Host edilmiş AI</string>
+    <string name="onboarding_ai_hosted_card_subtitle">Plus və ya Pro planları gündəlik AI kreditləri ilə — API açarı lazım deyil.</string>
+    <string name="onboarding_ai_hosted_badge">Tezliklə</string>
     <string name="onboarding_provider_title">Öz AI-ni Quraşdır</string>
     <string name="onboarding_provider_subtitle">Öz AI provayder açarınızı əlavə edin — tətbiq pulsuz qalır.</string>
     <string name="onboarding_provider_recommended_title">Tövsiyə olunur: Google Gemini</string>

--- a/android/app/src/main/res/values-cs/strings.xml
+++ b/android/app/src/main/res/values-cs/strings.xml
@@ -224,9 +224,9 @@
     <string name="onboarding_ai_byok_card_title">Použij vlastní klíč</string>
     <string name="onboarding_ai_byok_card_subtitle">Navždy zdarma — neomezeně na tvém klíči. Gemini, OpenAI, Groq a další.</string>
     <string name="onboarding_ai_byok_badge">Doporučeno</string>
-    <string name="onboarding_ai_hosted_ios_card_title">Hostovaná AI na iOS</string>
-    <string name="onboarding_ai_hosted_ios_card_subtitle">Předplatné Plus/Pro je dostupné na iPhonu a iPadu. Android používá BYOK.</string>
-    <string name="onboarding_ai_hosted_ios_note">Žádné předplatné v Play Store — pro pokračování připoj vlastní AI klíč.</string>
+    <string name="onboarding_ai_hosted_card_title">Hostovaná AI</string>
+    <string name="onboarding_ai_hosted_card_subtitle">Plány Plus nebo Pro s denními AI kredity — bez API klíče.</string>
+    <string name="onboarding_ai_hosted_badge">Již brzy</string>
     <string name="onboarding_provider_title">Nastav si svou AI</string>
     <string name="onboarding_provider_subtitle">Přidej klíč svého AI poskytovatele — aplikace zůstane zdarma.</string>
     <string name="onboarding_provider_recommended_title">Doporučujeme: Google Gemini</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -262,9 +262,9 @@
     <string name="onboarding_ai_byok_card_title">Eigenen Schlüssel mitbringen</string>
     <string name="onboarding_ai_byok_card_subtitle">Für immer kostenlos — unbegrenzt mit deinem Schlüssel. Gemini, OpenAI, Groq &amp; mehr.</string>
     <string name="onboarding_ai_byok_badge">Empfohlen</string>
-    <string name="onboarding_ai_hosted_ios_card_title">Gehostete KI auf iOS</string>
-    <string name="onboarding_ai_hosted_ios_card_subtitle">Plus/Pro-Abos sind auf iPhone und iPad verfügbar. Android nutzt BYOK.</string>
-    <string name="onboarding_ai_hosted_ios_note">Kein Play-Store-Abo — verbinde deinen eigenen KI-Schlüssel, um fortzufahren.</string>
+    <string name="onboarding_ai_hosted_card_title">Gehostete KI</string>
+    <string name="onboarding_ai_hosted_card_subtitle">Plus- oder Pro-Pläne mit täglichen KI-Credits — kein API-Schlüssel nötig.</string>
+    <string name="onboarding_ai_hosted_badge">Demnächst</string>
     <string name="onboarding_provider_title">Richte deine KI ein</string>
     <string name="onboarding_provider_subtitle">Füge deinen eigenen KI-Anbieter-Schlüssel hinzu — die App bleibt kostenlos.</string>
     <string name="onboarding_provider_recommended_title">Empfohlen: Google Gemini</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -263,9 +263,9 @@
     <string name="onboarding_ai_byok_card_title">Trae tu propia clave</string>
     <string name="onboarding_ai_byok_card_subtitle">Gratis para siempre — ilimitado con tu clave. Gemini, OpenAI, Groq y más.</string>
     <string name="onboarding_ai_byok_badge">Recomendado</string>
-    <string name="onboarding_ai_hosted_ios_card_title">IA alojada en iOS</string>
-    <string name="onboarding_ai_hosted_ios_card_subtitle">Las suscripciones Plus/Pro están disponibles en iPhone e iPad. Android usa BYOK.</string>
-    <string name="onboarding_ai_hosted_ios_note">Sin suscripción en Play Store — conecta tu propia clave de IA para continuar.</string>
+    <string name="onboarding_ai_hosted_card_title">IA alojada</string>
+    <string name="onboarding_ai_hosted_card_subtitle">Planes Plus o Pro con créditos diarios de IA — sin clave API.</string>
+    <string name="onboarding_ai_hosted_badge">Próximamente</string>
     <string name="onboarding_provider_title">Configura tu IA</string>
     <string name="onboarding_provider_subtitle">Añade tu propia clave de proveedor de IA — la app sigue siendo gratis.</string>
     <string name="onboarding_provider_recommended_title">Recomendado: Google Gemini</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -263,9 +263,9 @@
     <string name="onboarding_ai_byok_card_title">Apporte ta propre clé</string>
     <string name="onboarding_ai_byok_card_subtitle">Gratuit pour toujours — illimité sur ta clé. Gemini, OpenAI, Groq et plus.</string>
     <string name="onboarding_ai_byok_badge">Recommandé</string>
-    <string name="onboarding_ai_hosted_ios_card_title">IA hébergée sur iOS</string>
-    <string name="onboarding_ai_hosted_ios_card_subtitle">Les abonnements Plus/Pro sont disponibles sur iPhone et iPad. Android utilise BYOK.</string>
-    <string name="onboarding_ai_hosted_ios_note">Pas d\'abonnement Play Store — connecte ta propre clé IA pour continuer.</string>
+    <string name="onboarding_ai_hosted_card_title">IA hébergée</string>
+    <string name="onboarding_ai_hosted_card_subtitle">Forfaits Plus ou Pro avec crédits IA quotidiens — pas de clé API nécessaire.</string>
+    <string name="onboarding_ai_hosted_badge">Bientôt disponible</string>
     <string name="onboarding_provider_title">Configure ton IA</string>
     <string name="onboarding_provider_subtitle">Ajoute ta propre clé de fournisseur IA — l\'app reste gratuite.</string>
     <string name="onboarding_provider_recommended_title">Recommandé : Google Gemini</string>

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -262,9 +262,9 @@
     <string name="onboarding_ai_byok_card_title">अपनी कुंजी लाएँ</string>
     <string name="onboarding_ai_byok_card_subtitle">हमेशा मुफ़्त — आपकी कुंजी पर असीमित। Gemini, OpenAI, Groq और अन्य।</string>
     <string name="onboarding_ai_byok_badge">अनुशंसित</string>
-    <string name="onboarding_ai_hosted_ios_card_title">iOS पर होस्टेड AI</string>
-    <string name="onboarding_ai_hosted_ios_card_subtitle">Plus/Pro सब्सक्रिप्शन iPhone और iPad पर उपलब्ध हैं। Android BYOK उपयोग करता है।</string>
-    <string name="onboarding_ai_hosted_ios_note">कोई Play Store सब्सक्रिप्शन नहीं — जारी रखने के लिए अपनी AI कुंजी कनेक्ट करें।</string>
+    <string name="onboarding_ai_hosted_card_title">होस्टेड AI</string>
+    <string name="onboarding_ai_hosted_card_subtitle">Plus या Pro प्लान, दैनिक AI क्रेडिट — API कुंजी की जरूरत नहीं।</string>
+    <string name="onboarding_ai_hosted_badge">जल्द आ रहा है</string>
     <string name="onboarding_provider_title">अपना AI सेट अप करें</string>
     <string name="onboarding_provider_subtitle">अपनी AI प्रोवाइडर कुंजी जोड़ें — ऐप मुफ़्त रहता है।</string>
     <string name="onboarding_provider_recommended_title">अनुशंसित: Google Gemini</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -263,9 +263,9 @@
     <string name="onboarding_ai_byok_card_title">Porta la tua chiave</string>
     <string name="onboarding_ai_byok_card_subtitle">Gratis per sempre — illimitato sulla tua chiave. Gemini, OpenAI, Groq e altri.</string>
     <string name="onboarding_ai_byok_badge">Consigliato</string>
-    <string name="onboarding_ai_hosted_ios_card_title">IA ospitata su iOS</string>
-    <string name="onboarding_ai_hosted_ios_card_subtitle">Gli abbonamenti Plus/Pro sono disponibili su iPhone e iPad. Android usa BYOK.</string>
-    <string name="onboarding_ai_hosted_ios_note">Nessun abbonamento Play Store — collega la tua chiave IA per continuare.</string>
+    <string name="onboarding_ai_hosted_card_title">IA ospitata</string>
+    <string name="onboarding_ai_hosted_card_subtitle">Piani Plus o Pro con crediti IA giornalieri — nessuna chiave API necessaria.</string>
+    <string name="onboarding_ai_hosted_badge">In arrivo</string>
     <string name="onboarding_provider_title">Configura la tua IA</string>
     <string name="onboarding_provider_subtitle">Aggiungi la tua chiave del provider IA — l\'app resta gratuita.</string>
     <string name="onboarding_provider_recommended_title">Consigliato: Google Gemini</string>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -261,9 +261,9 @@
     <string name="onboarding_ai_byok_card_title">自分のキーを使う</string>
     <string name="onboarding_ai_byok_card_subtitle">永久無料 — 自分のキーで無制限。Gemini、OpenAI、Groqなど。</string>
     <string name="onboarding_ai_byok_badge">おすすめ</string>
-    <string name="onboarding_ai_hosted_ios_card_title">iOSのホスト型AI</string>
-    <string name="onboarding_ai_hosted_ios_card_subtitle">Plus/ProサブスクリプションはiPhoneとiPadで利用可能。AndroidはBYOKです。</string>
-    <string name="onboarding_ai_hosted_ios_note">Play Storeのサブスクリプションはありません — 続行するには自分のAIキーを接続してください。</string>
+    <string name="onboarding_ai_hosted_card_title">ホスト型AI</string>
+    <string name="onboarding_ai_hosted_card_subtitle">PlusまたはProプランで毎日のAIクレジット — APIキー不要。</string>
+    <string name="onboarding_ai_hosted_badge">近日公開</string>
     <string name="onboarding_provider_title">AIをセットアップ</string>
     <string name="onboarding_provider_subtitle">自分のAIプロバイダーキーを追加 — アプリは無料のままです。</string>
     <string name="onboarding_provider_recommended_title">おすすめ：Google Gemini</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -261,9 +261,9 @@
     <string name="onboarding_ai_byok_card_title">자체 키 사용</string>
     <string name="onboarding_ai_byok_card_subtitle">영원히 무료 — 내 키로 무제한. Gemini, OpenAI, Groq 등.</string>
     <string name="onboarding_ai_byok_badge">추천</string>
-    <string name="onboarding_ai_hosted_ios_card_title">iOS 호스팅 AI</string>
-    <string name="onboarding_ai_hosted_ios_card_subtitle">Plus/Pro 구독은 iPhone과 iPad에서 이용 가능합니다. Android는 BYOK를 사용합니다.</string>
-    <string name="onboarding_ai_hosted_ios_note">Play Store 구독 없음 — 계속하려면 자체 AI 키를 연결하세요.</string>
+    <string name="onboarding_ai_hosted_card_title">호스팅 AI</string>
+    <string name="onboarding_ai_hosted_card_subtitle">Plus 또는 Pro 요금제로 매일 AI 크레딧 — API 키 불필요.</string>
+    <string name="onboarding_ai_hosted_badge">곧 출시</string>
     <string name="onboarding_provider_title">AI 설정하기</string>
     <string name="onboarding_provider_subtitle">자체 AI 제공업체 키를 추가하세요 — 앱은 무료입니다.</string>
     <string name="onboarding_provider_recommended_title">추천: Google Gemini</string>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -262,9 +262,9 @@
     <string name="onboarding_ai_byok_card_title">Breng je eigen sleutel</string>
     <string name="onboarding_ai_byok_card_subtitle">Voor altijd gratis — onbeperkt op jouw sleutel. Gemini, OpenAI, Groq &amp; meer.</string>
     <string name="onboarding_ai_byok_badge">Aanbevolen</string>
-    <string name="onboarding_ai_hosted_ios_card_title">Gehoste AI op iOS</string>
-    <string name="onboarding_ai_hosted_ios_card_subtitle">Plus/Pro-abonnementen zijn beschikbaar op iPhone en iPad. Android gebruikt BYOK.</string>
-    <string name="onboarding_ai_hosted_ios_note">Geen Play Store-abonnement — koppel je eigen AI-sleutel om door te gaan.</string>
+    <string name="onboarding_ai_hosted_card_title">Gehoste AI</string>
+    <string name="onboarding_ai_hosted_card_subtitle">Plus- of Pro-abonnementen met dagelijkse AI-tegoeden — geen API-sleutel nodig.</string>
+    <string name="onboarding_ai_hosted_badge">Binnenkort</string>
     <string name="onboarding_provider_title">Stel je AI in</string>
     <string name="onboarding_provider_subtitle">Voeg je eigen AI-providersleutel toe — de app blijft gratis.</string>
     <string name="onboarding_provider_recommended_title">Aanbevolen: Google Gemini</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -264,9 +264,9 @@
     <string name="onboarding_ai_byok_card_title">Użyj własnego klucza</string>
     <string name="onboarding_ai_byok_card_subtitle">Za darmo na zawsze — bez limitu na twoim kluczu. Gemini, OpenAI, Groq i inne.</string>
     <string name="onboarding_ai_byok_badge">Polecane</string>
-    <string name="onboarding_ai_hosted_ios_card_title">Hostowane AI na iOS</string>
-    <string name="onboarding_ai_hosted_ios_card_subtitle">Subskrypcje Plus/Pro są dostępne na iPhone i iPad. Android używa BYOK.</string>
-    <string name="onboarding_ai_hosted_ios_note">Brak subskrypcji w Play Store — podłącz własny klucz AI, aby kontynuować.</string>
+    <string name="onboarding_ai_hosted_card_title">Hostowane AI</string>
+    <string name="onboarding_ai_hosted_card_subtitle">Plany Plus lub Pro z dziennymi kredytami AI — bez klucza API.</string>
+    <string name="onboarding_ai_hosted_badge">Wkrótce</string>
     <string name="onboarding_provider_title">Skonfiguruj swoje AI</string>
     <string name="onboarding_provider_subtitle">Dodaj własny klucz dostawcy AI — aplikacja pozostaje darmowa.</string>
     <string name="onboarding_provider_recommended_title">Zalecane: Google Gemini</string>

--- a/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -263,9 +263,9 @@
     <string name="onboarding_ai_byok_card_title">Traga sua própria chave</string>
     <string name="onboarding_ai_byok_card_subtitle">Grátis para sempre — ilimitado na sua chave. Gemini, OpenAI, Groq e mais.</string>
     <string name="onboarding_ai_byok_badge">Recomendado</string>
-    <string name="onboarding_ai_hosted_ios_card_title">IA hospedada no iOS</string>
-    <string name="onboarding_ai_hosted_ios_card_subtitle">Assinaturas Plus/Pro estão disponíveis no iPhone e iPad. Android usa BYOK.</string>
-    <string name="onboarding_ai_hosted_ios_note">Sem assinatura na Play Store — conecte sua própria chave de IA para continuar.</string>
+    <string name="onboarding_ai_hosted_card_title">IA hospedada</string>
+    <string name="onboarding_ai_hosted_card_subtitle">Planos Plus ou Pro com créditos diários de IA — sem chave de API.</string>
+    <string name="onboarding_ai_hosted_badge">Em breve</string>
     <string name="onboarding_provider_title">Configure sua IA</string>
     <string name="onboarding_provider_subtitle">Adicione sua própria chave de provedor de IA — o app continua gratuito.</string>
     <string name="onboarding_provider_recommended_title">Recomendado: Google Gemini</string>

--- a/android/app/src/main/res/values-ro/strings.xml
+++ b/android/app/src/main/res/values-ro/strings.xml
@@ -263,9 +263,9 @@
     <string name="onboarding_ai_byok_card_title">Adu propria cheie</string>
     <string name="onboarding_ai_byok_card_subtitle">Gratuit pentru totdeauna — nelimitat pe cheia ta. Gemini, OpenAI, Groq și altele.</string>
     <string name="onboarding_ai_byok_badge">Recomandat</string>
-    <string name="onboarding_ai_hosted_ios_card_title">AI găzduit pe iOS</string>
-    <string name="onboarding_ai_hosted_ios_card_subtitle">Abonamentele Plus/Pro sunt disponibile pe iPhone și iPad. Android folosește BYOK.</string>
-    <string name="onboarding_ai_hosted_ios_note">Fără abonament Play Store — conectează propria cheie AI pentru a continua.</string>
+    <string name="onboarding_ai_hosted_card_title">AI găzduit</string>
+    <string name="onboarding_ai_hosted_card_subtitle">Planuri Plus sau Pro cu credite AI zilnice — fără cheie API.</string>
+    <string name="onboarding_ai_hosted_badge">În curând</string>
     <string name="onboarding_provider_title">Configurează-ți AI-ul</string>
     <string name="onboarding_provider_subtitle">Adaugă propria cheie de furnizor AI — aplicația rămâne gratuită.</string>
     <string name="onboarding_provider_recommended_title">Recomandat: Google Gemini</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -264,9 +264,9 @@
     <string name="onboarding_ai_byok_card_title">Свой ключ</string>
     <string name="onboarding_ai_byok_card_subtitle">Бесплатно навсегда — без лимитов на твоём ключе. Gemini, OpenAI, Groq и другие.</string>
     <string name="onboarding_ai_byok_badge">Рекомендуется</string>
-    <string name="onboarding_ai_hosted_ios_card_title">Хостинг ИИ на iOS</string>
-    <string name="onboarding_ai_hosted_ios_card_subtitle">Подписки Plus/Pro доступны на iPhone и iPad. Android использует BYOK.</string>
-    <string name="onboarding_ai_hosted_ios_note">Нет подписки в Play Store — подключи свой ключ ИИ, чтобы продолжить.</string>
+    <string name="onboarding_ai_hosted_card_title">Хостинг ИИ</string>
+    <string name="onboarding_ai_hosted_card_subtitle">Тарифы Plus или Pro с ежедневными кредитами ИИ — ключ API не нужен.</string>
+    <string name="onboarding_ai_hosted_badge">Скоро</string>
     <string name="onboarding_provider_title">Настрой свой ИИ</string>
     <string name="onboarding_provider_subtitle">Добавь свой ключ провайдера ИИ — приложение остаётся бесплатным.</string>
     <string name="onboarding_provider_recommended_title">Рекомендуется: Google Gemini</string>

--- a/android/app/src/main/res/values-uk/strings.xml
+++ b/android/app/src/main/res/values-uk/strings.xml
@@ -315,9 +315,9 @@
     <string name="onboarding_ai_byok_card_title">Свій ключ</string>
     <string name="onboarding_ai_byok_card_subtitle">Безкоштовно назавжди — без обмежень на твоєму ключі. Gemini, OpenAI, Groq та інші.</string>
     <string name="onboarding_ai_byok_badge">Рекомендовано</string>
-    <string name="onboarding_ai_hosted_ios_card_title">Хостинг ШІ на iOS</string>
-    <string name="onboarding_ai_hosted_ios_card_subtitle">Підписки Plus/Pro доступні на iPhone та iPad. Android використовує BYOK.</string>
-    <string name="onboarding_ai_hosted_ios_note">Немає підписки в Play Store — підключи свій ключ ШІ, щоб продовжити.</string>
+    <string name="onboarding_ai_hosted_card_title">Хостинг ШІ</string>
+    <string name="onboarding_ai_hosted_card_subtitle">Тарифи Plus або Pro з щоденними кредитами ШІ — ключ API не потрібен.</string>
+    <string name="onboarding_ai_hosted_badge">Незабаром</string>
     <string name="onboarding_provider_title">Налаштуй свій ШІ</string>
     <string name="onboarding_provider_subtitle">Додай свій ключ провайдера ШІ — застосунок залишається безкоштовним.</string>
     <string name="onboarding_provider_recommended_title">Рекомендовано: Google Gemini</string>

--- a/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -261,9 +261,9 @@
     <string name="onboarding_ai_byok_card_title">自带密钥</string>
     <string name="onboarding_ai_byok_card_subtitle">永久免费 — 使用你的密钥无限制。Gemini、OpenAI、Groq 等。</string>
     <string name="onboarding_ai_byok_badge">推荐</string>
-    <string name="onboarding_ai_hosted_ios_card_title">iOS 托管 AI</string>
-    <string name="onboarding_ai_hosted_ios_card_subtitle">Plus/Pro 订阅可在 iPhone 和 iPad 上使用。Android 使用 BYOK。</string>
-    <string name="onboarding_ai_hosted_ios_note">无 Play Store 订阅 — 连接你自己的 AI 密钥以继续。</string>
+    <string name="onboarding_ai_hosted_card_title">托管 AI</string>
+    <string name="onboarding_ai_hosted_card_subtitle">Plus 或 Pro 计划，每日 AI 额度 — 无需 API 密钥。</string>
+    <string name="onboarding_ai_hosted_badge">即将推出</string>
     <string name="onboarding_provider_title">设置你的 AI</string>
     <string name="onboarding_provider_subtitle">添加你自己的 AI 提供商密钥 — 应用保持免费。</string>
     <string name="onboarding_provider_recommended_title">推荐：Google Gemini</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -313,9 +313,9 @@
     <string name="onboarding_ai_byok_card_title">Bring Your Own Key</string>
     <string name="onboarding_ai_byok_card_subtitle">Free forever — unlimited on your key. Gemini, OpenAI, Groq &amp; more.</string>
     <string name="onboarding_ai_byok_badge">Recommended</string>
-    <string name="onboarding_ai_hosted_ios_card_title">Hosted AI on iOS</string>
-    <string name="onboarding_ai_hosted_ios_card_subtitle">Plus/Pro subscriptions are available on iPhone and iPad. Android uses BYOK.</string>
-    <string name="onboarding_ai_hosted_ios_note">No Play Store subscription — connect your own AI key to continue.</string>
+    <string name="onboarding_ai_hosted_card_title">Hosted AI</string>
+    <string name="onboarding_ai_hosted_card_subtitle">Plus or Pro plans with daily AI credits — no API key needed.</string>
+    <string name="onboarding_ai_hosted_badge">Coming soon</string>
     <string name="onboarding_provider_title">Set Up Your AI</string>
     <string name="onboarding_provider_subtitle">Add your own AI provider key — the app stays free.</string>
     <string name="onboarding_provider_recommended_title">Recommended: Google Gemini</string>

--- a/android/app/src/test/java/com/apoorvdarshan/calorietracker/ui/onboarding/OnboardingStateTest.kt
+++ b/android/app/src/test/java/com/apoorvdarshan/calorietracker/ui/onboarding/OnboardingStateTest.kt
@@ -1,0 +1,68 @@
+package com.apoorvdarshan.calorietracker.ui.onboarding
+
+import com.apoorvdarshan.calorietracker.models.AIProvider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OnboardingStateTest {
+
+    @Test
+    fun providerChoiceBlocksContinue() {
+        val state = OnboardingState(
+            step = OnboardingStep.PROVIDER,
+            aiPhase = OnboardingAiPhase.CHOICE
+        )
+        assertFalse(state.canAdvance)
+    }
+
+    @Test
+    fun byokWithoutKeyBlocksContinueForGemini() {
+        val state = OnboardingState(
+            step = OnboardingStep.PROVIDER,
+            aiPhase = OnboardingAiPhase.BYOK,
+            aiProvider = AIProvider.GEMINI,
+            apiKey = ""
+        )
+        assertFalse(state.canAdvance)
+        assertFalse(state.byokSetupComplete)
+    }
+
+    @Test
+    fun byokWithKeyEnablesContinue() {
+        val state = OnboardingState(
+            step = OnboardingStep.PROVIDER,
+            aiPhase = OnboardingAiPhase.BYOK,
+            aiProvider = AIProvider.GEMINI,
+            apiKey = "  test-key  "
+        )
+        assertTrue(state.byokSetupComplete)
+        assertTrue(state.canAdvance)
+    }
+
+    @Test
+    fun byokOllamaDoesNotRequireKey() {
+        val state = OnboardingState(
+            step = OnboardingStep.PROVIDER,
+            aiPhase = OnboardingAiPhase.BYOK,
+            aiProvider = AIProvider.OLLAMA,
+            apiKey = ""
+        )
+        assertTrue(state.byokSetupComplete)
+        assertTrue(state.canAdvance)
+    }
+
+    @Test
+    fun providerStepReopensByokWhenConfigured() {
+        val configured = OnboardingState(
+            step = OnboardingStep.PLAN_READY,
+            aiPhase = OnboardingAiPhase.BYOK,
+            aiProvider = AIProvider.GEMINI,
+            apiKey = "saved"
+        )
+        assertTrue(configured.aiPhaseForProviderStep() == OnboardingAiPhase.BYOK)
+
+        val fresh = OnboardingState(step = OnboardingStep.PROVIDER)
+        assertTrue(fresh.aiPhaseForProviderStep() == OnboardingAiPhase.CHOICE)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Android onboarding AI choice regressions and UX polish:

### 1) Continue disabled on BYOK path
- **Hide Continue on the choice screen** (matches iOS — no disabled ghost CTA)
- **Show Continue on BYOK** once required fields are valid (same rule as pre-choice onboarding: API key when required, Ollama exempt)
- **Fix `setAiProvider` race**: prefs write was async and could overwrite a key the user typed while the provider picker was open
- **`selectByokSetup()`** now flips to BYOK immediately and hydrates provider/model/key from prefs + keystore
- **Back navigation** restores BYOK phase when the user already configured a valid key (instead of always resetting to choice)

### 2) Hosted AI card copy
- Second card is now **Hosted AI** with a **Coming soon** badge (disabled, not tappable)
- Removed iOS/iPhone/iPad/Play Store/BYOK cross-platform disclaimer copy
- Renamed string keys (`onboarding_ai_hosted_*`) and updated all 18 locale files

### 3) Recommended badge layout
- **Fix letter-by-letter wrapping** of the "Recommended" pill next to "Bring Your Own Key"
- Badge uses `softWrap = false`, `maxLines = 1`; title ellipsizes up to 2 lines
- `FlowRow` drops the badge to a second line when horizontal space is tight instead of crushing the pill against the chevron

## Test plan
- [ ] Fresh onboarding → AI step: Continue hidden on choice screen
- [ ] Tap **Bring Your Own Key** → BYOK form appears, Continue visible
- [ ] Enter Gemini API key → Continue enables; tap Continue → Building Plan runs
- [ ] Select Ollama (no key) → Continue enables immediately
- [ ] Change provider in picker, type key quickly → key is not wiped; Continue enables
- [ ] Back from Plan Ready → returns to BYOK (not choice) when key already set
- [ ] Hosted AI card shows **Coming soon** (not "Hosted AI on iOS"), is not tappable, no iOS/Play Store copy
- [ ] **Recommended** badge stays one-line; on narrow width it moves below title, never letter-wraps
- [ ] iOS onboarding unchanged

## Notes
- Adds `OnboardingStateTest` unit tests for `canAdvance` / `byokSetupComplete` gating
- No Android Store subscriptions added; hosted remains unavailable on Android

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae266127-90ff-4ff5-96b9-20a628786c1a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae266127-90ff-4ff5-96b9-20a628786c1a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR revises Android onboarding’s AI-provider choice and BYOK setup flow, marks hosted AI as unavailable for now, and improves narrow-width badge layout.
- Hides Continue on the initial provider-choice phase and gates it on valid BYOK configuration.
- Hydrates saved provider, model, and key settings when BYOK is selected and restores BYOK when navigating back.
- Replaces the hosted-iOS messaging with localized Hosted AI/Coming soon copy.
- Adds state-level tests for provider-step advancement and back-navigation phase selection.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until BYOK hydration can no longer discard provider or model selections made after the form becomes interactive.

The provider form is exposed before saved preferences finish loading, and the eventual hydration unconditionally replaces current provider and model state, creating a realistic user-visible state race.

**Files Needing Attention:** android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/onboarding/OnboardingViewModel.kt

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/onboarding/OnboardingViewModel.kt | Adds BYOK completion and restoration logic, but asynchronous hydration can overwrite provider or model edits made after the form appears. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/onboarding/OnboardingScreen.kt | Conditionally displays Continue, disables hosted AI, and uses FlowRow to preserve one-line badges. |
| android/app/src/test/java/com/apoorvdarshan/calorietracker/ui/onboarding/OnboardingStateTest.kt | Covers advancement gates and phase selection, but does not exercise the asynchronous BYOK hydration interaction. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    C[AI choice] -->|Bring Your Own Key| H[Enter BYOK and hydrate saved settings]
    H --> F[Provider, model, and key form]
    F -->|Valid key or keyless provider| P[Continue]
    P --> B[Build plan]
    B --> R[Plan ready]
    R -->|Back| F
    C -. disabled .-> A[Hosted AI — Coming soon]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20apoorvdarshan%2Ffud-ai%20PR%20%23290%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=290&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fonboarding%2FOnboardingViewModel.kt%3A179-183%0A**Hydration%20overwrites%20user%20selections**%0A%0AAfter%20BYOK%20becomes%20interactive%2C%20loading%20the%20saved%20settings%20can%20still%20be%20suspended.%20If%20the%20user%20changes%20the%20provider%20or%20model%20during%20that%20time%2C%20this%20assignment%20unconditionally%20restores%20the%20previously%20saved%20values%2C%20discarding%20the%20visible%20selection%20and%20potentially%20pairing%20the%20form%20with%20the%20wrong%20credentials.%20Guard%20the%20hydration%20result%20against%20edits%20or%20finish%20hydration%20before%20enabling%20these%20controls.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=290&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22apoorvdarshan%2Ffud-ai%22%20on%20the%20existing%20branch%20%22cursor%2Fandroid-onboarding-continue-coming-soon-d449%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fandroid-onboarding-continue-coming-soon-d449%22.%0A%0A%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fonboarding%2FOnboardingViewModel.kt%3A179-183%0A**Hydration%20overwrites%20user%20selections**%0A%0AAfter%20BYOK%20becomes%20interactive%2C%20loading%20the%20saved%20settings%20can%20still%20be%20suspended.%20If%20the%20user%20changes%20the%20provider%20or%20model%20during%20that%20time%2C%20this%20assignment%20unconditionally%20restores%20the%20previously%20saved%20values%2C%20discarding%20the%20visible%20selection%20and%20potentially%20pairing%20the%20form%20with%20the%20wrong%20credentials.%20Guard%20the%20hydration%20result%20against%20edits%20or%20finish%20hydration%20before%20enabling%20these%20controls.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=290&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fonboarding%2FOnboardingViewModel.kt%3A179-183%0A**Hydration%20overwrites%20user%20selections**%0A%0AAfter%20BYOK%20becomes%20interactive%2C%20loading%20the%20saved%20settings%20can%20still%20be%20suspended.%20If%20the%20user%20changes%20the%20provider%20or%20model%20during%20that%20time%2C%20this%20assignment%20unconditionally%20restores%20the%20previously%20saved%20values%2C%20discarding%20the%20visible%20selection%20and%20potentially%20pairing%20the%20form%20with%20the%20wrong%20credentials.%20Guard%20the%20hydration%20result%20against%20edits%20or%20finish%20hydration%20before%20enabling%20these%20controls.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=290&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/onboarding/OnboardingViewModel.kt:179-183
**Hydration overwrites user selections**

After BYOK becomes interactive, loading the saved settings can still be suspended. If the user changes the provider or model during that time, this assignment unconditionally restores the previously saved values, discarding the visible selection and potentially pairing the form with the wrong credentials. Guard the hydration result against edits or finish hydration before enabling these controls.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Recommended badge letter-wrapping on..."](https://github.com/apoorvdarshan/fud-ai/commit/9b8947d4784c7e6708f50250c9d31a3c16fd55e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63521899)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved AI provider onboarding with adaptive titles and badges that wrap cleanly across screen sizes.
  - BYOK setup now restores the appropriate onboarding step and saved provider details when revisited.
  - The Continue action is appropriately unavailable during the initial provider-choice step.

- **Content Updates**
  - Hosted AI messaging is now platform-neutral across supported languages, highlighting Plus/Pro daily credits and upcoming availability.

- **Tests**
  - Added coverage for provider selection, BYOK validation, navigation, and setup restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->