### PR TITLE
Fix Android debug label build (drop resValue)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -88,14 +88,12 @@ android {
             versionNameSuffix = "-debug"
             // Literal placeholder so locale app_name strings can't override the label.
             manifestPlaceholders["launcherAppName"] = "Fud AI Debug"
-            resValue("string", "app_name", "Fud AI Debug")
         }
         create("debug2") {
             initWith(getByName("debug"))
             applicationIdSuffix = ".debug2"
             versionNameSuffix = "-debug2"
             manifestPlaceholders["launcherAppName"] = "Fud AI Debug 2"
-            resValue("string", "app_name", "Fud AI Debug 2")
         }
     }
     compileOptions {


### PR DESCRIPTION
## Summary
- Remove `resValue` for debug `app_name` — AGP reports custom resource values disabled
- Keep **Fud AI Debug** via `manifestPlaceholders[launcherAppName]`

## Test plan
- [ ] `./gradlew :app:assembleDebug` succeeds
- [ ] Launcher shows Fud AI Debug

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes Gradle-generated `app_name` resources from the Android debug build types and relies on manifest placeholders for debug naming.
- Avoids the disabled custom-resource-value path that prevented the debug build.
- Preserves application and activity labels through `launcherAppName`.
- Does not preserve the primary debug launcher alias label, which still reads `@string/app_name`.

<h3>Confidence Score: 4/5</h3>

The PR is not safe to merge as written because the standard debug build no longer displays the required “Fud AI Debug” launcher label.

The retained manifest placeholder only controls application and activity labels, while the enabled launcher alias resolves the now-unmodified production `app_name` resource.

**Files Needing Attention:** android/app/build.gradle.kts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/build.gradle.kts | Removes debug resource overrides, fixing the reported build configuration problem but regressing the primary debug launcher's visible label. |

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20apoorvdarshan%2Ffud-ai%20PR%20%23292%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=292&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fbuild.gradle.kts%3A90%0A**Debug%20launcher%20label%20regresses**%0A%0ARemoving%20the%20debug%20%60app_name%60%20override%20does%20not%20preserve%20the%20intended%20launcher%20label.%20The%20enabled%20%60FudPinkLauncherActivity%60%20alias%20uses%20%60%40string%2Fapp_name%60%2C%20not%20%60%24%7BlauncherAppName%7D%60.%20Because%20the%20debug%20source%20set%20has%20no%20replacement%20resource%2C%20the%20launcher%20label%20now%20resolves%20to%20the%20production%20value%2C%20%E2%80%9CFud%20AI%2C%E2%80%9D%20instead%20of%20%E2%80%9CFud%20AI%20Debug.%E2%80%9D%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=292&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22apoorvdarshan%2Ffud-ai%22%20on%20the%20existing%20branch%20%22fix%2Fandroid-debug-app-name-no-resvalue%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fandroid-debug-app-name-no-resvalue%22.%0A%0A%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fbuild.gradle.kts%3A90%0A**Debug%20launcher%20label%20regresses**%0A%0ARemoving%20the%20debug%20%60app_name%60%20override%20does%20not%20preserve%20the%20intended%20launcher%20label.%20The%20enabled%20%60FudPinkLauncherActivity%60%20alias%20uses%20%60%40string%2Fapp_name%60%2C%20not%20%60%24%7BlauncherAppName%7D%60.%20Because%20the%20debug%20source%20set%20has%20no%20replacement%20resource%2C%20the%20launcher%20label%20now%20resolves%20to%20the%20production%20value%2C%20%E2%80%9CFud%20AI%2C%E2%80%9D%20instead%20of%20%E2%80%9CFud%20AI%20Debug.%E2%80%9D%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=292&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fbuild.gradle.kts%3A90%0A**Debug%20launcher%20label%20regresses**%0A%0ARemoving%20the%20debug%20%60app_name%60%20override%20does%20not%20preserve%20the%20intended%20launcher%20label.%20The%20enabled%20%60FudPinkLauncherActivity%60%20alias%20uses%20%60%40string%2Fapp_name%60%2C%20not%20%60%24%7BlauncherAppName%7D%60.%20Because%20the%20debug%20source%20set%20has%20no%20replacement%20resource%2C%20the%20launcher%20label%20now%20resolves%20to%20the%20production%20value%2C%20%E2%80%9CFud%20AI%2C%E2%80%9D%20instead%20of%20%E2%80%9CFud%20AI%20Debug.%E2%80%9D%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=292&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
android/app/build.gradle.kts:90
**Debug launcher label regresses**

Removing the debug `app_name` override does not preserve the intended launcher label. The enabled `FudPinkLauncherActivity` alias uses `@string/app_name`, not `${launcherAppName}`. Because the debug source set has no replacement resource, the launcher label now resolves to the production value, “Fud AI,” instead of “Fud AI Debug.”

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Drop debug resValue for app\_name; AGP ha..."](https://github.com/apoorvdarshan/fud-ai/commit/cc66fd87565f28760846ba46f4fe9be5c209acae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63524269)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->