### PR TITLE
Restore About credentials and Android Settings tab re-tap

### DIFF
--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/about/AboutScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/about/AboutScreen.kt
@@ -3,6 +3,7 @@ package com.apoorvdarshan.calorietracker.ui.about
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -28,6 +29,7 @@ import androidx.compose.material.icons.filled.AlternateEmail
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Work
 import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material.icons.filled.Business
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.Description
@@ -36,12 +38,14 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.Lightbulb
 import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Security
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.StarRate
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.filled.SystemUpdate
 import androidx.compose.material.icons.filled.ThumbUp
+import androidx.compose.material.icons.filled.Verified
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -172,6 +176,22 @@ fun AboutSettingsRows(category: AboutSettingsCategory) {
                 AboutRow(Icons.Filled.Code, stringResource(R.string.about_open_source)) {
                     open("https://github.com/apoorvdarshan/fud-ai")
                 }
+                Hairline()
+                AboutRow(
+                    Icons.Filled.Verified,
+                    stringResource(R.string.about_openssf_best_practices),
+                    subtitle = stringResource(R.string.about_openssf_best_practices_desc)
+                ) {
+                    open("https://www.bestpractices.dev/projects/14553")
+                }
+                Hairline()
+                AboutRow(
+                    Icons.Filled.Security,
+                    stringResource(R.string.about_openssf_scorecard),
+                    subtitle = stringResource(R.string.about_openssf_scorecard_desc)
+                ) {
+                    open("https://scorecard.dev/viewer/?uri=github.com/apoorvdarshan/fud-ai")
+                }
             }
 
             AboutSettingsCategory.SUPPORT -> {
@@ -229,6 +249,23 @@ fun AboutSettingsRows(category: AboutSettingsCategory) {
                 Hairline()
                 AboutRow(Icons.Filled.Description, stringResource(R.string.about_terms)) {
                     open("https://fud-ai.app/terms.html")
+                }
+                Hairline()
+                AboutRow(
+                    Icons.Filled.Business,
+                    stringResource(R.string.about_udyam),
+                    subtitle = stringResource(R.string.about_udyam_desc)
+                ) {
+                    open("https://udyamregistration.gov.in/")
+                }
+                Hairline()
+                AboutRow(
+                    iconRes = R.drawable.ace_cpt_mark,
+                    label = stringResource(R.string.about_ace),
+                    subtitle = stringResource(R.string.about_ace_desc),
+                    iconSize = 28.dp
+                ) {
+                    open("https://credentials.acefitness.org/d23fcb24-899b-4588-be1b-93298a039289")
                 }
                 Hairline()
                 AboutRow(
@@ -463,6 +500,56 @@ private fun AboutRow(
     trailing: (@Composable () -> Unit)? = null,
     onClick: () -> Unit
 ) {
+    AboutRow(
+        iconContent = {
+            Icon(
+                icon,
+                contentDescription = null,
+                tint = AppColors.Calorie,
+                modifier = Modifier.size(22.dp)
+            )
+        },
+        label = label,
+        subtitle = subtitle,
+        showDot = showDot,
+        trailing = trailing,
+        onClick = onClick
+    )
+}
+
+@Composable
+private fun AboutRow(
+    @DrawableRes iconRes: Int,
+    label: String,
+    subtitle: String? = null,
+    iconSize: androidx.compose.ui.unit.Dp = 22.dp,
+    onClick: () -> Unit
+) {
+    AboutRow(
+        iconContent = {
+            Image(
+                painter = painterResource(iconRes),
+                contentDescription = null,
+                modifier = Modifier
+                    .size(iconSize)
+                    .clip(RoundedCornerShape(4.dp))
+            )
+        },
+        label = label,
+        subtitle = subtitle,
+        onClick = onClick
+    )
+}
+
+@Composable
+private fun AboutRow(
+    iconContent: @Composable () -> Unit,
+    label: String,
+    subtitle: String? = null,
+    showDot: Boolean = false,
+    trailing: (@Composable () -> Unit)? = null,
+    onClick: () -> Unit
+) {
     Row(
         Modifier
             .fillMaxWidth()
@@ -470,13 +557,8 @@ private fun AboutRow(
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Box(Modifier.size(22.dp), contentAlignment = Alignment.Center) {
-            Icon(
-                icon,
-                contentDescription = null,
-                tint = AppColors.Calorie,
-                modifier = Modifier.size(22.dp)
-            )
+        Box(Modifier.size(28.dp), contentAlignment = Alignment.Center) {
+            iconContent()
             if (showDot) {
                 Box(
                     Modifier
@@ -487,7 +569,7 @@ private fun AboutRow(
                 )
             }
         }
-        Spacer(Modifier.width(16.dp))
+        Spacer(Modifier.width(14.dp))
         Column(Modifier.weight(1f)) {
             Text(label, fontSize = 17.sp, color = MaterialTheme.colorScheme.onSurface)
             if (!subtitle.isNullOrBlank()) {
@@ -509,7 +591,7 @@ private fun AboutRow(
 private fun Hairline() {
     Box(
         Modifier
-            .padding(start = 54.dp)
+            .padding(start = 58.dp)
             .fillMaxWidth()
             .height(0.5.dp)
             .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f))

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/navigation/FudAINavHost.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/navigation/FudAINavHost.kt
@@ -94,7 +94,13 @@ fun FudAINavHost(
     // Match iOS's versioned AppStorage key: reset the former library-first
     // default once, then keep every user switch persistent after that.
     val workoutMode = if (workoutModeV2Initialized) persistedWorkoutMode else WorkoutTabMode.LOG
-    val showTabs = currentRoute in FudAIRoutes.bottomTabs && !analyzing
+    // Nested settings/* screens keep the tab bar visible and highlight Settings,
+    // so re-tapping the Settings icon can return to the hub (iOS parity).
+    val selectedTabRoute = FudAIRoutes.selectedBottomTab(currentRoute)
+    val showTabs = selectedTabRoute != null && !analyzing
+    // Bumped when the Settings tab is re-tapped so SettingsScreen can pop back to the hub
+    // (matches iOS TabView + NavigationStack reselect → root behavior).
+    var settingsPopToRootTick by remember { mutableIntStateOf(0) }
     val currentVersion = remember(context) { AndroidUpdateChecker.currentVersion(context) }
     var updateAvailable by remember { mutableStateOf(false) }
 
@@ -166,11 +172,25 @@ fun FudAINavHost(
         bottomBar = {
             if (showTabs) {
                 FudAIBottomNavBar(
-                    currentRoute = currentRoute,
+                    currentRoute = selectedTabRoute,
                     showAboutBadge = updateAvailable,
                     workoutMode = workoutMode,
                     onTap = { target ->
-                        if (target == currentRoute) return@FudAIBottomNavBar
+                        // Re-tapping Settings while already in Settings (hub category or a
+                        // nested settings/* destination) returns to the Settings hub — same
+                        // as iOS re-tapping the Settings tab to pop the navigation stack.
+                        if (target == FudAIRoutes.SETTINGS) {
+                            val onSettingsRoot = currentRoute == FudAIRoutes.SETTINGS
+                            val onSettingsChild = currentRoute?.startsWith("settings/") == true
+                            if (onSettingsRoot || onSettingsChild) {
+                                settingsPopToRootTick++
+                                if (onSettingsChild) {
+                                    nav.popBackStack(FudAIRoutes.SETTINGS, inclusive = false)
+                                }
+                                return@FudAIBottomNavBar
+                            }
+                        }
+                        if (target == selectedTabRoute) return@FudAIBottomNavBar
                         // Tapping HOME (the start destination) needs popBackStack
                         // — `navigate(HOME) { popUpTo(HOME); launchSingleTop = true }`
                         // is a no-op because NavController sees HOME at the top of
@@ -217,7 +237,12 @@ fun FudAINavHost(
                 composable(FudAIRoutes.COACH) { TabInset { CoachScreen(container = container) } }
                 composable(FudAIRoutes.SETTINGS) {
                     TabInset {
-                        SettingsScreen(container = container, nav = nav, vm = settingsViewModel)
+                        SettingsScreen(
+                            container = container,
+                            nav = nav,
+                            vm = settingsViewModel,
+                            popToRootTick = settingsPopToRootTick
+                        )
                     }
                 }
                 composable(FudAIRoutes.OPTIONAL_NUTRIENT_GOALS) {

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/navigation/FudAIRoutes.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/navigation/FudAIRoutes.kt
@@ -15,4 +15,12 @@ object FudAIRoutes {
     const val WORKOUTS = "workouts"
 
     val bottomTabs = listOf(HOME, PROGRESS, COACH, SETTINGS, WORKOUTS)
+
+    /** Maps a Nav destination to the bottom-tab route that should appear selected. */
+    fun selectedBottomTab(route: String?): String? = when {
+        route == null -> null
+        route in bottomTabs -> route
+        route.startsWith("settings/") -> SETTINGS
+        else -> null
+    }
 }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt
@@ -291,7 +291,12 @@ internal enum class SettingsCategory(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SettingsScreen(container: AppContainer, nav: NavHostController, vm: SettingsViewModel) {
+fun SettingsScreen(
+    container: AppContainer,
+    nav: NavHostController,
+    vm: SettingsViewModel,
+    popToRootTick: Int = 0
+) {
     val ui by vm.ui.collectAsState()
     val profile = ui.profile
     val latestMeasurement by container.bodyMeasurementRepository.latest.collectAsState(initial = null)
@@ -322,6 +327,11 @@ fun SettingsScreen(container: AppContainer, nav: NavHostController, vm: Settings
     var showCloudDeleteConfirm by remember { mutableStateOf(false) }
     var cloudBackupError by remember { mutableStateOf<String?>(null) }
     var selectedCategory by rememberSaveable { mutableStateOf<SettingsCategory?>(null) }
+    LaunchedEffect(popToRootTick) {
+        if (popToRootTick > 0) {
+            selectedCategory = null
+        }
+    }
     val settingsHomeScrollState = rememberScrollState()
     val settingsDetailScrollState = remember(selectedCategory) { ScrollState(initial = 0) }
     var pendingHealthPermissionAction by remember { mutableStateOf<HealthConnectPermissionAction?>(null) }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -905,6 +905,14 @@
     <string name="about_rate">Rate the App</string>
     <string name="about_share">Share the App</string>
     <string name="about_open_source">Open Source (MIT)</string>
+    <string name="about_openssf_best_practices">OpenSSF Best Practices</string>
+    <string name="about_openssf_best_practices_desc">Passing · project 14553</string>
+    <string name="about_openssf_scorecard">OpenSSF Scorecard</string>
+    <string name="about_openssf_scorecard_desc">Security health score</string>
+    <string name="about_udyam">Udyam Registered</string>
+    <string name="about_udyam_desc">UDYAM-DL-06-0225072 · Micro enterprise</string>
+    <string name="about_ace">ACE Certified</string>
+    <string name="about_ace_desc">Personal Trainer · NCCA-accredited</string>
     <string name="about_star_github">Star on GitHub</string>
     <string name="about_vote_ph">Vote on Product Hunt</string>
     <string name="about_leave_tip_kofi">Leave a Tip on Ko-fi</string>

--- a/android/app/src/test/java/com/apoorvdarshan/calorietracker/ui/navigation/FudAIRoutesTest.kt
+++ b/android/app/src/test/java/com/apoorvdarshan/calorietracker/ui/navigation/FudAIRoutesTest.kt
@@ -1,0 +1,23 @@
+package com.apoorvdarshan.calorietracker.ui.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class FudAIRoutesTest {
+    @Test
+    fun selectedBottomTabMapsNestedSettingsToSettings() {
+        assertEquals(FudAIRoutes.SETTINGS, FudAIRoutes.selectedBottomTab(FudAIRoutes.SETTINGS))
+        assertEquals(
+            FudAIRoutes.SETTINGS,
+            FudAIRoutes.selectedBottomTab(FudAIRoutes.QUICK_ACTIONS)
+        )
+        assertEquals(
+            FudAIRoutes.SETTINGS,
+            FudAIRoutes.selectedBottomTab(FudAIRoutes.OPTIONAL_NUTRIENT_GOALS)
+        )
+        assertEquals(FudAIRoutes.HOME, FudAIRoutes.selectedBottomTab(FudAIRoutes.HOME))
+        assertNull(FudAIRoutes.selectedBottomTab(FudAIRoutes.ONBOARDING))
+        assertNull(FudAIRoutes.selectedBottomTab(null))
+    }
+}

--- a/ios/calorietracker/ContentView.swift
+++ b/ios/calorietracker/ContentView.swift
@@ -346,6 +346,36 @@ private struct AboutSettingsSections: View {
                         }
                     }
                     .tint(.primary)
+
+                    Link(destination: URL(string: "https://www.bestpractices.dev/projects/14553")!) {
+                        Label {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("OpenSSF Best Practices")
+                                Text("Passing · project 14553")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        } icon: {
+                            Image(systemName: "checkmark.seal.fill")
+                                .foregroundStyle(AppColors.calorie)
+                        }
+                    }
+                    .tint(.primary)
+
+                    Link(destination: URL(string: "https://scorecard.dev/viewer/?uri=github.com/apoorvdarshan/fud-ai")!) {
+                        Label {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("OpenSSF Scorecard")
+                                Text("Security health score")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        } icon: {
+                            Image(systemName: "shield.checkered")
+                                .foregroundStyle(AppColors.calorie)
+                        }
+                    }
+                    .tint(.primary)
                 }
                 .listRowBackground(AppColors.appCard)
 
@@ -493,6 +523,39 @@ private struct AboutSettingsSections: View {
                     } icon: {
                         Image(systemName: "doc.text.fill")
                             .foregroundStyle(AppColors.calorie)
+                    }
+                }
+                .tint(.primary)
+
+                Link(destination: URL(string: "https://udyamregistration.gov.in/")!) {
+                    Label {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Udyam Registered")
+                            Text("UDYAM-DL-06-0225072 · Micro enterprise")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    } icon: {
+                        Image(systemName: "building.2.fill")
+                            .foregroundStyle(AppColors.calorie)
+                    }
+                }
+                .tint(.primary)
+
+                Link(destination: URL(string: "https://credentials.acefitness.org/d23fcb24-899b-4588-be1b-93298a039289")!) {
+                    Label {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("ACE Certified")
+                            Text("Personal Trainer · NCCA-accredited")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    } icon: {
+                        Image("ACECPTMark")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 28, height: 28)
+                            .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
                     }
                 }
                 .tint(.primary)

--- a/ios/calorietracker/Localizable.xcstrings
+++ b/ios/calorietracker/Localizable.xcstrings
@@ -61673,6 +61673,86 @@
           }
         }
       }
+    },
+    "OpenSSF Best Practices": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenSSF Best Practices"
+          }
+        }
+      }
+    },
+    "Passing · project 14553": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passing · project 14553"
+          }
+        }
+      }
+    },
+    "OpenSSF Scorecard": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenSSF Scorecard"
+          }
+        }
+      }
+    },
+    "Security health score": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Security health score"
+          }
+        }
+      }
+    },
+    "Udyam Registered": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Udyam Registered"
+          }
+        }
+      }
+    },
+    "UDYAM-DL-06-0225072 · Micro enterprise": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "UDYAM-DL-06-0225072 · Micro enterprise"
+          }
+        }
+      }
+    },
+    "ACE Certified": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ACE Certified"
+          }
+        }
+      }
+    },
+    "Personal Trainer · NCCA-accredited": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personal Trainer · NCCA-accredited"
+          }
+        }
+      }
     }
   },
   "version": "1.1"


