### PR TITLE
Name Android debug app Fud AI Debug

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -31,6 +31,8 @@ android {
         targetSdk = 36
         versionCode = 35
         versionName = "7.0"
+        // Release uses localized @string/app_name; debug overrides to "Fud AI Debug".
+        manifestPlaceholders["launcherAppName"] = "@string/app_name"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -81,16 +83,19 @@ android {
         }
         debug {
             // Suffix the package + version so the debug build installs side-by-side
-            // with the production app pulled from Play Store. Launcher label stays
-            // "Fud AI" (same as release) — distinguish the two by the install order
-            // / icon position rather than a separate label.
+            // with the production app. Launcher label matches iOS Debug: "Fud AI Debug".
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-debug"
+            // Literal placeholder so locale app_name strings can't override the label.
+            manifestPlaceholders["launcherAppName"] = "Fud AI Debug"
+            resValue("string", "app_name", "Fud AI Debug")
         }
         create("debug2") {
             initWith(getByName("debug"))
             applicationIdSuffix = ".debug2"
             versionNameSuffix = "-debug2"
+            manifestPlaceholders["launcherAppName"] = "Fud AI Debug 2"
+            resValue("string", "app_name", "Fud AI Debug 2")
         }
     }
     compileOptions {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -51,7 +51,7 @@
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
+        android:label="${launcherAppName}"
         android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
@@ -66,7 +66,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
+            android:label="${launcherAppName}"
             android:launchMode="singleTop"
             android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.FudAI.Splash">


### PR DESCRIPTION
## Summary
- Android debug launcher label is now **Fud AI Debug** (matches iOS Debug)
- `debug2` uses **Fud AI Debug 2**
- Release keeps localized `@string/app_name` (**Fud AI**)

## Test plan
- [ ] Install debug APK → home screen shows **Fud AI Debug**
- [ ] Release/Play install still shows **Fud AI**

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces variant-specific Android launcher names while preserving the localized release name.
- Release resolves the new manifest placeholder to `@string/app_name`.
- Debug uses the literal label and generated resource `Fud AI Debug`.
- Debug2 is intended to use `Fud AI Debug 2`, but its new generated resource duplicates an existing debug2 resource and prevents that variant from building.

<h3>Confidence Score: 4/5</h3>

The PR is not safe to merge until the duplicate debug2 string resource is removed so that variant can build.

The release and ordinary debug label paths are coherent, but `debug2` now declares `app_name` through both its source set and `resValue`, causing a resource-merge failure for that build variant.

**Files Needing Attention:** android/app/build.gradle.kts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/build.gradle.kts | Adds release, debug, and debug2 launcher-label configuration; debug2 now has a duplicate `app_name` resource definition. |
| android/app/src/main/AndroidManifest.xml | Routes the application and main activity labels through the new build-variant manifest placeholder. |

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20apoorvdarshan%2Ffud-ai%20PR%20%23291%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=291&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fbuild.gradle.kts%3A98%0A**Duplicate%20debug2%20app%20name**%0A%0AThe%20%60debug2%60%20source%20set%20already%20defines%20%60app_name%60%20in%20%60android%2Fapp%2Fsrc%2Fdebug2%2Fres%2Fvalues%2Fstrings.xml%60.%20Adding%20the%20same%20resource%20with%20%60resValue%60%20creates%20two%20definitions%20for%20this%20variant%2C%20so%20Android%20resource%20merging%20fails%20and%20%60assembleDebug2%60%20cannot%20build.%20Keep%20only%20one%20definition%20of%20the%20Debug%202%20label.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=291&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22apoorvdarshan%2Ffud-ai%22%20on%20the%20existing%20branch%20%22fix%2Fandroid-debug-app-name%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fandroid-debug-app-name%22.%0A%0A%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fbuild.gradle.kts%3A98%0A**Duplicate%20debug2%20app%20name**%0A%0AThe%20%60debug2%60%20source%20set%20already%20defines%20%60app_name%60%20in%20%60android%2Fapp%2Fsrc%2Fdebug2%2Fres%2Fvalues%2Fstrings.xml%60.%20Adding%20the%20same%20resource%20with%20%60resValue%60%20creates%20two%20definitions%20for%20this%20variant%2C%20so%20Android%20resource%20merging%20fails%20and%20%60assembleDebug2%60%20cannot%20build.%20Keep%20only%20one%20definition%20of%20the%20Debug%202%20label.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=291&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fbuild.gradle.kts%3A98%0A**Duplicate%20debug2%20app%20name**%0A%0AThe%20%60debug2%60%20source%20set%20already%20defines%20%60app_name%60%20in%20%60android%2Fapp%2Fsrc%2Fdebug2%2Fres%2Fvalues%2Fstrings.xml%60.%20Adding%20the%20same%20resource%20with%20%60resValue%60%20creates%20two%20definitions%20for%20this%20variant%2C%20so%20Android%20resource%20merging%20fails%20and%20%60assembleDebug2%60%20cannot%20build.%20Keep%20only%20one%20definition%20of%20the%20Debug%202%20label.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=291&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
android/app/build.gradle.kts:98
**Duplicate debug2 app name**

The `debug2` source set already defines `app_name` in `android/app/src/debug2/res/values/strings.xml`. Adding the same resource with `resValue` creates two definitions for this variant, so Android resource merging fails and `assembleDebug2` cannot build. Keep only one definition of the Debug 2 label.

```suggestion

```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Name Android debug launcher Fud AI Debug..."](https://github.com/apoorvdarshan/fud-ai/commit/d5a47e5f896c314988046705ba2b4fef9c894499) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63524047)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->