### PR TITLE
Fix Fud AI Debug name on themed launcher icons

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -105,7 +105,7 @@
             android:enabled="true"
             android:exported="true"
             android:icon="@mipmap/ic_launcher"
-            android:label="@string/app_name"
+            android:label="${launcherAppName}"
             android:roundIcon="@mipmap/ic_launcher_round"
             android:targetActivity=".MainActivity">
             <intent-filter>
@@ -119,7 +119,7 @@
             android:enabled="false"
             android:exported="true"
             android:icon="@mipmap/ic_launcher_red"
-            android:label="@string/app_name"
+            android:label="${launcherAppName}"
             android:roundIcon="@mipmap/ic_launcher_red_round"
             android:targetActivity=".MainActivity">
             <intent-filter>
@@ -133,7 +133,7 @@
             android:enabled="false"
             android:exported="true"
             android:icon="@mipmap/ic_launcher_orange"
-            android:label="@string/app_name"
+            android:label="${launcherAppName}"
             android:roundIcon="@mipmap/ic_launcher_orange_round"
             android:targetActivity=".MainActivity">
             <intent-filter>
@@ -147,7 +147,7 @@
             android:enabled="false"
             android:exported="true"
             android:icon="@mipmap/ic_launcher_green"
-            android:label="@string/app_name"
+            android:label="${launcherAppName}"
             android:roundIcon="@mipmap/ic_launcher_green_round"
             android:targetActivity=".MainActivity">
             <intent-filter>
@@ -161,7 +161,7 @@
             android:enabled="false"
             android:exported="true"
             android:icon="@mipmap/ic_launcher_mint"
-            android:label="@string/app_name"
+            android:label="${launcherAppName}"
             android:roundIcon="@mipmap/ic_launcher_mint_round"
             android:targetActivity=".MainActivity">
             <intent-filter>
@@ -175,7 +175,7 @@
             android:enabled="false"
             android:exported="true"
             android:icon="@mipmap/ic_launcher_teal"
-            android:label="@string/app_name"
+            android:label="${launcherAppName}"
             android:roundIcon="@mipmap/ic_launcher_teal_round"
             android:targetActivity=".MainActivity">
             <intent-filter>
@@ -189,7 +189,7 @@
             android:enabled="false"
             android:exported="true"
             android:icon="@mipmap/ic_launcher_blue"
-            android:label="@string/app_name"
+            android:label="${launcherAppName}"
             android:roundIcon="@mipmap/ic_launcher_blue_round"
             android:targetActivity=".MainActivity">
             <intent-filter>
@@ -203,7 +203,7 @@
             android:enabled="false"
             android:exported="true"
             android:icon="@mipmap/ic_launcher_purple"
-            android:label="@string/app_name"
+            android:label="${launcherAppName}"
             android:roundIcon="@mipmap/ic_launcher_purple_round"
             android:targetActivity=".MainActivity">
             <intent-filter>
@@ -217,7 +217,7 @@
             android:enabled="false"
             android:exported="true"
             android:icon="@mipmap/ic_launcher_yellow"
-            android:label="@string/app_name"
+            android:label="${launcherAppName}"
             android:roundIcon="@mipmap/ic_launcher_yellow_round"
             android:targetActivity=".MainActivity">
             <intent-filter>
@@ -231,7 +231,7 @@
             android:enabled="false"
             android:exported="true"
             android:icon="@mipmap/ic_launcher_coral"
-            android:label="@string/app_name"
+            android:label="${launcherAppName}"
             android:roundIcon="@mipmap/ic_launcher_coral_round"
             android:targetActivity=".MainActivity">
             <intent-filter>
@@ -245,7 +245,7 @@
             android:enabled="false"
             android:exported="true"
             android:icon="@mipmap/ic_launcher_rose_gold"