### PR DESCRIPTION
## Summary
- Restore OpenSSF Best Practices / Scorecard, Udyam, and ACE Certified rows in About on **iOS and Android** (both were missing on `main`)
- Android: re-tapping Settings returns to the Settings hub (category + nested `settings/*` screens), matching iOS tab reselect

## Test plan
- [ ] iOS: Settings → App & Updates shows OpenSSF rows; Legal shows Udyam + ACE
- [ ] Android: same About rows; Discord/Instagram still present in Community
- [ ] Android: open a Settings category / nested screen, re-tap Settings tab → back to hub

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restores OpenSSF, Udyam, and ACE credential rows in the iOS and Android About screens and adds Android Settings-tab reselect behavior.
- Maps nested `settings/*` destinations to the Settings bottom tab.
- Pops NavController-backed Settings children and state-backed categories to the Settings hub.
- Adds the credential labels, descriptions, links, and ACE image rendering on both platforms.
- The implementation paths appear coherent, but the regression test covers only route mapping rather than the reselect interaction itself.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking gap in regression coverage for the Android Settings re-tap interaction.

The route coverage, back-stack structure, state reset, and credential resources are internally consistent; the only accepted concern is that the added unit test cannot detect regressions in the actual re-tap event and navigation flow.

**Files Needing Attention:** android/app/src/test/java/com/apoorvdarshan/calorietracker/ui/navigation/FudAIRoutesTest.kt

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/navigation/FudAINavHost.kt | Adds nested Settings tab visibility, selection, and re-tap handling through back-stack popping and a root-reset tick. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/navigation/FudAIRoutes.kt | Maps static nested Settings routes to the Settings bottom-tab route. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/settings/SettingsScreen.kt | Observes Settings reselect events and clears the state-backed category selection. |
| android/app/src/test/java/com/apoorvdarshan/calorietracker/ui/navigation/FudAIRoutesTest.kt | Verifies route mapping but does not exercise the newly restored tab-reselect navigation behavior. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/ui/about/AboutScreen.kt | Restores credential rows and adds drawable-backed About-row icon support. |
| ios/calorietracker/ContentView.swift | Restores the OpenSSF, Udyam, and ACE credential links in the iOS About sections. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Tap Settings tab] --> B{Current Settings state}
  B -->|Hub| C[No navigation change]
  B -->|State-backed category| D[Increment pop-to-root tick]
  D --> E[SettingsScreen clears selectedCategory]
  B -->|settings/* destination| F[Increment pop-to-root tick]
  F --> G[Pop back stack to settings]
  G --> E
  E --> H[Settings hub]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20apoorvdarshan%2Ffud-ai%20PR%20%23294%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=294&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Ftest%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fnavigation%2FFudAIRoutesTest.kt%3A8-21%0A**Reselect%20Flow%20Is%20Untested**%0A%0AThis%20test%20only%20checks%20route-to-tab%20mapping.%20It%20can%20still%20pass%20if%20tapping%20Settings%20again%20fails%20to%20pop%20a%20nested%20destination%20or%20clear%20the%20selected%20category.%20Add%20a%20navigation%20or%20Compose%20test%20that%20opens%20both%20kinds%20of%20Settings%20detail%20and%20re-taps%20the%20Settings%20tab%20so%20regressions%20in%20the%20restored%20behavior%20are%20caught.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=294&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22apoorvdarshan%2Ffud-ai%22%20on%20the%20existing%20branch%20%22cursor%2Fabout-credentials-settings-retap%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fabout-credentials-settings-retap%22.%0A%0A%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Ftest%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fnavigation%2FFudAIRoutesTest.kt%3A8-21%0A**Reselect%20Flow%20Is%20Untested**%0A%0AThis%20test%20only%20checks%20route-to-tab%20mapping.%20It%20can%20still%20pass%20if%20tapping%20Settings%20again%20fails%20to%20pop%20a%20nested%20destination%20or%20clear%20the%20selected%20category.%20Add%20a%20navigation%20or%20Compose%20test%20that%20opens%20both%20kinds%20of%20Settings%20detail%20and%20re-taps%20the%20Settings%20tab%20so%20regressions%20in%20the%20restored%20behavior%20are%20caught.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=294&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aandroid%2Fapp%2Fsrc%2Ftest%2Fjava%2Fcom%2Fapoorvdarshan%2Fcalorietracker%2Fui%2Fnavigation%2FFudAIRoutesTest.kt%3A8-21%0A**Reselect%20Flow%20Is%20Untested**%0A%0AThis%20test%20only%20checks%20route-to-tab%20mapping.%20It%20can%20still%20pass%20if%20tapping%20Settings%20again%20fails%20to%20pop%20a%20nested%20destination%20or%20clear%20the%20selected%20category.%20Add%20a%20navigation%20or%20Compose%20test%20that%20opens%20both%20kinds%20of%20Settings%20detail%20and%20re-taps%20the%20Settings%20tab%20so%20regressions%20in%20the%20restored%20behavior%20are%20caught.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apoorvdarshan%2Ffud-ai&pr=294&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
android/app/src/test/java/com/apoorvdarshan/calorietracker/ui/navigation/FudAIRoutesTest.kt:8-21
**Reselect Flow Is Untested**

This test only checks route-to-tab mapping. It can still pass if tapping Settings again fails to pop a nested destination or clear the selected category. Add a navigation or Compose test that opens both kinds of Settings detail and re-taps the Settings tab so regressions in the restored behavior are caught.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Restore About credentials and Android Se..."](https://github.com/apoorvdarshan/fud-ai/commit/7b77fe3f2a3927596413d69204271806a067e496) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63524980)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->