-            android:label="@string/app_name"
+            android:label="${launcherAppName}"
             android:roundIcon="@mipmap/ic_launcher_rose_gold_round"
             android:targetActivity=".MainActivity">
             <intent-filter>
@@ -259,7 +259,7 @@
             android:enabled="false"
             android:exported="true"
             android:icon="@mipmap/ic_launcher_mocha_brown"
-            android:label="@string/app_name"
+            android:label="${launcherAppName}"
             android:roundIcon="@mipmap/ic_launcher_mocha_brown_round"
             android:targetActivity=".MainActivity">
             <intent-filter>
@@ -273,7 +273,7 @@
             android:enabled="false"
             android:exported="true"
             android:icon="@mipmap/ic_launcher_indigo"
-            android:label="@string/app_name"
+            android:label="${launcherAppName}"
             android:roundIcon="@mipmap/ic_launcher_indigo_round"
             android:targetActivity=".MainActivity">
             <intent-filter>
@@ -287,7 +287,7 @@
             android:enabled="false"
             android:exported="true"
             android:icon="@mipmap/ic_launcher_lavender"
-            android:label="@string/app_name"
+            android:label="${launcherAppName}"
             android:roundIcon="@mipmap/ic_launcher_lavender_round"
             android:targetActivity=".MainActivity">
             <intent-filter>
@@ -301,7 +301,7 @@
             android:enabled="false"
             android:exported="true"
             android:icon="@mipmap/ic_launcher_sky_cyan"
-            android:label="@string/app_name"
+            android:label="${launcherAppName}"
             android:roundIcon="@mipmap/ic_launcher_sky_cyan_round"
             android:targetActivity=".MainActivity">
             <intent-filter>
@@ -315,7 +315,7 @@
             android:enabled="false"
             android:exported="true"
             android:icon="@mipmap/ic_launcher_graphite"
-            android:label="@string/app_name"
+            android:label="${launcherAppName}"
             android:roundIcon="@mipmap/ic_launcher_graphite_round"
             android:targetActivity=".MainActivity">
             <intent-filter>
@@ -329,7 +329,7 @@
             android:enabled="false"
             android:exported="true"
             android:icon="@mipmap/ic_launcher_baby_pink"
-            android:label="@string/app_name"
+            android:label="${launcherAppName}"
             android:roundIcon="@mipmap/ic_launcher_baby_pink_round"
             android:targetActivity=".MainActivity">
             <intent-filter>
@@ -343,7 +343,7 @@
             android:enabled="false"
             android:exported="true"
             android:icon="@mipmap/ic_launcher_lime"
-            android:label="@string/app_name"
+            android:label="${launcherAppName}"
             android:roundIcon="@mipmap/ic_launcher_lime_round"
             android:targetActivity=".MainActivity">
             <intent-filter>


### PR DESCRIPTION
## Summary
- Themed `activity-alias` launchers now use `${launcherAppName}` so debug shows **Fud AI Debug** on the home screen (not just the application tag).

## Test plan
- [ ] Debug install → home screen icon labeled **Fud AI Debug**

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates every themed launcher alias to use the build-variant-aware `launcherAppName` manifest placeholder.
- Debug launchers now display `Fud AI Debug` or `Fud AI Debug 2`.
- Release launchers continue to resolve the `@string/app_name` resource.
- No actionable correctness, security, or maintainability issues were identified.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because all supported Android variants resolve the launcher label correctly.

The placeholder is configured for every build type and already works elsewhere in the manifest; the aliases now consistently inherit the intended release, debug, or debug2 label.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/src/main/AndroidManifest.xml | Consistently changes themed activity-alias labels to the existing, fully configured launcher-name placeholder. |

<sub>Reviews (1): Last reviewed commit: ["Apply Fud AI Debug label to themed launc..."](https://github.com/apoorvdarshan/fud-ai/commit/440151e4ee174c501fc8ebb30bbc074544885555) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63524553)</sub>

<!-- /greptile_comment -->