### PR TITLE
Fix C3/H7/M1: decode failures no longer wipe the diary, duplicate ids no longer trap, corrupt DataStore no longer crash-loops

### DIFF
--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/FudAIApp.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/FudAIApp.kt
@@ -1,6 +1,7 @@
 package com.apoorvdarshan.calorietracker
 
 import android.app.Application
+import android.util.Log
 import com.apoorvdarshan.calorietracker.data.BodyFatRepository
 import com.apoorvdarshan.calorietracker.data.BodyMeasurementRepository
 import com.apoorvdarshan.calorietracker.data.ChatRepository
@@ -36,6 +37,7 @@ import com.apoorvdarshan.calorietracker.services.ondevice.LocalWhisperRuntime
 import com.apoorvdarshan.calorietracker.services.speech.SpeechService
 import com.apoorvdarshan.calorietracker.widget.WidgetRefreshScheduler
 import kotlin.math.roundToInt
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -58,7 +60,14 @@ class FudAIApp : Application() {
     lateinit var container: AppContainer
         private set
 
-    private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    // Startup work (migrations, image pruning, reminder re-arming) must never
+    // take the process down: an uncaught exception here would otherwise crash
+    // on every launch until the user clears app data — and their diary with it.
+    private val appScope = CoroutineScope(
+        SupervisorJob() + Dispatchers.Default + CoroutineExceptionHandler { _, throwable ->
+            Log.e("FudAIApp", "Background startup task failed", throwable)
+        }
+    )
 
     override fun onCreate() {
         super.onCreate()

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/BodyFatRepository.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/BodyFatRepository.kt
@@ -39,8 +39,7 @@ class BodyFatRepository(
     }
 
     suspend fun addEntry(entry: BodyFatEntry) {
-        val current = prefs.bodyFatEntries.first()
-        prefs.setBodyFatEntries(current + entry)
+        prefs.updateBodyFatEntries { current -> current + entry }
         syncProfileBodyFatToLatest()
         if (shouldSyncHealth()) {
             health?.writeBodyFat(entry)
@@ -48,8 +47,7 @@ class BodyFatRepository(
     }
 
     suspend fun deleteEntry(id: UUID) {
-        val current = prefs.bodyFatEntries.first()
-        prefs.setBodyFatEntries(current.filter { it.id != id })
+        prefs.updateBodyFatEntries { current -> current.filter { it.id != id } }
         syncProfileBodyFatToLatest()
         // Delete the HC record even when sync is off (iOS parity, best-effort) —
         // a surviving fudai-tagged record would resurrect through the own-record
@@ -93,17 +91,19 @@ class BodyFatRepository(
                 )
             }
         if (incoming.isEmpty()) return
-        val byId = prefs.bodyFatEntries.first().associateBy { it.id }.toMutableMap()
         var changed = false
-        for (entry in incoming) {
-            val existing = byId[entry.id]
-            if (existing == null || abs(existing.bodyFatFraction - entry.bodyFatFraction) > 0.0001 || existing.date != entry.date) {
-                byId[entry.id] = entry
-                changed = true
+        prefs.updateBodyFatEntries { current ->
+            val byId = current.associateBy { it.id }.toMutableMap()
+            for (entry in incoming) {
+                val existing = byId[entry.id]
+                if (existing == null || abs(existing.bodyFatFraction - entry.bodyFatFraction) > 0.0001 || existing.date != entry.date) {
+                    byId[entry.id] = entry
+                    changed = true
+                }
             }
+            if (changed) byId.values.sortedBy { it.date } else current
         }
         if (!changed) return
-        prefs.setBodyFatEntries(byId.values.sortedBy { it.date })
         syncProfileBodyFatToLatest()
     }
 

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/BodyMeasurementRepository.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/BodyMeasurementRepository.kt
@@ -23,13 +23,11 @@ class BodyMeasurementRepository(private val prefs: PreferencesStore) {
 
     suspend fun addEntry(entry: BodyMeasurement) {
         if (!entry.hasAnyValue) return
-        val current = prefs.bodyMeasurements.first()
-        prefs.setBodyMeasurements(current + entry)
+        prefs.updateBodyMeasurements { current -> current + entry }
     }
 
     suspend fun deleteEntry(id: UUID) {
-        val current = prefs.bodyMeasurements.first()
-        prefs.setBodyMeasurements(current.filter { it.id != id })
+        prefs.updateBodyMeasurements { current -> current.filter { it.id != id } }
     }
 
     /**
@@ -38,21 +36,22 @@ class BodyMeasurementRepository(private val prefs: PreferencesStore) {
      * forward (so the latest entry always holds the user's current full set). `null` clears a site.
      */
     suspend fun setValue(site: BodyMeasurement.Site, cm: Double?) {
-        val current = prefs.bodyMeasurements.first()
-        val latest = current.maxByOrNull { it.date }
         val zone = ZoneId.systemDefault()
         val today = LocalDate.now(zone)
-        if (latest != null && latest.date.atZone(zone).toLocalDate() == today) {
-            val updated = latest.setting(site, cm)
-            val rest = current.filter { it.id != latest.id }
-            prefs.setBodyMeasurements(if (updated.hasAnyValue) rest + updated else rest)
-        } else {
-            var fresh = BodyMeasurement()
-            if (latest != null) {
-                BodyMeasurement.Site.values().forEach { s -> fresh = fresh.setting(s, latest.value(s)) }
+        prefs.updateBodyMeasurements { current ->
+            val latest = current.maxByOrNull { it.date }
+            if (latest != null && latest.date.atZone(zone).toLocalDate() == today) {
+                val updated = latest.setting(site, cm)
+                val rest = current.filter { it.id != latest.id }
+                if (updated.hasAnyValue) rest + updated else rest
+            } else {
+                var fresh = BodyMeasurement()
+                if (latest != null) {
+                    BodyMeasurement.Site.values().forEach { s -> fresh = fresh.setting(s, latest.value(s)) }
+                }
+                fresh = fresh.setting(site, cm)
+                if (fresh.hasAnyValue) current + fresh else current
             }
-            fresh = fresh.setting(site, cm)
-            if (fresh.hasAnyValue) prefs.setBodyMeasurements(current + fresh)
         }
     }
 

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FastingRepository.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FastingRepository.kt
@@ -14,15 +14,17 @@ class FastingRepository(private val prefs: PreferencesStore) {
     suspend fun active(): FastingSession? = prefs.fastingSessions.first().lastOrNull { it.isActive }
 
     suspend fun start(goalMinutes: Int, at: Instant = Instant.now()): FastingSession? {
-        val current = prefs.fastingSessions.first()
-        if (current.any { it.isActive }) return null
         val session = FastingSession(
             startedAt = at,
             goalMinutes = goalMinutes.coerceIn(FastingDefaults.MIN_GOAL_MINUTES, FastingDefaults.MAX_GOAL_MINUTES)
         )
-        if (current.any { overlaps(session, it) }) return null
-        prefs.setFastingSessions(current + session)
-        return session
+        var started = false
+        prefs.updateFastingSessions { current ->
+            if (current.any { it.isActive } || current.any { overlaps(session, it) }) return@updateFastingSessions current
+            started = true
+            current + session
+        }
+        return if (started) session else null
     }
 
     suspend fun endActive(at: Instant = Instant.now(), updatedSession: FastingSession? = null): FastingSession? {
@@ -40,13 +42,12 @@ class FastingRepository(private val prefs: PreferencesStore) {
             ?: active
         val completed = source.copy(endedAt = maxOf(at, source.startedAt))
         if (current.any { it.id != completed.id && overlaps(completed, it) }) return null
-        prefs.setFastingSessions(current.map { if (it.id == active.id) completed else it })
+        prefs.updateFastingSessions { stored -> stored.map { if (it.id == active.id) completed else it } }
         return completed
     }
 
     suspend fun cancelActive() {
-        val current = prefs.fastingSessions.first()
-        prefs.setFastingSessions(current.filterNot { it.isActive })
+        prefs.updateFastingSessions { current -> current.filterNot { it.isActive } }
     }
 
     suspend fun update(session: FastingSession): Boolean {
@@ -60,12 +61,12 @@ class FastingRepository(private val prefs: PreferencesStore) {
             )
         )
         if (current.any { it.id != validated.id && overlaps(validated, it) }) return false
-        prefs.setFastingSessions(current.map { if (it.id == session.id) validated else it })
+        prefs.updateFastingSessions { stored -> stored.map { if (it.id == session.id) validated else it } }
         return true
     }
 
     suspend fun delete(id: UUID) {
-        prefs.setFastingSessions(prefs.fastingSessions.first().filterNot { it.id == id })
+        prefs.updateFastingSessions { current -> current.filterNot { it.id == id } }
     }
 
     private fun overlaps(left: FastingSession, right: FastingSession): Boolean {

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FastingRepository.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FastingRepository.kt
@@ -27,22 +27,31 @@ class FastingRepository(private val prefs: PreferencesStore) {
         return if (started) session else null
     }
 
+    /**
+     * Completes the active session. Lookup, validation and replacement all run
+     * against the list inside the DataStore transaction, so a session started,
+     * edited or deleted by a concurrent caller cannot slip past the overlap
+     * check or make this report success after changing nothing.
+     */
     suspend fun endActive(at: Instant = Instant.now(), updatedSession: FastingSession? = null): FastingSession? {
-        val current = prefs.fastingSessions.first()
-        val active = current.lastOrNull { it.isActive } ?: return null
-        val proposed = updatedSession?.takeIf { it.id == active.id }
-        val source = proposed
-            ?.copy(
-                endedAt = null,
-                goalMinutes = proposed.goalMinutes.coerceIn(
-                    FastingDefaults.MIN_GOAL_MINUTES,
-                    FastingDefaults.MAX_GOAL_MINUTES
+        var completed: FastingSession? = null
+        prefs.updateFastingSessions { current ->
+            val active = current.lastOrNull { it.isActive } ?: return@updateFastingSessions current
+            val proposed = updatedSession?.takeIf { it.id == active.id }
+            val source = proposed
+                ?.copy(
+                    endedAt = null,
+                    goalMinutes = proposed.goalMinutes.coerceIn(
+                        FastingDefaults.MIN_GOAL_MINUTES,
+                        FastingDefaults.MAX_GOAL_MINUTES
+                    )
                 )
-            )
-            ?: active
-        val completed = source.copy(endedAt = maxOf(at, source.startedAt))
-        if (current.any { it.id != completed.id && overlaps(completed, it) }) return null
-        prefs.updateFastingSessions { stored -> stored.map { if (it.id == active.id) completed else it } }
+                ?: active
+            val candidate = source.copy(endedAt = maxOf(at, source.startedAt))
+            if (current.any { it.id != candidate.id && overlaps(candidate, it) }) return@updateFastingSessions current
+            completed = candidate
+            current.map { if (it.id == active.id) candidate else it }
+        }
         return completed
     }
 
@@ -50,19 +59,24 @@ class FastingRepository(private val prefs: PreferencesStore) {
         prefs.updateFastingSessions { current -> current.filterNot { it.isActive } }
     }
 
+    /** Returns false when the session no longer exists or the edit would violate an invariant. */
     suspend fun update(session: FastingSession): Boolean {
-        val current = prefs.fastingSessions.first()
-        if (session.isActive && current.any { it.id != session.id && it.isActive }) return false
-        val validated = session.copy(
-            endedAt = session.endedAt?.let { maxOf(it, session.startedAt) },
-            goalMinutes = session.goalMinutes.coerceIn(
-                FastingDefaults.MIN_GOAL_MINUTES,
-                FastingDefaults.MAX_GOAL_MINUTES
+        var updated = false
+        prefs.updateFastingSessions { current ->
+            if (current.none { it.id == session.id }) return@updateFastingSessions current
+            if (session.isActive && current.any { it.id != session.id && it.isActive }) return@updateFastingSessions current
+            val validated = session.copy(
+                endedAt = session.endedAt?.let { maxOf(it, session.startedAt) },
+                goalMinutes = session.goalMinutes.coerceIn(
+                    FastingDefaults.MIN_GOAL_MINUTES,
+                    FastingDefaults.MAX_GOAL_MINUTES
+                )
             )
-        )
-        if (current.any { it.id != validated.id && overlaps(validated, it) }) return false
-        prefs.updateFastingSessions { stored -> stored.map { if (it.id == session.id) validated else it } }
-        return true
+            if (current.any { it.id != validated.id && overlaps(validated, it) }) return@updateFastingSessions current
+            updated = true
+            current.map { if (it.id == session.id) validated else it }
+        }
+        return updated
     }
 
     suspend fun delete(id: UUID) {

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FoodRepository.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FoodRepository.kt
@@ -72,8 +72,9 @@ class FoodRepository(
 
     suspend fun addEntry(entry: FoodEntry): Boolean {
         if (prefs.fastingSessions.first().any { it.isActive }) return false
-        val current = prefs.foodEntries.first()
-        prefs.setFoodEntries(current + entry)
+        // Decode + append + encode in one transaction: a diary that fails to
+        // decode is preserved, never replaced by `[entry]`.
+        prefs.updateFoodEntries { current -> current + entry }
         healthRetry.sync(entry, isUpdate = false)
         // One-time organic review moment: the first successful food log (iOS parity).
         if (!prefs.reviewPromptedAfterFirstLog.first()) {
@@ -86,12 +87,14 @@ class FoodRepository(
     suspend fun updateEntry(entry: FoodEntry) {
         // Legacy favorites must keep their original photos before the diary copy changes.
         ensureFavoritesMigrated()
-        val current = prefs.foodEntries.first()
-        val index = current.indexOfFirst { it.id == entry.id }
-        if (index < 0) return
-        val removedImages = current[index].allImageFilenames.toSet() - entry.allImageFilenames.toSet()
-        val updated = current.toMutableList().also { it[index] = entry }
-        prefs.setFoodEntries(updated)
+        var previous: FoodEntry? = null
+        prefs.updateFoodEntries { current ->
+            val index = current.indexOfFirst { it.id == entry.id }
+            if (index < 0) return@updateFoodEntries current
+            previous = current[index]
+            current.toMutableList().also { it[index] = entry }
+        }
+        val removedImages = (previous ?: return).allImageFilenames.toSet() - entry.allImageFilenames.toSet()
         if (imageStore != null && removedImages.isNotEmpty()) {
             // Only consider this edit's removed files, preserving shared saved meals,
             // other log entries and the recoverable analysis draft. A decode failure
@@ -116,8 +119,7 @@ class FoodRepository(
         // Drop the queue entry under the same mutex retry/sync uses, before the local
         // row disappears, so an in-flight retry cannot recreate Health Connect data.
         healthRetry.forget(entryId)
-        val current = prefs.foodEntries.first()
-        prefs.setFoodEntries(current.filter { it.id != entryId })
+        prefs.updateFoodEntries { current -> current.filter { it.id != entryId } }
         pruneOrphanedImages()
         // Delete even when sync is off (iOS parity, best-effort) — a surviving
         // fudai-tagged record would resurrect through restoreFromHealthConnect.
@@ -133,18 +135,22 @@ class FoodRepository(
         ensureFavoritesMigrated()
         val idSet = entryIds.toSet()
         if (idSet.size < 2) return null
-        val current = prefs.foodEntries.first()
-        val selected = current.filter { it.id in idSet }
-        if (selected.size < 2) return null
-        val combined = combineFoodEntries(selected)
-        val remaining = current.filter { it.id !in idSet }
-        prefs.setFoodEntries(remaining + combined)
+        var selected: List<FoodEntry> = emptyList()
+        var combined: FoodEntry? = null
+        prefs.updateFoodEntries { current ->
+            selected = current.filter { it.id in idSet }
+            if (selected.size < 2) return@updateFoodEntries current
+            val merged = combineFoodEntries(selected)
+            combined = merged
+            current.filter { it.id !in idSet } + merged
+        }
+        val result = combined ?: return null
         pruneOrphanedImages()
         selected.forEach { health?.deleteNutrition(it.id) }
         if (shouldSyncHealth()) {
-            health?.writeNutrition(combined)
+            health?.writeNutrition(result)
         }
-        return combined
+        return result
     }
 
     suspend fun replaceAll(entries: List<FoodEntry>) {
@@ -156,13 +162,16 @@ class FoodRepository(
     /** Apply a validated diary import in one local write and keep Health Connect in sync. */
     suspend fun replaceFromImport(entries: List<FoodEntry>) {
         ensureFavoritesMigrated()
-        val previous = prefs.foodEntries.first()
+        var previous: List<FoodEntry> = emptyList()
+        prefs.updateFoodEntries { current ->
+            previous = current
+            entries
+        }
         val previousById = previous.associateBy { it.id }
         val importedIds = entries.mapTo(mutableSetOf()) { it.id }
         val removedIds = previous.map { it.id }.filterNot { it in importedIds }
         val changed = entries.filter { previousById[it.id] != it }
 
-        prefs.setFoodEntries(entries)
         pruneOrphanedImages()
 
         if (shouldSyncHealth()) {
@@ -198,17 +207,19 @@ class FoodRepository(
      */
     suspend fun toggleFavorite(entry: FoodEntry) {
         ensureFavoritesMigrated()
-        val current = prefs.favoriteFoodEntries.first().toMutableList()
-        val idx = current.indexOfFirst { it.favoriteKey == entry.favoriteKey }
-        if (idx >= 0) {
-            current.removeAt(idx)
-        } else {
-            // Drop any other entry with the same id (defensive — should not
-            // normally happen since we matched by favoriteKey above).
-            current.removeAll { it.id == entry.id }
-            current.add(entry)
+        val current = prefs.updateFavoriteFoodEntries { stored ->
+            val list = stored.toMutableList()
+            val idx = list.indexOfFirst { it.favoriteKey == entry.favoriteKey }
+            if (idx >= 0) {
+                list.removeAt(idx)
+            } else {
+                // Drop any other entry with the same id (defensive — should not
+                // normally happen since we matched by favoriteKey above).
+                list.removeAll { it.id == entry.id }
+                list.add(entry)
+            }
+            list
         }
-        prefs.setFavoriteFoodEntries(current)
         prefs.setFavoriteKeys(current.map { it.favoriteKey }.toSet())
         pruneOrphanedImages()
     }
@@ -220,12 +231,14 @@ class FoodRepository(
      */
     suspend fun moveFavorite(from: Int, to: Int) {
         ensureFavoritesMigrated()
-        val list = prefs.favoriteFoodEntries.first().toMutableList()
-        if (from !in list.indices) return
-        val item = list.removeAt(from)
-        val safeTo = to.coerceIn(0, list.size)
-        list.add(safeTo, item)
-        prefs.setFavoriteFoodEntries(list)
+        prefs.updateFavoriteFoodEntries { stored ->
+            val list = stored.toMutableList()
+            if (from !in list.indices) return@updateFavoriteFoodEntries stored
+            val item = list.removeAt(from)
+            val safeTo = to.coerceIn(0, list.size)
+            list.add(safeTo, item)
+            list
+        }
     }
 
     /**
@@ -302,53 +315,54 @@ class FoodRepository(
      */
     suspend fun restoreFromHealthConnect(external: List<com.apoorvdarshan.calorietracker.services.health.ExternalNutrition>) {
         val manager = health ?: return
-        val current = prefs.foodEntries.first()
-        val existingIds = current.map { it.id }.toSet()
-        val restored = external.mapNotNull { record ->
-            val id = manager.ownRecordId(record.clientRecordId) ?: return@mapNotNull null
-            if (id in existingIds) return@mapNotNull null
-            val name = record.name?.trim().orEmpty()
-            if (name.isEmpty()) return@mapNotNull null
-            FoodEntry(
-                id = id,
-                name = name,
-                calories = (record.calories ?: 0.0).roundToInt(),
-                protein = record.protein ?: 0.0,
-                carbs = record.carbs ?: 0.0,
-                fat = record.fat ?: 0.0,
-                timestamp = record.time,
-                source = FoodSource.MANUAL,
-                mealType = record.mealType,
-                sugar = record.sugar,
-                fiber = record.fiber,
-                saturatedFat = record.saturatedFat,
-                monounsaturatedFat = record.monounsaturatedFat,
-                polyunsaturatedFat = record.polyunsaturatedFat,
-                cholesterol = record.cholesterol,
-                caffeine = record.caffeine,
-                sodium = record.sodium,
-                potassium = record.potassium,
-                transFat = record.transFat,
-                calcium = record.calcium,
-                iron = record.iron,
-                magnesium = record.magnesium,
-                zinc = record.zinc,
-                vitaminA = record.vitaminA,
-                vitaminC = record.vitaminC,
-                vitaminD = record.vitaminD,
-                vitaminB12 = record.vitaminB12,
-                vitaminE = record.vitaminE,
-                vitaminK = record.vitaminK,
-                folate = record.folate,
-                // Health Connect NutritionRecord exposes nutrient totals but
-                // no food-mass/custom-metadata field. Preserve that truth as
-                // one logged serving instead of fabricating 100 grams.
-                selectedServingUnit = "serving",
-                selectedServingQuantity = 1.0
-            )
+        prefs.updateFoodEntries { current ->
+            val existingIds = current.map { it.id }.toMutableSet()
+            val restored = external.mapNotNull { record ->
+                val id = manager.ownRecordId(record.clientRecordId) ?: return@mapNotNull null
+                val name = record.name?.trim().orEmpty()
+                if (name.isEmpty()) return@mapNotNull null
+                // `add` also dedupes ids repeated within the Health Connect batch.
+                if (!existingIds.add(id)) return@mapNotNull null
+                FoodEntry(
+                    id = id,
+                    name = name,
+                    calories = (record.calories ?: 0.0).roundToInt(),
+                    protein = record.protein ?: 0.0,
+                    carbs = record.carbs ?: 0.0,
+                    fat = record.fat ?: 0.0,
+                    timestamp = record.time,
+                    source = FoodSource.MANUAL,
+                    mealType = record.mealType,
+                    sugar = record.sugar,
+                    fiber = record.fiber,
+                    saturatedFat = record.saturatedFat,
+                    monounsaturatedFat = record.monounsaturatedFat,
+                    polyunsaturatedFat = record.polyunsaturatedFat,
+                    cholesterol = record.cholesterol,
+                    caffeine = record.caffeine,
+                    sodium = record.sodium,
+                    potassium = record.potassium,
+                    transFat = record.transFat,
+                    calcium = record.calcium,
+                    iron = record.iron,
+                    magnesium = record.magnesium,
+                    zinc = record.zinc,
+                    vitaminA = record.vitaminA,
+                    vitaminC = record.vitaminC,
+                    vitaminD = record.vitaminD,
+                    vitaminB12 = record.vitaminB12,
+                    vitaminE = record.vitaminE,
+                    vitaminK = record.vitaminK,
+                    folate = record.folate,
+                    // Health Connect NutritionRecord exposes nutrient totals but
+                    // no food-mass/custom-metadata field. Preserve that truth as
+                    // one logged serving instead of fabricating 100 grams.
+                    selectedServingUnit = "serving",
+                    selectedServingQuantity = 1.0
+                )
+            }
+            if (restored.isEmpty()) current else (current + restored).sortedBy { it.timestamp }
         }
-        if (restored.isEmpty()) return
-        prefs.setFoodEntries((current + restored).sortedBy { it.timestamp })
     }
 
     // -- Recents / Frequent ---------------------------------------------

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FudaiDataStore.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FudaiDataStore.kt
@@ -1,0 +1,55 @@
+package com.apoorvdarshan.calorietracker.data
+
+import android.content.Context
+import android.util.Log
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import java.io.File
+
+private const val DATASTORE_NAME = "fudai_prefs"
+private const val TAG = "FudaiDataStore"
+
+/**
+ * The single app-wide Preferences DataStore.
+ *
+ * Replaces the `preferencesDataStore` delegate so a corrupt `fudai_prefs`
+ * file no longer throws `CorruptionException` into every collector (a crash
+ * loop on launch). The corruption handler copies the unreadable file aside as
+ * `fudai_prefs.preferences_pb.corrupt-<timestamp>` and starts from empty
+ * preferences, so the user gets a working app and support still has the bytes.
+ */
+val Context.fudaiDataStore: DataStore<Preferences>
+    get() = FudaiDataStoreHolder.get(this)
+
+internal object FudaiDataStoreHolder {
+    @Volatile
+    private var instance: DataStore<Preferences>? = null
+
+    fun get(context: Context): DataStore<Preferences> =
+        instance ?: synchronized(this) {
+            instance ?: create(context.applicationContext).also { instance = it }
+        }
+
+    private fun create(app: Context): DataStore<Preferences> {
+        val file = app.preferencesDataStoreFile(DATASTORE_NAME)
+        return PreferenceDataStoreFactory.create(
+            corruptionHandler = ReplaceFileCorruptionHandler { exception ->
+                val backup = preserveCorruptFile(file)
+                Log.e(
+                    TAG,
+                    "Preferences file is corrupt; preserved copy at ${backup?.absolutePath ?: "<copy failed>"}",
+                    exception
+                )
+                emptyPreferences()
+            },
+            produceFile = { file }
+        )
+    }
+
+    private fun preserveCorruptFile(file: File): File? =
+        CorruptBlobArchive(File(file.parentFile ?: file, CorruptBlobArchive.DIRECTORY_NAME)).preserveFile(file)
+}

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FudaiDataStore.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FudaiDataStore.kt
@@ -21,6 +21,11 @@ private const val TAG = "FudaiDataStore"
  * loop on launch). The corruption handler copies the unreadable file aside as
  * `fudai_prefs.preferences_pb.corrupt-<timestamp>` and starts from empty
  * preferences, so the user gets a working app and support still has the bytes.
+ *
+ * If that copy cannot be written the handler rethrows instead: DataStore then
+ * leaves the original file untouched (readers keep failing, which is the
+ * pre-existing behaviour) rather than replacing the only copy of every
+ * preference with an empty file.
  */
 val Context.fudaiDataStore: DataStore<Preferences>
     get() = FudaiDataStoreHolder.get(this)
@@ -39,11 +44,11 @@ internal object FudaiDataStoreHolder {
         return PreferenceDataStoreFactory.create(
             corruptionHandler = ReplaceFileCorruptionHandler { exception ->
                 val backup = preserveCorruptFile(file)
-                Log.e(
-                    TAG,
-                    "Preferences file is corrupt; preserved copy at ${backup?.absolutePath ?: "<copy failed>"}",
-                    exception
-                )
+                if (backup == null) {
+                    Log.e(TAG, "Preferences file is corrupt and could not be copied aside; keeping it in place", exception)
+                    throw exception
+                }
+                Log.e(TAG, "Preferences file is corrupt; preserved copy at ${backup.absolutePath}", exception)
                 emptyPreferences()
             },
             produceFile = { file }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/PersistedJsonGuard.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/PersistedJsonGuard.kt
@@ -1,0 +1,116 @@
+package com.apoorvdarshan.calorietracker.data
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import java.io.File
+
+/**
+ * Outcome of reading a persisted JSON list.
+ *
+ * Keeping [Missing] and [Corrupt] apart is the whole point: collapsing both
+ * into `emptyList()` is how one unreadable byte used to erase the diary — the
+ * repository read `[]`, appended the new entry and persisted `[entry]` over
+ * the original blob.
+ */
+sealed interface PersistedListDecode<out T> {
+    /** The key has never been written — a genuinely empty store. */
+    data object Missing : PersistedListDecode<Nothing>
+
+    /**
+     * Decoded successfully. [dropped] is non-zero when individual rows were
+     * unreadable and skipped; callers must preserve [raw] before overwriting.
+     */
+    data class Decoded<T>(val items: List<T>, val dropped: Int, val raw: String) : PersistedListDecode<T>
+
+    /** Nothing usable could be decoded. [raw] must be preserved before overwriting. */
+    data class Corrupt(val raw: String) : PersistedListDecode<Nothing>
+
+    val itemsOrEmpty: List<T>
+        get() = when (this) {
+            Missing -> emptyList()
+            is Decoded -> items
+            is Corrupt -> emptyList()
+        }
+
+    /** True when the stored text should be copied aside before it is replaced. */
+    val needsPreservation: Boolean
+        get() = when (this) {
+            Missing -> false
+            is Decoded -> dropped > 0
+            is Corrupt -> true
+        }
+
+    val rawOrNull: String?
+        get() = when (this) {
+            Missing -> null
+            is Decoded -> raw
+            is Corrupt -> raw
+        }
+}
+
+/**
+ * Element-wise JSON list decoding: a list with one unreadable row loses that
+ * row, not the whole list.
+ */
+object LenientJsonList {
+    fun <T> decode(json: Json, serializer: KSerializer<T>, raw: String?): PersistedListDecode<T> {
+        if (raw == null) return PersistedListDecode.Missing
+        runCatching { json.decodeFromString(ListSerializer(serializer), raw) }
+            .getOrNull()
+            ?.let { return PersistedListDecode.Decoded(it, dropped = 0, raw = raw) }
+
+        val array = runCatching { json.parseToJsonElement(raw) as? JsonArray }.getOrNull()
+            ?: return PersistedListDecode.Corrupt(raw)
+        val items = array.mapNotNull { element ->
+            runCatching { json.decodeFromJsonElement(serializer, element) }.getOrNull()
+        }
+        if (items.isEmpty()) return PersistedListDecode.Corrupt(raw)
+        return PersistedListDecode.Decoded(items, dropped = array.size - items.size, raw = raw)
+    }
+}
+
+/**
+ * Copies unreadable persisted blobs aside as `<name>.corrupt-<timestamp>` so
+ * a decode failure never costs the user their data. Best-effort: returns
+ * `null` when the copy could not be written, letting callers fall back to an
+ * in-store backup.
+ */
+class CorruptBlobArchive(private val directory: File) {
+    fun preserveText(name: String, raw: String): File? = runCatching {
+        val target = uniqueTarget(name)
+        target.parentFile?.mkdirs()
+        val tmp = File(target.parentFile, target.name + ".tmp")
+        tmp.writeText(raw)
+        if (!tmp.renameTo(target)) {
+            target.writeText(raw)
+            tmp.delete()
+        }
+        target
+    }.getOrNull()
+
+    fun preserveFile(source: File): File? = runCatching {
+        if (!source.exists()) return null
+        val target = File(source.parentFile ?: directory, backupName(source.name))
+        source.copyTo(target, overwrite = false)
+        target
+    }.getOrNull()
+
+    private fun uniqueTarget(name: String): File {
+        var candidate = File(directory, backupName(name))
+        var attempt = 0
+        while (candidate.exists()) {
+            attempt += 1
+            candidate = File(directory, backupName(name, suffix = "-$attempt"))
+        }
+        return candidate
+    }
+
+    companion object {
+        const val DIRECTORY_NAME = "corrupt-backups"
+
+        fun backupName(name: String, now: Long = System.currentTimeMillis(), suffix: String = ""): String =
+            "$name.corrupt-$now$suffix"
+    }
+}

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/PersistedJsonGuard.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/PersistedJsonGuard.kt
@@ -75,7 +75,7 @@ object LenientJsonList {
  * Copies unreadable persisted blobs aside as `<name>.corrupt-<timestamp>` so
  * a decode failure never costs the user their data. Best-effort: returns
  * `null` when the copy could not be written, letting callers fall back to an
- * in-store backup.
+ * in-store backup or refuse the overwrite.
  */
 class CorruptBlobArchive(private val directory: File) {
     fun preserveText(name: String, raw: String): File? = runCatching {
@@ -90,19 +90,34 @@ class CorruptBlobArchive(private val directory: File) {
         target
     }.getOrNull()
 
-    fun preserveFile(source: File): File? = runCatching {
+    /**
+     * Copies [source] to a collision-free `<name>.corrupt-<timestamp>` sibling,
+     * falling back to the archive directory when the sibling cannot be written.
+     * Returns `null` only when neither location accepted the copy, so a non-null
+     * result means the bytes are safe to replace.
+     */
+    fun preserveFile(source: File): File? {
         if (!source.exists()) return null
-        val target = File(source.parentFile ?: directory, backupName(source.name))
-        source.copyTo(target, overwrite = false)
-        target
-    }.getOrNull()
+        val locations = listOfNotNull(source.parentFile, directory).distinct()
+        for (location in locations) {
+            val copied = runCatching {
+                location.mkdirs()
+                val target = uniqueTarget(source.name, location)
+                source.copyTo(target, overwrite = false)
+                target
+            }.getOrNull()
+            if (copied != null && copied.length() == source.length()) return copied
+            copied?.delete()
+        }
+        return null
+    }
 
-    private fun uniqueTarget(name: String): File {
-        var candidate = File(directory, backupName(name))
+    private fun uniqueTarget(name: String, location: File = directory): File {
+        var candidate = File(location, backupName(name))
         var attempt = 0
         while (candidate.exists()) {
             attempt += 1
-            candidate = File(directory, backupName(name, suffix = "-$attempt"))
+            candidate = File(location, backupName(name, suffix = "-$attempt"))
         }
         return candidate
     }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/PreferencesStore.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/PreferencesStore.kt
@@ -2,13 +2,14 @@ package com.apoorvdarshan.calorietracker.data
 
 import com.apoorvdarshan.calorietracker.models.OpenRouterReasoningEffort
 import android.content.Context
+import android.util.Log
+import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
 import com.apoorvdarshan.calorietracker.models.AddMenuConfig
 import com.apoorvdarshan.calorietracker.models.AIProvider
 import com.apoorvdarshan.calorietracker.models.AutoBalanceMacro
@@ -40,13 +41,13 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.SetSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
-
-val Context.fudaiDataStore by preferencesDataStore(name = "fudai_prefs")
+import java.io.File
 
 @Serializable
 private data class HealthEnergyGoalTargetSnapshot(
@@ -96,8 +97,85 @@ class PreferencesStore(
     private val isLocalWhisperExecutable: () -> Boolean = { false }
 ) : WorkoutStateStore, NutritionSyncStore {
 
-    private val json = Json { ignoreUnknownKeys = true }
+    // coerceInputValues: an enum value this build does not know (e.g. a meal
+    // type added by a newer release) falls back to the property default
+    // instead of failing the whole row.
+    private val json = Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+    }
     private val ds get() = context.fudaiDataStore
+    private val corruptArchive by lazy {
+        CorruptBlobArchive(File(context.filesDir, CorruptBlobArchive.DIRECTORY_NAME))
+    }
+
+    // -- Guarded JSON list persistence -----------------------------------
+    //
+    // Decode failures used to surface as `emptyList()`, and the next
+    // `first() + entry` write persisted `[entry]` over the user's history.
+    // Every list mutation now runs decode + transform + encode inside one
+    // DataStore transaction, and any blob that could not be (fully) decoded
+    // is copied aside before it is replaced.
+
+    private fun <T> jsonListFlow(key: Preferences.Key<String>, serializer: KSerializer<T>): Flow<List<T>> =
+        ds.data.map { prefs -> decodeList(prefs[key], serializer, key.name).itemsOrEmpty }
+
+    private fun <T> decodeList(raw: String?, serializer: KSerializer<T>, name: String): PersistedListDecode<T> {
+        val decoded = LenientJsonList.decode(json, serializer, raw)
+        when (decoded) {
+            is PersistedListDecode.Corrupt ->
+                Log.e(TAG, "Stored '$name' could not be decoded; showing empty until it is preserved on next write")
+            is PersistedListDecode.Decoded ->
+                if (decoded.dropped > 0) Log.w(TAG, "Dropped ${decoded.dropped} unreadable row(s) from '$name'")
+            PersistedListDecode.Missing -> Unit
+        }
+        return decoded
+    }
+
+    /**
+     * Atomically replaces the list under [key] with `transform(current)`.
+     * Runs inside a single `edit`, so concurrent callers cannot interleave a
+     * stale read with a write, and an unreadable blob is preserved (file
+     * first, in-store key as fallback) before being overwritten.
+     */
+    private suspend fun <T> updateJsonList(
+        key: Preferences.Key<String>,
+        serializer: KSerializer<T>,
+        transform: (List<T>) -> List<T>
+    ): List<T> {
+        var result: List<T> = emptyList()
+        ds.edit { prefs ->
+            val decoded = decodeList(prefs[key], serializer, key.name)
+            preserveIfUnreadable(prefs, key, decoded)
+            result = transform(decoded.itemsOrEmpty)
+            prefs[key] = json.encodeToString(ListSerializer(serializer), result)
+        }
+        return result
+    }
+
+    private fun preserveIfUnreadable(prefs: MutablePreferences, key: Preferences.Key<String>, decoded: PersistedListDecode<*>) {
+        if (!decoded.needsPreservation) return
+        preserveRaw(prefs, key, decoded.rawOrNull ?: return)
+    }
+
+    private fun preserveRaw(prefs: MutablePreferences, key: Preferences.Key<String>, raw: String) {
+        val file = corruptArchive.preserveText("${key.name}.json", raw)
+        if (file != null) {
+            Log.w(TAG, "Preserved unreadable '${key.name}' at ${file.absolutePath}")
+        } else {
+            // Same transaction as the overwrite, so the bytes survive even when
+            // the file copy fails.
+            val backupKey = stringPreferencesKey(CorruptBlobArchive.backupName(key.name))
+            prefs[backupKey] = raw
+            Log.w(TAG, "Preserved unreadable '${key.name}' under '${backupKey.name}'")
+        }
+    }
+
+    /** Single-value variant: back up an unreadable blob before replacing it. */
+    private fun <T> preserveIfUndecodable(prefs: MutablePreferences, key: Preferences.Key<String>, serializer: KSerializer<T>) {
+        val raw = prefs[key] ?: return
+        if (runCatching { json.decodeFromString(serializer, raw) }.isFailure) preserveRaw(prefs, key, raw)
+    }
     private val fallbackBaseUrlMigrationMutex = Mutex()
     @Volatile private var fallbackBaseUrlMigrationCompleted = false
 
@@ -107,7 +185,10 @@ class PreferencesStore(
     }
 
     suspend fun setUserProfile(profile: UserProfile) {
-        ds.edit { it[Keys.USER_PROFILE] = json.encodeToString(UserProfile.serializer(), profile) }
+        ds.edit {
+            preserveIfUndecodable(it, Keys.USER_PROFILE, UserProfile.serializer())
+            it[Keys.USER_PROFILE] = json.encodeToString(UserProfile.serializer(), profile)
+        }
     }
 
     // -- Onboarding -------------------------------------------------------
@@ -174,15 +255,14 @@ class PreferencesStore(
     val waterReminderHour: Flow<Int> = ds.data.map { it[Keys.WATER_REMINDER_HOUR] ?: 14 }
     val waterReminderMinute: Flow<Int> = ds.data.map { it[Keys.WATER_REMINDER_MINUTE] ?: 0 }
 
-    val waterEntries: Flow<List<WaterEntry>> = ds.data.map { prefs ->
-        prefs[Keys.WATER_ENTRIES]?.let {
-            runCatching { json.decodeFromString(ListSerializer(WaterEntry.serializer()), it) }.getOrNull()
-        } ?: emptyList()
-    }
+    val waterEntries: Flow<List<WaterEntry>> = jsonListFlow(Keys.WATER_ENTRIES, WaterEntry.serializer())
 
     suspend fun setWaterEntries(entries: List<WaterEntry>) {
-        ds.edit { it[Keys.WATER_ENTRIES] = json.encodeToString(ListSerializer(WaterEntry.serializer()), entries) }
+        updateWaterEntries { entries }
     }
+
+    suspend fun updateWaterEntries(transform: (List<WaterEntry>) -> List<WaterEntry>): List<WaterEntry> =
+        updateJsonList(Keys.WATER_ENTRIES, WaterEntry.serializer(), transform)
 
     // -- Fasting tracking -----------------------------------------------
     val fastingTrackingEnabled: Flow<Boolean> = ds.data.map { it[Keys.FASTING_TRACKING_ENABLED] ?: false }
@@ -205,15 +285,14 @@ class PreferencesStore(
         ds.edit { it[Keys.FASTING_GOAL_NOTIFICATION_ENABLED] = v }
     }
 
-    val fastingSessions: Flow<List<FastingSession>> = ds.data.map { prefs ->
-        prefs[Keys.FASTING_SESSIONS]?.let {
-            runCatching { json.decodeFromString(ListSerializer(FastingSession.serializer()), it) }.getOrNull()
-        } ?: emptyList()
-    }
+    val fastingSessions: Flow<List<FastingSession>> = jsonListFlow(Keys.FASTING_SESSIONS, FastingSession.serializer())
 
     suspend fun setFastingSessions(sessions: List<FastingSession>) {
-        ds.edit { it[Keys.FASTING_SESSIONS] = json.encodeToString(ListSerializer(FastingSession.serializer()), sessions) }
+        updateFastingSessions { sessions }
     }
+
+    suspend fun updateFastingSessions(transform: (List<FastingSession>) -> List<FastingSession>): List<FastingSession> =
+        updateJsonList(Keys.FASTING_SESSIONS, FastingSession.serializer(), transform)
 
     /// Last app version a "new update" notification was posted for — so it fires at most once per
     /// version even though the update check runs on every launch.
@@ -494,6 +573,7 @@ class PreferencesStore(
 
     override suspend fun setWorkoutState(state: WorkoutPersistedState) {
         ds.edit {
+            preserveIfUndecodable(it, Keys.WORKOUT_STATE, WorkoutPersistedState.serializer())
             it[Keys.WORKOUT_STATE] = json.encodeToString(
                 WorkoutPersistedState.serializer(),
                 state.sanitized()
@@ -548,6 +628,7 @@ class PreferencesStore(
     }
     suspend fun setOptionalNutrientGoals(goals: OptionalNutrientGoals) {
         ds.edit {
+            preserveIfUndecodable(it, Keys.OPTIONAL_NUTRIENT_GOALS, OptionalNutrientGoals.serializer())
             it[Keys.OPTIONAL_NUTRIENT_GOALS] =
                 json.encodeToString(OptionalNutrientGoals.serializer(), goals)
         }
@@ -982,20 +1063,38 @@ class PreferencesStore(
     }
 
     // -- Food entries -----------------------------------------------------
-    override val foodEntries: Flow<List<FoodEntry>> = ds.data.map { prefs ->
-        prefs[Keys.FOOD_ENTRIES]?.let {
-            runCatching { json.decodeFromString(ListSerializer(FoodEntry.serializer()), it) }.getOrNull()
-        } ?: emptyList()
+    override val foodEntries: Flow<List<FoodEntry>> =
+        jsonListFlow(Keys.FOOD_ENTRIES, FoodEntry.serializer()).flowOn(Dispatchers.Default)
+
+    /**
+     * Whether the stored food log is currently unreadable. A `true` here means
+     * [foodEntries] is emitting an empty list for a diary that still exists on
+     * disk; the next mutation preserves the raw blob before replacing it.
+     */
+    val foodEntriesCorrupt: Flow<Boolean> = ds.data.map { prefs ->
+        LenientJsonList.decode(json, FoodEntry.serializer(), prefs[Keys.FOOD_ENTRIES]) is PersistedListDecode.Corrupt
     }.flowOn(Dispatchers.Default)
 
     suspend fun setFoodEntries(entries: List<FoodEntry>) {
-        ds.edit { it[Keys.FOOD_ENTRIES] = json.encodeToString(ListSerializer(FoodEntry.serializer()), entries) }
+        updateFoodEntries { entries }
     }
+
+    /**
+     * Decode + mutate + encode the food log in one DataStore transaction.
+     * Repositories must use this instead of `foodEntries.first()` followed by
+     * [setFoodEntries]: a decode failure on the read side would otherwise
+     * turn "append one entry" into "replace the diary with one entry".
+     */
+    suspend fun updateFoodEntries(transform: (List<FoodEntry>) -> List<FoodEntry>): List<FoodEntry> =
+        updateJsonList(Keys.FOOD_ENTRIES, FoodEntry.serializer(), transform)
 
     // Keep this ledger after local deletion so repeat imports never resurrect removed meals.
     private val nutritionImportLedgerKey = stringPreferencesKey("healthNutritionImportedKeys")
+    private val ledgerSerializer = SetSerializer(String.serializer())
     val nutritionImportedKeys: Flow<Set<String>> = ds.data.map {
-        it[nutritionImportLedgerKey]?.let { raw -> json.decodeFromString<Set<String>>(raw) } ?: emptySet()
+        it[nutritionImportLedgerKey]?.let { raw ->
+            runCatching { json.decodeFromString(ledgerSerializer, raw) }.getOrNull()
+        } ?: emptySet()
     }
 
     /** Commit the log and import ledger together, checking duplicates again after preview. */
@@ -1005,10 +1104,14 @@ class PreferencesStore(
     ): Int {
         var count = 0
         ds.edit { stored ->
-            val current = stored[Keys.FOOD_ENTRIES]?.let { json.decodeFromString<List<FoodEntry>>(it) }
-                ?: emptyList()
-            val ledger = stored[nutritionImportLedgerKey]?.let { json.decodeFromString<Set<String>>(it) }
-                ?: emptySet()
+            val decoded = decodeList(stored[Keys.FOOD_ENTRIES], FoodEntry.serializer(), Keys.FOOD_ENTRIES.name)
+            preserveIfUnreadable(stored, Keys.FOOD_ENTRIES, decoded)
+            val current = decoded.itemsOrEmpty
+            val storedLedger = stored[nutritionImportLedgerKey]
+            val ledger = storedLedger?.let { raw ->
+                runCatching { json.decodeFromString(ledgerSerializer, raw) }.getOrNull()
+                    ?: run { preserveRaw(stored, nutritionImportLedgerKey, raw); null }
+            } ?: emptySet()
             val merged = mergeNutritionImport(current, ledger, records, context.packageName, fallbackName)
             stored[Keys.FOOD_ENTRIES] = json.encodeToString(ListSerializer(FoodEntry.serializer()), merged.entries)
             stored[nutritionImportLedgerKey] = json.encodeToString(SetSerializer(String.serializer()), merged.ledger)
@@ -1033,15 +1136,14 @@ class PreferencesStore(
      * into [foodEntries]) so a favorite survives deletion of the original
      * log entry, AND so user-defined order is preserved across restarts.
      */
-    val favoriteFoodEntries: Flow<List<FoodEntry>> = ds.data.map { prefs ->
-        prefs[Keys.FAVORITE_ENTRIES]?.let {
-            runCatching { json.decodeFromString(ListSerializer(FoodEntry.serializer()), it) }.getOrNull()
-        } ?: emptyList()
-    }
+    val favoriteFoodEntries: Flow<List<FoodEntry>> = jsonListFlow(Keys.FAVORITE_ENTRIES, FoodEntry.serializer())
 
     suspend fun setFavoriteFoodEntries(entries: List<FoodEntry>) {
-        ds.edit { it[Keys.FAVORITE_ENTRIES] = json.encodeToString(ListSerializer(FoodEntry.serializer()), entries) }
+        updateFavoriteFoodEntries { entries }
     }
+
+    suspend fun updateFavoriteFoodEntries(transform: (List<FoodEntry>) -> List<FoodEntry>): List<FoodEntry> =
+        updateJsonList(Keys.FAVORITE_ENTRIES, FoodEntry.serializer(), transform)
 
     /**
      * Returns an atomic snapshot of every persisted food-image reference. A
@@ -1104,37 +1206,34 @@ class PreferencesStore(
     }
 
     // -- Weight entries ---------------------------------------------------
-    val weightEntries: Flow<List<WeightEntry>> = ds.data.map { prefs ->
-        prefs[Keys.WEIGHT_ENTRIES]?.let {
-            runCatching { json.decodeFromString(ListSerializer(WeightEntry.serializer()), it) }.getOrNull()
-        } ?: emptyList()
-    }
+    val weightEntries: Flow<List<WeightEntry>> = jsonListFlow(Keys.WEIGHT_ENTRIES, WeightEntry.serializer())
 
     suspend fun setWeightEntries(entries: List<WeightEntry>) {
-        ds.edit { it[Keys.WEIGHT_ENTRIES] = json.encodeToString(ListSerializer(WeightEntry.serializer()), entries) }
+        updateWeightEntries { entries }
     }
+
+    suspend fun updateWeightEntries(transform: (List<WeightEntry>) -> List<WeightEntry>): List<WeightEntry> =
+        updateJsonList(Keys.WEIGHT_ENTRIES, WeightEntry.serializer(), transform)
 
     // -- Body fat entries --------------------------------------------------
-    val bodyFatEntries: Flow<List<BodyFatEntry>> = ds.data.map { prefs ->
-        prefs[Keys.BODY_FAT_ENTRIES]?.let {
-            runCatching { json.decodeFromString(ListSerializer(BodyFatEntry.serializer()), it) }.getOrNull()
-        } ?: emptyList()
-    }
+    val bodyFatEntries: Flow<List<BodyFatEntry>> = jsonListFlow(Keys.BODY_FAT_ENTRIES, BodyFatEntry.serializer())
 
     suspend fun setBodyFatEntries(entries: List<BodyFatEntry>) {
-        ds.edit { it[Keys.BODY_FAT_ENTRIES] = json.encodeToString(ListSerializer(BodyFatEntry.serializer()), entries) }
+        updateBodyFatEntries { entries }
     }
+
+    suspend fun updateBodyFatEntries(transform: (List<BodyFatEntry>) -> List<BodyFatEntry>): List<BodyFatEntry> =
+        updateJsonList(Keys.BODY_FAT_ENTRIES, BodyFatEntry.serializer(), transform)
 
     // -- Body measurement (circumference) entries --------------------------
-    val bodyMeasurements: Flow<List<BodyMeasurement>> = ds.data.map { prefs ->
-        prefs[Keys.BODY_MEASUREMENTS]?.let {
-            runCatching { json.decodeFromString(ListSerializer(BodyMeasurement.serializer()), it) }.getOrNull()
-        } ?: emptyList()
-    }
+    val bodyMeasurements: Flow<List<BodyMeasurement>> = jsonListFlow(Keys.BODY_MEASUREMENTS, BodyMeasurement.serializer())
 
     suspend fun setBodyMeasurements(entries: List<BodyMeasurement>) {
-        ds.edit { it[Keys.BODY_MEASUREMENTS] = json.encodeToString(ListSerializer(BodyMeasurement.serializer()), entries) }
+        updateBodyMeasurements { entries }
     }
+
+    suspend fun updateBodyMeasurements(transform: (List<BodyMeasurement>) -> List<BodyMeasurement>): List<BodyMeasurement> =
+        updateJsonList(Keys.BODY_MEASUREMENTS, BodyMeasurement.serializer(), transform)
 
     // -- Coach chat history ----------------------------------------------
     val chatHistory: Flow<List<ChatMessage>> = ds.data.map { prefs ->
@@ -1271,6 +1370,7 @@ class PreferencesStore(
     }
 
     companion object {
+        private const val TAG = "PreferencesStore"
         private const val CUSTOM_BASE_URL_PREFIX = "customBaseURL_"
         private const val FALLBACK_BASE_URL_PREFIX = "fallbackCustomBaseURL_"
         private const val MATCHING_SPEECH_PROVIDER_MIGRATION_VERSION = 1

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/WaterRepository.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/WaterRepository.kt
@@ -5,7 +5,6 @@ import com.apoorvdarshan.calorietracker.export.DiaryImporter
 import com.apoorvdarshan.calorietracker.export.DiaryImportPreview
 import com.apoorvdarshan.calorietracker.export.DiaryImportMode
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -18,20 +17,20 @@ class WaterRepository(private val prefs: PreferencesStore) {
     suspend fun add(entry: WaterEntry) {
         if (entry.milliliters <= 0) return
         mutationMutex.withLock {
-            prefs.setWaterEntries(prefs.waterEntries.first() + entry)
+            prefs.updateWaterEntries { current -> current + entry }
         }
     }
 
     suspend fun importDiary(preview: DiaryImportPreview, mode: DiaryImportMode) {
         if (!preview.includesWater) return
         mutationMutex.withLock {
-            prefs.setWaterEntries(DiaryImporter.applyingWater(preview, prefs.waterEntries.first(), mode))
+            prefs.updateWaterEntries { current -> DiaryImporter.applyingWater(preview, current, mode) }
         }
     }
 
     suspend fun delete(id: UUID) {
         mutationMutex.withLock {
-            prefs.setWaterEntries(prefs.waterEntries.first().filter { it.id != id })
+            prefs.updateWaterEntries { current -> current.filter { it.id != id } }
         }
     }
 }

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/WeightRepository.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/WeightRepository.kt
@@ -125,6 +125,9 @@ class WeightRepository(
             // associateBy keeps the last duplicate id, so a history that already
             // holds the same id twice collapses instead of failing the import.
             val byId = current.associateBy { it.id }.toMutableMap()
+            // Persist the collapse even if every incoming value already matches,
+            // otherwise the duplicate survives and keeps skewing the trend math.
+            if (byId.size != current.size) changed = true
             for (entry in incoming) {
                 val existing = byId[entry.id]
                 if (existing == null || abs(existing.weightKg - entry.weightKg) > 0.0001 || existing.date != entry.date) {

--- a/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/WeightRepository.kt
+++ b/android/app/src/main/java/com/apoorvdarshan/calorietracker/data/WeightRepository.kt
@@ -40,9 +40,12 @@ class WeightRepository(
     }
 
     suspend fun addEntry(entry: WeightEntry): WeightGoalReachedEvent? {
-        val current = prefs.weightEntries.first()
-        val previousLatest = current.maxByOrNull { it.date }
-        prefs.setWeightEntries(current + entry)
+        var latestBeforeAdd: WeightEntry? = null
+        prefs.updateWeightEntries { current ->
+            latestBeforeAdd = current.maxByOrNull { it.date }
+            current + entry
+        }
+        val previousLatest = latestBeforeAdd
 
         syncProfileWeightToLatest()
         if (shouldSyncHealth()) {
@@ -65,8 +68,7 @@ class WeightRepository(
     }
 
     suspend fun deleteEntry(id: UUID) {
-        val current = prefs.weightEntries.first()
-        prefs.setWeightEntries(current.filter { it.id != id })
+        prefs.updateWeightEntries { current -> current.filter { it.id != id } }
         syncProfileWeightToLatest()
         // Delete the HC record even when sync is off (iOS parity, best-effort) —
         // a surviving fudai-tagged record would resurrect through the own-record
@@ -118,17 +120,21 @@ class WeightRepository(
                 )
             }
         if (incoming.isEmpty()) return
-        val byId = prefs.weightEntries.first().associateBy { it.id }.toMutableMap()
         var changed = false
-        for (entry in incoming) {
-            val existing = byId[entry.id]
-            if (existing == null || abs(existing.weightKg - entry.weightKg) > 0.0001 || existing.date != entry.date) {
-                byId[entry.id] = entry
-                changed = true
+        prefs.updateWeightEntries { current ->
+            // associateBy keeps the last duplicate id, so a history that already
+            // holds the same id twice collapses instead of failing the import.
+            val byId = current.associateBy { it.id }.toMutableMap()
+            for (entry in incoming) {
+                val existing = byId[entry.id]
+                if (existing == null || abs(existing.weightKg - entry.weightKg) > 0.0001 || existing.date != entry.date) {
+                    byId[entry.id] = entry
+                    changed = true
+                }
             }
+            if (changed) byId.values.sortedBy { it.date } else current
         }
         if (!changed) return
-        prefs.setWeightEntries(byId.values.sortedBy { it.date })
         syncProfileWeightToLatest()
     }
 

--- a/android/app/src/test/java/com/apoorvdarshan/calorietracker/data/PersistedJsonGuardTest.kt
+++ b/android/app/src/test/java/com/apoorvdarshan/calorietracker/data/PersistedJsonGuardTest.kt
@@ -1,0 +1,126 @@
+package com.apoorvdarshan.calorietracker.data
+
+import com.apoorvdarshan.calorietracker.models.FoodEntry
+import com.apoorvdarshan.calorietracker.models.FoodSource
+import com.apoorvdarshan.calorietracker.models.MealType
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.time.Instant
+
+class PersistedJsonGuardTest {
+    // Same configuration as PreferencesStore.
+    private val json = Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+    }
+    private val serializer = FoodEntry.serializer()
+
+    private fun meal(name: String = "Rice and beans") = FoodEntry(
+        name = name, calories = 270, protein = 12.0, carbs = 52.0, fat = 2.0,
+        timestamp = Instant.parse("2027-01-15T08:00:00Z"),
+        source = FoodSource.SNAP_FOOD, mealType = MealType.LUNCH
+    )
+
+    private fun encode(vararg entries: FoodEntry) =
+        json.encodeToString(ListSerializer(serializer), entries.toList())
+
+    @Test fun missingKeyIsMissingNotCorrupt() {
+        val decoded = LenientJsonList.decode(json, serializer, null)
+        assertEquals(PersistedListDecode.Missing, decoded)
+        assertFalse(decoded.needsPreservation)
+        assertTrue(decoded.itemsOrEmpty.isEmpty())
+    }
+
+    @Test fun validListDecodesWithoutPreservation() {
+        val decoded = LenientJsonList.decode(json, serializer, encode(meal(), meal("Toast")))
+        val result = decoded as PersistedListDecode.Decoded
+        assertEquals(listOf("Rice and beans", "Toast"), result.items.map { it.name })
+        assertEquals(0, result.dropped)
+        assertFalse(decoded.needsPreservation)
+    }
+
+    @Test fun garbageIsCorruptAndKeepsRawForPreservation() {
+        val raw = "[{\"id\": \"broken\""
+        val decoded = LenientJsonList.decode(json, serializer, raw)
+        assertEquals(PersistedListDecode.Corrupt(raw), decoded)
+        assertTrue(decoded.needsPreservation)
+        assertEquals(raw, decoded.rawOrNull)
+        // The bug: this used to be indistinguishable from an empty diary.
+        assertTrue(decoded.itemsOrEmpty.isEmpty())
+    }
+
+    @Test fun oneBadRowIsDroppedNotTheWholeList() {
+        val good = meal()
+        val goodJson = json.encodeToString(serializer, good)
+        val raw = "[$goodJson, {\"name\": \"no id or macros\"}, $goodJson]"
+
+        val decoded = LenientJsonList.decode(json, serializer, raw) as PersistedListDecode.Decoded
+        assertEquals(listOf(good, good), decoded.items)
+        assertEquals(1, decoded.dropped)
+        assertTrue(decoded.needsPreservation)
+        assertEquals(raw, decoded.rawOrNull)
+    }
+
+    @Test fun allRowsUnreadableIsCorrupt() {
+        val raw = "[{\"name\": \"x\"}, {\"name\": \"y\"}]"
+        assertEquals(PersistedListDecode.Corrupt(raw), LenientJsonList.decode(json, serializer, raw))
+    }
+
+    @Test fun unknownMealTypeCoercesToDefaultInsteadOfDroppingRow() {
+        val raw = json.encodeToString(serializer, meal()).replace("\"lunch\"", "\"brunch\"")
+        val decoded = LenientJsonList.decode(json, serializer, "[$raw]") as PersistedListDecode.Decoded
+        assertEquals(MealType.OTHER, decoded.items.single().mealType)
+        assertEquals(0, decoded.dropped)
+    }
+
+    @Test fun archivePreservesTextUnderCorruptSuffixAndNeverOverwrites() {
+        val dir = java.nio.file.Files.createTempDirectory("guard").toFile()
+        try {
+            val archive = CorruptBlobArchive(dir)
+            val first = archive.preserveText("foodEntries.json", "one")
+            val second = archive.preserveText("foodEntries.json", "two")
+            assertNotNull(first)
+            assertNotNull(second)
+            assertTrue(first!!.name.startsWith("foodEntries.json.corrupt-"))
+            assertTrue(second!!.name.startsWith("foodEntries.json.corrupt-"))
+            assertEquals("one", first.readText())
+            assertEquals("two", second.readText())
+            assertTrue(first.path != second.path)
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test fun archiveReturnsNullWhenDirectoryCannotBeCreated() {
+        val blocker = File.createTempFile("blocker", null)
+        try {
+            // A regular file where the directory should be: mkdirs fails.
+            val archive = CorruptBlobArchive(File(blocker, "nested"))
+            assertNull(archive.preserveText("foodEntries.json", "raw"))
+        } finally {
+            blocker.delete()
+        }
+    }
+
+    @Test fun archiveCopiesCorruptDataStoreFileNextToOriginal() {
+        val dir = java.nio.file.Files.createTempDirectory("guard").toFile()
+        try {
+            val source = File(dir, "fudai_prefs.preferences_pb").apply { writeText("not protobuf") }
+            val backup = CorruptBlobArchive(File(dir, "unused"))
+                .preserveFile(source)
+            assertNotNull(backup)
+            assertTrue(backup!!.name.startsWith("fudai_prefs.preferences_pb.corrupt-"))
+            assertEquals("not protobuf", backup.readText())
+            assertEquals("not protobuf", source.readText())
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+}

--- a/android/app/src/test/java/com/apoorvdarshan/calorietracker/data/PersistedJsonGuardTest.kt
+++ b/android/app/src/test/java/com/apoorvdarshan/calorietracker/data/PersistedJsonGuardTest.kt
@@ -123,4 +123,40 @@ class PersistedJsonGuardTest {
             dir.deleteRecursively()
         }
     }
+
+    @Test fun archiveNeverOverwritesAnEarlierDataStoreBackup() {
+        val dir = java.nio.file.Files.createTempDirectory("guard").toFile()
+        try {
+            val source = File(dir, "fudai_prefs.preferences_pb").apply { writeText("first") }
+            val archive = CorruptBlobArchive(File(dir, "unused"))
+            val first = archive.preserveFile(source)
+            source.writeText("second")
+            // Same millisecond timestamp is likely here; the name must still be unique.
+            val second = archive.preserveFile(source)
+            assertNotNull(first)
+            assertNotNull(second)
+            assertTrue(first!!.path != second!!.path)
+            assertEquals("first", first.readText())
+            assertEquals("second", second.readText())
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test fun archiveFallsBackToArchiveDirectoryWhenSiblingCopyFails() {
+        val dir = java.nio.file.Files.createTempDirectory("guard").toFile()
+        try {
+            val parent = File(dir, "readonly").apply { mkdirs() }
+            val source = File(parent, "fudai_prefs.preferences_pb").apply { writeText("bytes") }
+            if (!parent.setWritable(false) || parent.canWrite()) return // running as root: cannot simulate
+            val fallback = File(dir, "corrupt-backups")
+            val backup = CorruptBlobArchive(fallback).preserveFile(source)
+            assertNotNull(backup)
+            assertEquals(fallback, backup!!.parentFile)
+            assertEquals("bytes", backup.readText())
+        } finally {
+            File(dir, "readonly").setWritable(true)
+            dir.deleteRecursively()
+        }
+    }
 }

--- a/ios/calorietracker/Models/UserProfile.swift
+++ b/ios/calorietracker/Models/UserProfile.swift
@@ -541,18 +541,22 @@ struct UserProfile: Codable, Equatable {
 
     // MARK: - Persistence
 
+    static let storageKey = "userProfile"
+
+    /// Shared guard so an unreadable profile blob is backed up and cannot be
+    /// silently replaced by `.default` on the next `save()`.
+    private static let storageBlob = PersistedBlobGuard(defaults: .standard, key: storageKey)
+
     static func load() -> UserProfile? {
-        guard let data = UserDefaults.standard.data(forKey: "userProfile"),
-              let profile = try? JSONDecoder().decode(UserProfile.self, from: data)
-        else { return nil }
-        return profile
+        switch storageBlob.loadValue(UserProfile.self) {
+        case .decoded(let profile, _): return profile
+        case .missing, .corrupt: return nil
+        }
     }
 
     func save() {
-        if let data = try? JSONEncoder().encode(self) {
-            UserDefaults.standard.set(data, forKey: "userProfile")
-            NotificationCenter.default.post(name: .userProfileDidChange, object: nil)
-        }
+        guard Self.storageBlob.save(self) else { return }
+        NotificationCenter.default.post(name: .userProfileDidChange, object: nil)
     }
 }
 

--- a/ios/calorietracker/Services/DiaryImporter.swift
+++ b/ios/calorietracker/Services/DiaryImporter.swift
@@ -262,7 +262,10 @@ enum DiaryImporter {
                 let day = calendar.startOfDay(for: $0.timestamp)
                 return day >= preview.startDate && day <= preview.endDate
             }
-            var existingByID = Dictionary(uniqueKeysWithValues: inRange.map { ($0.id, $0) })
+            // A diary that already holds two rows with the same id (older
+            // HealthKit restores could append duplicates) must not trap the
+            // import; the later row wins.
+            var existingByID = Dictionary(inRange.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
             var existingByKey: [String: [FoodEntry]] = Dictionary(grouping: inRange) { matchKey($0, calendar: calendar) }
             var usedIDs = Set<UUID>()
             var occupiedIDs = Set(outsideRange.map(\.id))

--- a/ios/calorietracker/Services/PersistedBlobGuard.swift
+++ b/ios/calorietracker/Services/PersistedBlobGuard.swift
@@ -36,6 +36,10 @@ enum PersistedBlobLoad<Value> {
 ///   guard last looked, the new bytes are decode-checked and quarantined the
 ///   same way, so a corrupt blob written behind the store's back is never
 ///   overwritten on the strength of a stale "all good" from the last load.
+/// * A `save`/`remove` issued before any load is treated the same way: if the
+///   key already holds bytes nobody has decoded, they are copied aside first
+///   (and the write refused if that copy fails) instead of being replaced
+///   blind.
 final class PersistedBlobGuard {
     struct CorruptBackup: Equatable {
         let key: String
@@ -222,15 +226,22 @@ final class PersistedBlobGuard {
     private func reconcileExternalChange() {
         let current = rawBlob()
         let currentBytes = current?.bytes
-        guard hasObservedBlob, currentBytes != lastObservedBlob else { return }
+        if hasObservedBlob, currentBytes == lastObservedBlob { return }
         lastObservedBlob = currentBytes
+        hasObservedBlob = true
         switch current {
         case .none:
             break
         case .some(.other):
             quarantine(currentBytes ?? Data(), reason: "value under '\(key)' was externally replaced with non-Data")
         case .some(.data(let data)):
-            guard let isFullyReadable else { return }
+            guard let isFullyReadable else {
+                // Never loaded through this guard, so there is no decoder to
+                // vouch for the bytes. Copy them aside rather than blindly
+                // overwrite what might be the only copy of the user's data.
+                quarantine(data, reason: "blob under '\(key)' would be replaced without ever having been decoded")
+                return
+            }
             if !isFullyReadable(data) {
                 quarantine(data, reason: "blob under '\(key)' was externally replaced with unreadable data")
             }

--- a/ios/calorietracker/Services/PersistedBlobGuard.swift
+++ b/ios/calorietracker/Services/PersistedBlobGuard.swift
@@ -1,0 +1,224 @@
+import Foundation
+import os
+
+/// Outcome of reading a JSON blob out of `UserDefaults`.
+///
+/// The whole point of this type is to keep "the key was never written" and
+/// "the key holds bytes we cannot read" apart. Collapsing both into an empty
+/// array is how a single bad byte used to erase years of diary history: the
+/// store loaded `[]`, the next `addEntry` saved `[newEntry]`, and the original
+/// blob was gone.
+enum PersistedBlobLoad<Value> {
+    /// Nothing has ever been stored under this key — a genuinely empty store.
+    case missing
+    /// Decoded successfully. `droppedElements` is non-zero when individual
+    /// rows were unreadable and skipped; the raw blob was backed up first so
+    /// those rows are still recoverable.
+    case decoded(Value, droppedElements: Int)
+    /// Nothing usable could be decoded. The raw blob has been (or will be)
+    /// copied aside and the guard refuses to overwrite it until that copy exists.
+    case corrupt
+}
+
+/// Guards one `UserDefaults` JSON blob against the decode-failure-wipes-data
+/// bug class.
+///
+/// * Element-wise decoding: a list with one unreadable row loses that row, not
+///   the whole list.
+/// * Corrupt or partially readable blobs are copied to
+///   `<backupDirectory>/<key>.corrupt-<unix timestamp>.json` before anything
+///   is written over them.
+/// * If the backup could not be written, every `save`/`remove` is refused
+///   (returns `false`) so the unreadable bytes stay in place for a later
+///   recovery attempt instead of being replaced by a fresh empty list.
+final class PersistedBlobGuard {
+    struct CorruptBackup: Equatable {
+        let key: String
+        let url: URL
+        let date: Date
+    }
+
+    let key: String
+    private let defaults: UserDefaults
+    private let backupDirectory: URL
+    private let logger = Logger(subsystem: "ai.fud.calorietracker", category: "Persistence")
+
+    /// Raw bytes that failed to decode and have not been copied aside yet.
+    /// Non-nil means writes are blocked.
+    private var pendingCorruptBlob: Data?
+    /// Hashes of blobs already backed up in this process, so repeated reloads
+    /// of the same corrupt bytes don't spawn a new backup file each time.
+    private var backedUpBlobHashes: Set<Int> = []
+    private(set) var backups: [CorruptBackup] = []
+
+    init(defaults: UserDefaults, key: String, backupDirectory: URL? = nil) {
+        self.defaults = defaults
+        self.key = key
+        self.backupDirectory = backupDirectory ?? Self.defaultBackupDirectory()
+    }
+
+    /// True while a corrupt blob sits in `defaults` without a backup copy.
+    /// Callers should refuse mutations rather than let them silently vanish.
+    var isWriteBlocked: Bool { pendingCorruptBlob != nil }
+
+    static func defaultBackupDirectory() -> URL {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        return base.appendingPathComponent("CorruptDataBackups", isDirectory: true)
+    }
+
+    // MARK: - Loading
+
+    /// Decodes a JSON array. Falls back to per-element decoding so a single bad
+    /// row is dropped rather than failing the whole list.
+    func loadList<Element: Decodable>(
+        _ type: Element.Type,
+        decoder: JSONDecoder = JSONDecoder()
+    ) -> PersistedBlobLoad<[Element]> {
+        guard let raw = rawBlob() else { return .missing }
+        guard case .data(let data) = raw else {
+            quarantine(raw.bytes, reason: "value under '\(key)' is not Data")
+            return .corrupt
+        }
+
+        if let decoded = try? decoder.decode([Element].self, from: data) {
+            pendingCorruptBlob = nil
+            return .decoded(decoded, droppedElements: 0)
+        }
+
+        if let lenient = try? decoder.decode([LenientElement<Element>].self, from: data) {
+            let recovered = lenient.compactMap(\.value)
+            let dropped = lenient.count - recovered.count
+            if !recovered.isEmpty {
+                quarantine(data, reason: "\(dropped) of \(lenient.count) rows under '\(key)' were unreadable")
+                return .decoded(recovered, droppedElements: dropped)
+            }
+        }
+
+        quarantine(data, reason: "blob under '\(key)' could not be decoded")
+        return .corrupt
+    }
+
+    /// Decodes a single JSON value (e.g. a profile or a versioned state struct).
+    func loadValue<Value: Decodable>(
+        _ type: Value.Type,
+        decoder: JSONDecoder = JSONDecoder()
+    ) -> PersistedBlobLoad<Value> {
+        guard let raw = rawBlob() else { return .missing }
+        guard case .data(let data) = raw else {
+            quarantine(raw.bytes, reason: "value under '\(key)' is not Data")
+            return .corrupt
+        }
+        if let decoded = try? decoder.decode(Value.self, from: data) {
+            pendingCorruptBlob = nil
+            return .decoded(decoded, droppedElements: 0)
+        }
+        quarantine(data, reason: "blob under '\(key)' could not be decoded")
+        return .corrupt
+    }
+
+    /// Treats whatever is currently stored as unreadable (e.g. a persisted
+    /// schema version this build does not understand) so it is backed up and
+    /// protected from being overwritten until the copy exists.
+    func quarantineCurrentBlob(reason: String) {
+        guard let raw = rawBlob() else { return }
+        quarantine(raw.bytes, reason: reason)
+    }
+
+    // MARK: - Writing
+
+    /// Encodes and stores `value`. Returns `false` — without touching
+    /// `defaults` — when encoding fails or a corrupt blob has not been backed
+    /// up yet.
+    @discardableResult
+    func save<Value: Encodable>(_ value: Value, encoder: JSONEncoder = JSONEncoder()) -> Bool {
+        guard ensureCorruptBlobIsBackedUp() else { return false }
+        guard let data = try? encoder.encode(value) else {
+            logger.error("Refusing to persist '\(self.key, privacy: .public)': encoding failed")
+            return false
+        }
+        defaults.set(data, forKey: key)
+        return true
+    }
+
+    /// Removes the key. Refused (returns `false`) while a corrupt blob is
+    /// still waiting for its backup copy.
+    @discardableResult
+    func remove() -> Bool {
+        guard ensureCorruptBlobIsBackedUp() else { return false }
+        defaults.removeObject(forKey: key)
+        return true
+    }
+
+    // MARK: - Internals
+
+    private enum RawBlob {
+        case data(Data)
+        case other(Any)
+
+        var bytes: Data {
+            switch self {
+            case .data(let data): return data
+            case .other(let value): return Data(String(describing: value).utf8)
+            }
+        }
+    }
+
+    private func rawBlob() -> RawBlob? {
+        guard let object = defaults.object(forKey: key) else { return nil }
+        if let data = object as? Data { return .data(data) }
+        return .other(object)
+    }
+
+    private func quarantine(_ data: Data, reason: String) {
+        logger.error("Preserving unreadable data for '\(self.key, privacy: .public)': \(reason, privacy: .public)")
+        if backedUpBlobHashes.contains(data.hashValue) {
+            pendingCorruptBlob = nil
+            return
+        }
+        pendingCorruptBlob = data
+        _ = ensureCorruptBlobIsBackedUp()
+    }
+
+    private func ensureCorruptBlobIsBackedUp() -> Bool {
+        guard let blob = pendingCorruptBlob else { return true }
+        guard let url = writeBackup(blob) else {
+            logger.fault("Could not back up corrupt blob for '\(self.key, privacy: .public)'; refusing writes")
+            return false
+        }
+        backedUpBlobHashes.insert(blob.hashValue)
+        backups.append(CorruptBackup(key: key, url: url, date: .now))
+        pendingCorruptBlob = nil
+        logger.notice("Backed up corrupt blob for '\(self.key, privacy: .public)' to \(url.lastPathComponent, privacy: .public)")
+        return true
+    }
+
+    private func writeBackup(_ blob: Data) -> URL? {
+        let fileManager = FileManager.default
+        do {
+            try fileManager.createDirectory(at: backupDirectory, withIntermediateDirectories: true)
+            let stamp = Int(Date.now.timeIntervalSince1970 * 1000)
+            var url = backupDirectory.appendingPathComponent("\(key).corrupt-\(stamp).json")
+            var attempt = 0
+            while fileManager.fileExists(atPath: url.path) {
+                attempt += 1
+                url = backupDirectory.appendingPathComponent("\(key).corrupt-\(stamp)-\(attempt).json")
+            }
+            try blob.write(to: url, options: .atomic)
+            return url
+        } catch {
+            return nil
+        }
+    }
+}
+
+/// Wraps an element so a decode failure yields `nil` instead of aborting the
+/// surrounding array decode.
+private struct LenientElement<Element: Decodable>: Decodable {
+    let value: Element?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        value = try? container.decode(Element.self)
+    }
+}

--- a/ios/calorietracker/Services/PersistedBlobGuard.swift
+++ b/ios/calorietracker/Services/PersistedBlobGuard.swift
@@ -31,6 +31,11 @@ enum PersistedBlobLoad<Value> {
 /// * If the backup could not be written, every `save`/`remove` is refused
 ///   (returns `false`) so the unreadable bytes stay in place for a later
 ///   recovery attempt instead of being replaced by a fresh empty list.
+/// * Before every `save`/`remove` the live `UserDefaults` value is re-read.
+///   If something else (widget, extension, restore) replaced it since the
+///   guard last looked, the new bytes are decode-checked and quarantined the
+///   same way, so a corrupt blob written behind the store's back is never
+///   overwritten on the strength of a stale "all good" from the last load.
 final class PersistedBlobGuard {
     struct CorruptBackup: Equatable {
         let key: String
@@ -50,6 +55,14 @@ final class PersistedBlobGuard {
     /// of the same corrupt bytes don't spawn a new backup file each time.
     private var backedUpBlobHashes: Set<Int> = []
     private(set) var backups: [CorruptBackup] = []
+
+    /// Raw bytes as of the guard's last load/save/remove (`nil` = key absent).
+    /// Any difference at write time means an external writer touched the key.
+    private var lastObservedBlob: Data?
+    private var hasObservedBlob = false
+    /// Decode check for the type this key holds, captured on load so an
+    /// externally written blob can be validated before it is replaced.
+    private var isFullyReadable: ((Data) -> Bool)?
 
     init(defaults: UserDefaults, key: String, backupDirectory: URL? = nil) {
         self.defaults = defaults
@@ -75,7 +88,8 @@ final class PersistedBlobGuard {
         _ type: Element.Type,
         decoder: JSONDecoder = JSONDecoder()
     ) -> PersistedBlobLoad<[Element]> {
-        guard let raw = rawBlob() else { return .missing }
+        isFullyReadable = { (try? decoder.decode([Element].self, from: $0)) != nil }
+        guard let raw = observeCurrentBlob() else { return .missing }
         guard case .data(let data) = raw else {
             quarantine(raw.bytes, reason: "value under '\(key)' is not Data")
             return .corrupt
@@ -86,13 +100,9 @@ final class PersistedBlobGuard {
             return .decoded(decoded, droppedElements: 0)
         }
 
-        if let lenient = try? decoder.decode([LenientElement<Element>].self, from: data) {
-            let recovered = lenient.compactMap(\.value)
-            let dropped = lenient.count - recovered.count
-            if !recovered.isEmpty {
-                quarantine(data, reason: "\(dropped) of \(lenient.count) rows under '\(key)' were unreadable")
-                return .decoded(recovered, droppedElements: dropped)
-            }
+        if let lenient = Self.decodeListLeniently(Element.self, from: data, decoder: decoder) {
+            quarantine(data, reason: "\(lenient.dropped) of \(lenient.items.count + lenient.dropped) rows under '\(key)' were unreadable")
+            return .decoded(lenient.items, droppedElements: lenient.dropped)
         }
 
         quarantine(data, reason: "blob under '\(key)' could not be decoded")
@@ -104,7 +114,8 @@ final class PersistedBlobGuard {
         _ type: Value.Type,
         decoder: JSONDecoder = JSONDecoder()
     ) -> PersistedBlobLoad<Value> {
-        guard let raw = rawBlob() else { return .missing }
+        isFullyReadable = { (try? decoder.decode(Value.self, from: $0)) != nil }
+        guard let raw = observeCurrentBlob() else { return .missing }
         guard case .data(let data) = raw else {
             quarantine(raw.bytes, reason: "value under '\(key)' is not Data")
             return .corrupt
@@ -117,11 +128,29 @@ final class PersistedBlobGuard {
         return .corrupt
     }
 
+    /// Element-wise decode of a JSON array: rows that fail to decode are
+    /// dropped instead of failing the whole list. Returns `nil` when the data
+    /// is not an array or no row could be recovered. Pure — nothing is backed
+    /// up or quarantined — so it is safe for one-off reads outside a store.
+    static func decodeListLeniently<Element: Decodable>(
+        _ type: Element.Type,
+        from data: Data,
+        decoder: JSONDecoder = JSONDecoder()
+    ) -> (items: [Element], dropped: Int)? {
+        if let decoded = try? decoder.decode([Element].self, from: data) {
+            return (decoded, 0)
+        }
+        guard let lenient = try? decoder.decode([LenientElement<Element>].self, from: data) else { return nil }
+        let recovered = lenient.compactMap(\.value)
+        guard !recovered.isEmpty else { return nil }
+        return (recovered, lenient.count - recovered.count)
+    }
+
     /// Treats whatever is currently stored as unreadable (e.g. a persisted
     /// schema version this build does not understand) so it is backed up and
     /// protected from being overwritten until the copy exists.
     func quarantineCurrentBlob(reason: String) {
-        guard let raw = rawBlob() else { return }
+        guard let raw = observeCurrentBlob() else { return }
         quarantine(raw.bytes, reason: reason)
     }
 
@@ -132,12 +161,14 @@ final class PersistedBlobGuard {
     /// up yet.
     @discardableResult
     func save<Value: Encodable>(_ value: Value, encoder: JSONEncoder = JSONEncoder()) -> Bool {
-        guard ensureCorruptBlobIsBackedUp() else { return false }
+        guard ensureCurrentBlobIsSafeToReplace() else { return false }
         guard let data = try? encoder.encode(value) else {
             logger.error("Refusing to persist '\(self.key, privacy: .public)': encoding failed")
             return false
         }
         defaults.set(data, forKey: key)
+        lastObservedBlob = data
+        hasObservedBlob = true
         return true
     }
 
@@ -145,8 +176,10 @@ final class PersistedBlobGuard {
     /// still waiting for its backup copy.
     @discardableResult
     func remove() -> Bool {
-        guard ensureCorruptBlobIsBackedUp() else { return false }
+        guard ensureCurrentBlobIsSafeToReplace() else { return false }
         defaults.removeObject(forKey: key)
+        lastObservedBlob = nil
+        hasObservedBlob = true
         return true
     }
 
@@ -168,6 +201,40 @@ final class PersistedBlobGuard {
         guard let object = defaults.object(forKey: key) else { return nil }
         if let data = object as? Data { return .data(data) }
         return .other(object)
+    }
+
+    /// Reads the live value and records it as the baseline for external-change detection.
+    private func observeCurrentBlob() -> RawBlob? {
+        let raw = rawBlob()
+        lastObservedBlob = raw?.bytes
+        hasObservedBlob = true
+        return raw
+    }
+
+    /// Re-reads `defaults` so a blob written by another process since the
+    /// last load is decode-checked (and quarantined if unreadable) before it
+    /// is overwritten, then makes sure any quarantined bytes have a backup.
+    private func ensureCurrentBlobIsSafeToReplace() -> Bool {
+        reconcileExternalChange()
+        return ensureCorruptBlobIsBackedUp()
+    }
+
+    private func reconcileExternalChange() {
+        let current = rawBlob()
+        let currentBytes = current?.bytes
+        guard hasObservedBlob, currentBytes != lastObservedBlob else { return }
+        lastObservedBlob = currentBytes
+        switch current {
+        case .none:
+            break
+        case .some(.other):
+            quarantine(currentBytes ?? Data(), reason: "value under '\(key)' was externally replaced with non-Data")
+        case .some(.data(let data)):
+            guard let isFullyReadable else { return }
+            if !isFullyReadable(data) {
+                quarantine(data, reason: "blob under '\(key)' was externally replaced with unreadable data")
+            }
+        }
     }
 
     private func quarantine(_ data: Data, reason: String) {

--- a/ios/calorietracker/Stores/FastingStore.swift
+++ b/ios/calorietracker/Stores/FastingStore.swift
@@ -29,12 +29,14 @@ final class FastingStore {
         }
     }
 
+    /// Same lenient row-wise decode as `load`, so one unreadable row cannot
+    /// make this report "no active fast" while `activeSession` still has one.
     static func persistedActiveSession(defaults: UserDefaults = .standard) -> FastingSession? {
         guard let data = defaults.data(forKey: FastingSettings.sessionsKey),
-              let decoded = try? JSONDecoder().decode([FastingSession].self, from: data) else {
+              let decoded = PersistedBlobGuard.decodeListLeniently(FastingSession.self, from: data) else {
             return nil
         }
-        return decoded.last(where: \.isActive)
+        return decoded.items.sorted { $0.startedAt < $1.startedAt }.last(where: \.isActive)
     }
 
     var activeSession: FastingSession? {

--- a/ios/calorietracker/Stores/FastingStore.swift
+++ b/ios/calorietracker/Stores/FastingStore.swift
@@ -4,13 +4,29 @@ import Foundation
 final class FastingStore {
     private(set) var sessions: [FastingSession] = []
     var onSessionsChanged: (() -> Void)?
-    private let defaults: UserDefaults
+    private let sessionsBlob: PersistedBlobGuard
 
-    init(defaults: UserDefaults = .standard) {
-        self.defaults = defaults
-        guard let data = defaults.data(forKey: FastingSettings.sessionsKey),
-              let decoded = try? JSONDecoder().decode([FastingSession].self, from: data) else { return }
-        sessions = decoded.sorted { $0.startedAt < $1.startedAt }
+    /// True while an unreadable blob is on disk without a backup copy.
+    var isPersistenceBlocked: Bool { sessionsBlob.isWriteBlocked }
+
+    init(defaults: UserDefaults = .standard, corruptBackupDirectory: URL? = nil) {
+        self.sessionsBlob = PersistedBlobGuard(
+            defaults: defaults,
+            key: FastingSettings.sessionsKey,
+            backupDirectory: corruptBackupDirectory
+        )
+        load(isInitialLoad: true)
+    }
+
+    private func load(isInitialLoad: Bool) {
+        switch sessionsBlob.loadList(FastingSession.self) {
+        case .missing:
+            sessions = []
+        case .decoded(let decoded, _):
+            sessions = decoded.sorted { $0.startedAt < $1.startedAt }
+        case .corrupt:
+            if isInitialLoad { sessions = [] }
+        }
     }
 
     static func persistedActiveSession(defaults: UserDefaults = .standard) -> FastingSession? {
@@ -27,6 +43,7 @@ final class FastingStore {
 
     @discardableResult
     func start(goalMinutes: Int, at date: Date = .now) -> FastingSession? {
+        guard !isPersistenceBlocked else { return nil }
         guard activeSession == nil else { return nil }
         let session = FastingSession(startedAt: date, goalMinutes: goalMinutes)
         guard !overlapsExistingSession(session) else { return nil }
@@ -37,6 +54,7 @@ final class FastingStore {
 
     @discardableResult
     func endActive(at date: Date = .now) -> FastingSession? {
+        guard !isPersistenceBlocked else { return nil }
         guard let active = activeSession,
               let index = sessions.firstIndex(where: { $0.id == active.id }) else { return nil }
         sessions[index].endedAt = max(date, active.startedAt)
@@ -46,13 +64,14 @@ final class FastingStore {
     }
 
     func cancelActive() {
-        guard let active = activeSession else { return }
+        guard !isPersistenceBlocked, let active = activeSession else { return }
         sessions.removeAll { $0.id == active.id }
         save()
     }
 
     @discardableResult
     func update(_ session: FastingSession) -> Bool {
+        guard !isPersistenceBlocked else { return false }
         guard let index = sessions.firstIndex(where: { $0.id == session.id }) else { return false }
         var validated = session
         validated.goalMinutes = min(
@@ -74,6 +93,7 @@ final class FastingStore {
     }
 
     func delete(id: UUID) {
+        guard !isPersistenceBlocked else { return }
         sessions.removeAll { $0.id == id }
         save()
     }
@@ -83,25 +103,18 @@ final class FastingStore {
     }
 
     func reloadFromDefaults() {
-        guard let data = defaults.data(forKey: FastingSettings.sessionsKey),
-              let decoded = try? JSONDecoder().decode([FastingSession].self, from: data) else {
-            sessions = []
-            onSessionsChanged?()
-            return
-        }
-        sessions = decoded.sorted { $0.startedAt < $1.startedAt }
+        load(isInitialLoad: false)
         onSessionsChanged?()
     }
 
     func clear() {
+        guard sessionsBlob.remove() else { return }
         sessions = []
-        defaults.removeObject(forKey: FastingSettings.sessionsKey)
         onSessionsChanged?()
     }
 
     private func save() {
-        guard let data = try? JSONEncoder().encode(sessions) else { return }
-        defaults.set(data, forKey: FastingSettings.sessionsKey)
+        guard sessionsBlob.save(sessions) else { return }
         onSessionsChanged?()
     }
 

--- a/ios/calorietracker/Stores/FoodStore.swift
+++ b/ios/calorietracker/Stores/FoodStore.swift
@@ -45,18 +45,41 @@ class FoodStore {
     var onEntryDeleted: ((UUID) -> Void)?
     var onEntryUpdated: ((FoodEntry) -> Void)?
 
-    private let storageKey = "foodEntries"
-    private let favoritesKey = "favoriteFoodEntries"
+    static let storageKey = "foodEntries"
+    static let favoritesKey = "favoriteFoodEntries"
     private(set) var favorites: [FoodEntry] = []
     private let observesExternalChanges: Bool
     private let defaults: UserDefaults
+    private let entriesBlob: PersistedBlobGuard
+    private let favoritesBlob: PersistedBlobGuard
+
+    /// Number of diary rows that were unreadable on the last load and had to be
+    /// skipped. The raw blob was backed up first, so nothing is lost.
+    private(set) var droppedEntriesOnLoad = 0
+
+    /// Backups written for diary blobs that could not be decoded. Surfaced so
+    /// a future recovery UI can point at the file; the store never deletes them.
+    var corruptBlobBackups: [PersistedBlobGuard.CorruptBackup] {
+        entriesBlob.backups + favoritesBlob.backups
+    }
+
+    /// True while an unreadable diary blob is still on disk without a backup
+    /// copy. Every mutation is refused in this state so the next save cannot
+    /// replace the user's history with a one-entry list.
+    var isPersistenceBlocked: Bool { entriesBlob.isWriteBlocked }
 
     static let externalChangeNotification = "ai.fud.foodEntriesDidChange"
 
-    init(observesExternalChanges: Bool = true, defaults: UserDefaults = .standard) {
+    init(
+        observesExternalChanges: Bool = true,
+        defaults: UserDefaults = .standard,
+        corruptBackupDirectory: URL? = nil
+    ) {
         self.observesExternalChanges = observesExternalChanges
         self.defaults = defaults
-        loadEntries()
+        self.entriesBlob = PersistedBlobGuard(defaults: defaults, key: Self.storageKey, backupDirectory: corruptBackupDirectory)
+        self.favoritesBlob = PersistedBlobGuard(defaults: defaults, key: Self.favoritesKey, backupDirectory: corruptBackupDirectory)
+        loadEntries(isInitialLoad: true)
         loadFavorites()
         if observesExternalChanges {
             startObservingExternalChanges()
@@ -315,6 +338,7 @@ class FoodStore {
     }
 
     func toggleFavorite(_ entry: FoodEntry) {
+        guard !favoritesBlob.isWriteBlocked else { return }
         if let index = favorites.firstIndex(where: { $0.favoriteKey == entry.favoriteKey }) {
             favorites.remove(at: index)
         } else {
@@ -334,28 +358,35 @@ class FoodStore {
     }
 
     func moveFavorite(from source: IndexSet, to destination: Int) {
+        guard !favoritesBlob.isWriteBlocked else { return }
         favorites.move(fromOffsets: source, toOffset: destination)
         saveFavorites()
     }
 
     private func saveFavorites() {
-        if let data = try? JSONEncoder().encode(favorites) {
-            defaults.set(data, forKey: favoritesKey)
+        if favoritesBlob.save(favorites) {
             defaults.synchronize()
         }
     }
 
     private func loadFavorites() {
-        guard let data = defaults.data(forKey: favoritesKey),
-              let decoded = try? JSONDecoder().decode([FoodEntry].self, from: data)
-        else { return }
-        favorites = decoded
+        switch favoritesBlob.loadList(FoodEntry.self) {
+        case .missing:
+            favorites = []
+        case .decoded(let decoded, _):
+            favorites = decoded
+        case .corrupt:
+            // Keep whatever is in memory; the unreadable blob has been backed up
+            // and `saveFavorites` stays blocked until that copy exists.
+            break
+        }
     }
 
     // MARK: - CRUD
 
     @discardableResult
     func addEntry(_ entry: FoodEntry) -> Bool {
+        guard !isPersistenceBlocked else { return false }
         guard FastingStore.persistedActiveSession(defaults: defaults) == nil else { return false }
         var entry = entry
         let photosToExport = (entry.imageData.map { [$0] } ?? []) + entry.additionalImageData
@@ -377,6 +408,7 @@ class FoodStore {
     }
 
     func updateEntry(_ entry: FoodEntry) {
+        guard !isPersistenceBlocked else { return }
         guard let index = entries.firstIndex(where: { $0.id == entry.id }) else { return }
         let previousFilenames = Set(entries[index].allImageFilenames)
         var entry = entry
@@ -394,6 +426,7 @@ class FoodStore {
     }
 
     func deleteEntry(_ entry: FoodEntry) {
+        guard !isPersistenceBlocked else { return }
         let id = entry.id
         // Skip the disk-delete when a favorite (or another entry) still
         // references this filename. Without this guard, favoriting a meal,
@@ -411,6 +444,7 @@ class FoodStore {
     /// Merge selected diary foods into one combined meal and remove the originals.
     @discardableResult
     func combineIntoMeal(ids: Set<UUID>) -> FoodEntry? {
+        guard !isPersistenceBlocked else { return nil }
         guard FastingStore.persistedActiveSession(defaults: defaults) == nil else { return nil }
         guard ids.count >= 2 else { return nil }
         let selected = entries.filter { ids.contains($0.id) }
@@ -436,12 +470,13 @@ class FoodStore {
     }
 
     func reloadFromDefaults() {
-        loadEntries()
+        loadEntries(isInitialLoad: false)
         loadFavorites()
         onEntriesChanged?()
     }
 
     func replaceAllEntries(_ newEntries: [FoodEntry]) {
+        guard !isPersistenceBlocked else { return }
         // Delete on-disk JPEGs for any entry that's about to be removed —
         // otherwise Clear Food Log / Delete All Data orphan files in
         // Application Support forever. Skip files that a favorite or a
@@ -464,6 +499,7 @@ class FoodStore {
     /// resulting ID changes to Apple Health through the existing callbacks.
     /// Entries whose IDs survive the import are updates; new IDs are additions.
     func replaceEntriesFromImport(_ newEntries: [FoodEntry]) {
+        guard !isPersistenceBlocked else { return }
         let oldIDs = Set(entries.map(\.id))
         let newIDs = Set(newEntries.map(\.id))
         let removedIDs = oldIDs.subtracting(newIDs)
@@ -477,14 +513,27 @@ class FoodStore {
         addedEntries.forEach { onEntryAdded?($0) }
     }
 
+    /// Upserts `cloudEntries` (iCloud restore, HealthKit recovery) by id.
+    /// Duplicate ids — in the local list, the incoming batch, or across both —
+    /// resolve newest-wins instead of trapping in `Dictionary(uniqueKeysWithValues:)`.
     func mergeWithCloudEntries(_ cloudEntries: [FoodEntry]) {
-        var merged = Dictionary(uniqueKeysWithValues: entries.map { ($0.id, $0) })
-        for cloudEntry in cloudEntries {
-            merged[cloudEntry.id] = cloudEntry
-        }
-        entries = Array(merged.values)
+        guard !isPersistenceBlocked else { return }
+        entries = Self.mergingByID(entries, with: cloudEntries)
         saveEntries()
         onEntriesChanged?()
+    }
+
+    /// Order-preserving upsert: existing rows keep their position, later
+    /// duplicates of the same id replace earlier ones, new ids append.
+    static func mergingByID(_ existing: [FoodEntry], with incoming: [FoodEntry]) -> [FoodEntry] {
+        var order: [UUID] = []
+        var byID: [UUID: FoodEntry] = [:]
+        for entry in existing + incoming {
+            if byID.updateValue(entry, forKey: entry.id) == nil {
+                order.append(entry.id)
+            }
+        }
+        return order.compactMap { byID[$0] }
     }
 
     func reprocessEntry(_ entry: FoodEntry, withNote note: String) async throws -> GeminiService.FoodAnalysis {
@@ -596,7 +645,7 @@ class FoodStore {
     }
 
     private func reloadFromExternalChange() {
-        loadEntries()
+        loadEntries(isInitialLoad: false)
         onEntriesChanged?()
     }
 
@@ -612,21 +661,27 @@ class FoodStore {
 
     @discardableResult
     private func saveEntries() -> Bool {
-        if let data = try? JSONEncoder().encode(entries) {
-            defaults.set(data, forKey: storageKey)
-            return defaults.synchronize()
-        }
-        return false
+        guard entriesBlob.save(entries) else { return false }
+        return defaults.synchronize()
     }
 
-    private func loadEntries() {
-        guard let data = defaults.data(forKey: storageKey),
-              let decoded = try? JSONDecoder().decode([FoodEntry].self, from: data)
-        else {
+    private func loadEntries(isInitialLoad: Bool) {
+        switch entriesBlob.loadList(FoodEntry.self) {
+        case .missing:
+            droppedEntriesOnLoad = 0
             entries = []
             return
+        case .decoded(let decoded, let dropped):
+            droppedEntriesOnLoad = dropped
+            entries = decoded
+        case .corrupt:
+            // The blob is unreadable and has been backed up (or writes are
+            // blocked until it is). On first launch there is nothing else to
+            // show; on a reload keep the good in-memory copy rather than
+            // replacing the user's diary with an empty list.
+            if isInitialLoad { entries = [] }
+            return
         }
-        entries = decoded
 
         // Legacy migration: rows written by pre-FoodImageStore builds embedded
         // JPEG bytes in the JSON blob. Offload any such rows to disk, stamp

--- a/ios/calorietracker/Stores/StrengthWorkoutStore.swift
+++ b/ios/calorietracker/Stores/StrengthWorkoutStore.swift
@@ -71,12 +71,22 @@ final class StrengthWorkoutStore {
 
     private let defaults: UserDefaults
     private let storageKey: String
+    private let stateBlob: PersistedBlobGuard
     private var liftSummaryCacheKey: String?
     private var liftSummaryCache: [String: String] = [:]
 
-    init(defaults: UserDefaults = .standard, storageKey: String = StrengthWorkoutStore.defaultStorageKey) {
+    /// True while an unreadable state blob is on disk without a backup copy;
+    /// `save()` is refused in that state so it cannot be overwritten.
+    var isPersistenceBlocked: Bool { stateBlob.isWriteBlocked }
+
+    init(
+        defaults: UserDefaults = .standard,
+        storageKey: String = StrengthWorkoutStore.defaultStorageKey,
+        corruptBackupDirectory: URL? = nil
+    ) {
         self.defaults = defaults
         self.storageKey = storageKey
+        self.stateBlob = PersistedBlobGuard(defaults: defaults, key: storageKey, backupDirectory: corruptBackupDirectory)
         load()
     }
 
@@ -570,7 +580,7 @@ final class StrengthWorkoutStore {
         }
         userExercises = []
         preferences = StrengthWorkoutPreferences()
-        defaults.removeObject(forKey: storageKey)
+        stateBlob.remove()
     }
 
     private func updatePlan(for date: Date, mutate: (inout StrengthWorkoutDayPlan) -> Void) {
@@ -689,10 +699,21 @@ final class StrengthWorkoutStore {
     }
 
     private func load() {
-        guard let data = defaults.data(forKey: storageKey),
-              let state = try? JSONDecoder().decode(PersistedState.self, from: data),
-              state.version == 1
-        else { return }
+        let state: PersistedState
+        switch stateBlob.loadValue(PersistedState.self) {
+        case .missing, .corrupt:
+            // Corrupt blobs are backed up by the guard and protected from
+            // being overwritten until that copy exists.
+            return
+        case .decoded(let decoded, _):
+            state = decoded
+        }
+        guard state.version == 1 else {
+            // Written by a build with a newer schema — preserve it rather than
+            // clobbering it with a downgraded empty state on the next save.
+            stateBlob.quarantineCurrentBlob(reason: "unsupported workout state version \(state.version)")
+            return
+        }
         dayPlans = state.dayPlans
         completedSessions = state.completedSessions
         savedExerciseIDs = state.savedExerciseIDs
@@ -723,8 +744,7 @@ final class StrengthWorkoutStore {
             customActivities: customActivities,
             userExercises: userExercises
         )
-        guard let data = try? JSONEncoder().encode(state) else { return }
-        defaults.set(data, forKey: storageKey)
+        stateBlob.save(state)
     }
 
     private static func decimalText(_ value: String) -> String {

--- a/ios/calorietracker/Stores/StrengthWorkoutStore.swift
+++ b/ios/calorietracker/Stores/StrengthWorkoutStore.swift
@@ -142,18 +142,24 @@ final class StrengthWorkoutStore {
         let additions = try draft.planned(library: library)
         guard let date = Self.date(for: draft.date) else { throw WorkoutTextError.invalid("Choose a valid date.") }
         let known = Set(customActivities.map(\.itemID))
-        customActivities.append(contentsOf: additions.filter {
+        let newActivities = additions.filter {
             $0.itemID.hasPrefix("custom_activity_") && !known.contains($0.itemID)
         }.map { item in
             var template = item
             template.sets = []
             template.timer = nil
             return template
-        })
-        updatePlan(for: date) { plan in
-            let existing = Set(plan.exercises.map(\.id))
-            plan.exercises.append(contentsOf: additions.filter { !existing.contains($0.id) })
         }
+        var invalidatedBurnIDs: [UUID] = []
+        let committed = commit {
+            customActivities.append(contentsOf: newActivities)
+            invalidatedBurnIDs = applyPlanMutation(for: date) { plan in
+                let existing = Set(plan.exercises.map(\.id))
+                plan.exercises.append(contentsOf: additions.filter { !existing.contains($0.id) })
+            }
+        }
+        guard committed else { throw WorkoutTextError.invalid(Self.persistenceBlockedMessage) }
+        for id in invalidatedBurnIDs { onWorkoutBurnDeleted?(id) }
     }
 
     func toggleExercise(_ item: ExerciseLibraryItem, on date: Date) {
@@ -175,6 +181,7 @@ final class StrengthWorkoutStore {
         let itemID = existingItemID ?? UserExercise.newID()
         var imagePaths = userExercises.first(where: { $0.itemID == itemID })?.imagePaths ?? []
         var orphanCandidates: [String] = []
+        var newPhotoFilename: String?
 
         if draft.removePhoto {
             orphanCandidates.append(contentsOf: imagePaths)
@@ -185,6 +192,7 @@ final class StrengthWorkoutStore {
            let filename = FoodImageStore.shared.storeExercisePhoto(data: photoData) {
             orphanCandidates.append(contentsOf: imagePaths)
             imagePaths = [filename]
+            newPhotoFilename = filename
         }
 
         let item = draft.libraryItem(id: itemID, imagePaths: imagePaths)
@@ -192,12 +200,18 @@ final class StrengthWorkoutStore {
         template.sets = []
         template.timer = nil
 
-        if let index = userExercises.firstIndex(where: { $0.itemID == itemID }) {
-            userExercises[index] = template
-        } else {
-            userExercises.append(template)
+        let committed = commit {
+            if let index = userExercises.firstIndex(where: { $0.itemID == itemID }) {
+                userExercises[index] = template
+            } else {
+                userExercises.append(template)
+            }
         }
-        guard save() else { return nil }
+        guard committed else {
+            // The exercise was rolled back, so the photo stored for it is an orphan.
+            if let newPhotoFilename { FoodImageStore.shared.delete(filename: newPhotoFilename) }
+            return nil
+        }
         orphanCandidates
             .filter { !referencesUserExerciseImage($0) }
             .forEach { FoodImageStore.shared.delete(filename: $0) }
@@ -207,9 +221,11 @@ final class StrengthWorkoutStore {
     func deleteUserExercise(itemID: String) {
         guard !isPersistenceBlocked, UserExercise.isUserExercise(itemID) else { return }
         let orphanCandidates = userExercises.first(where: { $0.itemID == itemID })?.imagePaths ?? []
-        userExercises.removeAll { $0.itemID == itemID }
-        savedExerciseIDs.remove(itemID)
-        guard save() else { return }
+        let committed = commit {
+            userExercises.removeAll { $0.itemID == itemID }
+            savedExerciseIDs.remove(itemID)
+        }
+        guard committed else { return }
         orphanCandidates
             .filter { !referencesUserExerciseImage($0) }
             .forEach { FoodImageStore.shared.delete(filename: $0) }
@@ -292,13 +308,13 @@ final class StrengthWorkoutStore {
     }
 
     func toggleSaved(_ itemID: String) {
-        guard !isPersistenceBlocked else { return }
-        if savedExerciseIDs.contains(itemID) {
-            savedExerciseIDs.remove(itemID)
-        } else {
-            savedExerciseIDs.insert(itemID)
+        commit {
+            if savedExerciseIDs.contains(itemID) {
+                savedExerciseIDs.remove(itemID)
+            } else {
+                savedExerciseIDs.insert(itemID)
+            }
         }
-        save()
     }
 
     func updateTimer(
@@ -420,8 +436,7 @@ final class StrengthWorkoutStore {
             durationSeconds: max(1, elapsedSeconds),
             exercises: logs
         )
-        completedSessions.append(session)
-        guard save() else { return nil }
+        guard commit({ completedSessions.append(session) }) else { return nil }
         return session
     }
 
@@ -462,13 +477,15 @@ final class StrengthWorkoutStore {
 
         // Keep timer-era completed sessions intact. The burn calculator owns
         // only the single daily burn snapshot it previously created.
-        completedSessions.removeAll {
-            $0.stableDiaryDateKey == key && $0.caloriesBurned != nil
-        }
-        completedSessions.append(session)
         // Health only hears about the burn once it is durably stored, so a
         // refused save cannot leave a sample with no diary record behind it.
-        guard save() else { return nil }
+        let committed = commit {
+            completedSessions.removeAll {
+                $0.stableDiaryDateKey == key && $0.caloriesBurned != nil
+            }
+            completedSessions.append(session)
+        }
+        guard committed else { return nil }
         for duplicate in existingBurns.dropFirst() where duplicate.id != session.id {
             onWorkoutBurnDeleted?(duplicate.id)
         }
@@ -504,8 +521,7 @@ final class StrengthWorkoutStore {
         let deletedBurnID = completedSessions.first {
             $0.id == id && $0.caloriesBurned != nil
         }?.id
-        completedSessions.removeAll { $0.id == id }
-        guard save() else { return }
+        guard commit({ completedSessions.removeAll { $0.id == id } }) else { return }
         if let deletedBurnID { onWorkoutBurnDeleted?(deletedBurnID) }
     }
 
@@ -514,41 +530,36 @@ final class StrengthWorkoutStore {
     /// echoed back to Apple Health.
     func importWorkoutBurnSessions(_ imported: [StrengthWorkoutSession]) {
         guard !isPersistenceBlocked, !imported.isEmpty else { return }
+        var merged = completedSessions
         var changed = false
 
         for session in imported where session.caloriesBurned != nil {
-            if let index = completedSessions.firstIndex(where: { $0.id == session.id }) {
-                let localVersion = completedSessions[index].healthSyncVersion ?? 0
+            if let index = merged.firstIndex(where: { $0.id == session.id }) {
+                let localVersion = merged[index].healthSyncVersion ?? 0
                 let importedVersion = session.healthSyncVersion ?? 0
                 if importedVersion > localVersion {
-                    completedSessions[index] = mergedBurnSession(
-                        local: completedSessions[index],
-                        imported: session
-                    )
+                    merged[index] = mergedBurnSession(local: merged[index], imported: session)
                     changed = true
                 }
                 continue
             }
 
-            if let sameDay = completedSessions.firstIndex(where: {
+            if let sameDay = merged.firstIndex(where: {
                 $0.stableDiaryDateKey == session.stableDiaryDateKey && $0.caloriesBurned != nil
             }) {
-                let localVersion = completedSessions[sameDay].healthSyncVersion ?? 0
+                let localVersion = merged[sameDay].healthSyncVersion ?? 0
                 let importedVersion = session.healthSyncVersion ?? 0
                 if importedVersion > localVersion {
-                    completedSessions[sameDay] = mergedBurnSession(
-                        local: completedSessions[sameDay],
-                        imported: session
-                    )
+                    merged[sameDay] = mergedBurnSession(local: merged[sameDay], imported: session)
                     changed = true
                 }
             } else {
-                completedSessions.append(session)
+                merged.append(session)
                 changed = true
             }
         }
 
-        if changed { save() }
+        if changed { commit { completedSessions = merged } }
     }
 
     /// Apple Health stores the burn value and stable identity, not the diary's
@@ -572,10 +583,10 @@ final class StrengthWorkoutStore {
     }
 
     func updatePreferences(_ mutate: (inout StrengthWorkoutPreferences) -> Void) {
-        guard !isPersistenceBlocked else { return }
-        mutate(&preferences)
-        preferences.sanitize()
-        save()
+        commit {
+            mutate(&preferences)
+            preferences.sanitize()
+        }
     }
 
     /// Re-reads the persisted state (e.g. after a cloud restore). Memory is
@@ -603,10 +614,21 @@ final class StrengthWorkoutStore {
         preferences = StrengthWorkoutPreferences()
     }
 
-    /// Returns `false` (leaving memory untouched) when persistence is blocked.
+    /// Returns `false` (leaving memory untouched) when persistence is blocked
+    /// or the write was refused.
     @discardableResult
     private func updatePlan(for date: Date, mutate: (inout StrengthWorkoutDayPlan) -> Void) -> Bool {
-        guard !isPersistenceBlocked else { return false }
+        var invalidatedBurnIDs: [UUID] = []
+        guard commit({ invalidatedBurnIDs = applyPlanMutation(for: date, mutate: mutate) }) else { return false }
+        for id in invalidatedBurnIDs { onWorkoutBurnDeleted?(id) }
+        return true
+    }
+
+    /// In-memory half of `updatePlan`. Must run inside `commit` so the change
+    /// is rolled back if it cannot be persisted. Returns the ids of burn
+    /// records the edit invalidated; the caller reports them to Health only
+    /// once the removal is durable.
+    private func applyPlanMutation(for date: Date, mutate: (inout StrengthWorkoutDayPlan) -> Void) -> [UUID] {
         let key = Self.dateKey(for: date)
         var plan = dayPlans[key] ?? StrengthWorkoutDayPlan(dateKey: key)
         let previousTimerInputs = savedTimerBurnInputs(in: plan)
@@ -620,20 +642,14 @@ final class StrengthWorkoutStore {
         // The explicit Calculate action owns daily burn snapshots. Changing
         // their saved timer inputs invalidates both the local estimate and its
         // Health sample; otherwise discarded time would keep counting forever.
-        let invalidatedBurnIDs: [UUID]
-        if previousTimerInputs != savedTimerBurnInputs(in: plan) {
-            invalidatedBurnIDs = completedSessions.filter {
-                $0.stableDiaryDateKey == key && $0.caloriesBurned != nil
-            }.map(\.id)
-            completedSessions.removeAll {
-                $0.stableDiaryDateKey == key && $0.caloriesBurned != nil
-            }
-        } else {
-            invalidatedBurnIDs = []
+        guard previousTimerInputs != savedTimerBurnInputs(in: plan) else { return [] }
+        let invalidatedBurnIDs = completedSessions.filter {
+            $0.stableDiaryDateKey == key && $0.caloriesBurned != nil
+        }.map(\.id)
+        completedSessions.removeAll {
+            $0.stableDiaryDateKey == key && $0.caloriesBurned != nil
         }
-        guard save() else { return false }
-        for id in invalidatedBurnIDs { onWorkoutBurnDeleted?(id) }
-        return true
+        return invalidatedBurnIDs
     }
 
     private struct SavedTimerBurnInput: Equatable {
@@ -747,13 +763,28 @@ final class StrengthWorkoutStore {
             return
         }
         hasUnsupportedPersistedState = false
+        apply(state)
+        preferences.sanitize()
+    }
+
+    private var currentState: PersistedState {
+        PersistedState(
+            dayPlans: dayPlans,
+            completedSessions: completedSessions,
+            savedExerciseIDs: savedExerciseIDs,
+            preferences: preferences,
+            customActivities: customActivities,
+            userExercises: userExercises
+        )
+    }
+
+    private func apply(_ state: PersistedState) {
         dayPlans = state.dayPlans
         completedSessions = state.completedSessions
         savedExerciseIDs = state.savedExerciseIDs
         customActivities = state.customActivities ?? []
         userExercises = state.userExercises ?? []
         preferences = state.preferences
-        preferences.sanitize()
     }
 
     private var liftSummaryHistoryToken: Int {
@@ -769,31 +800,35 @@ final class StrengthWorkoutStore {
     }
 
     private func resetInMemoryState() {
-        dayPlans = [:]
-        completedSessions = []
-        savedExerciseIDs = []
-        customActivities = []
-        userExercises = []
-        preferences = StrengthWorkoutPreferences()
+        apply(PersistedState())
     }
 
     static let persistenceBlockedMessage =
         "Your saved workout history is being protected and can't be changed right now. Update Fud AI to the latest version or restart the app and try again."
 
+    /// Applies `mutate` to memory and persists the result as one unit.
+    ///
+    /// The guard re-reads the on-disk blob at write time, so a save can still
+    /// be refused after the up-front `isPersistenceBlocked` check passed (for
+    /// example when another process replaced the blob with bytes that cannot
+    /// be decoded and the backup copy failed). In that case every in-memory
+    /// change is rolled back, so the UI never shows an edit that would vanish
+    /// on the next launch. Returns `false` when nothing was changed.
+    @discardableResult
+    private func commit(_ mutate: () -> Void) -> Bool {
+        guard !isPersistenceBlocked else { return false }
+        let snapshot = currentState
+        mutate()
+        if save() { return true }
+        apply(snapshot)
+        return false
+    }
+
     /// Returns `false` when the guard refused the write (a newer-schema blob is
     /// on disk, or a corrupt one still has no backup copy).
-    @discardableResult
     private func save() -> Bool {
         guard !hasUnsupportedPersistedState else { return false }
-        let state = PersistedState(
-            dayPlans: dayPlans,
-            completedSessions: completedSessions,
-            savedExerciseIDs: savedExerciseIDs,
-            preferences: preferences,
-            customActivities: customActivities,
-            userExercises: userExercises
-        )
-        return stateBlob.save(state)
+        return stateBlob.save(currentState)
     }
 
     private static func decimalText(_ value: String) -> String {

--- a/ios/calorietracker/Stores/StrengthWorkoutStore.swift
+++ b/ios/calorietracker/Stores/StrengthWorkoutStore.swift
@@ -75,9 +75,17 @@ final class StrengthWorkoutStore {
     private var liftSummaryCacheKey: String?
     private var liftSummaryCache: [String: String] = [:]
 
-    /// True while an unreadable state blob is on disk without a backup copy;
-    /// `save()` is refused in that state so it cannot be overwritten.
-    var isPersistenceBlocked: Bool { stateBlob.isWriteBlocked }
+    /// Set when the persisted state was written by a build with a newer
+    /// schema. Unlike a corrupt blob (which is safe to replace once backed up)
+    /// this is the user's live data, so writes stay blocked for as long as it
+    /// is on disk — a backup copy does not make overwriting it acceptable.
+    private var hasUnsupportedPersistedState = false
+
+    /// True while the on-disk state must not be overwritten: either an
+    /// unreadable blob has no backup copy yet, or the blob was written by a
+    /// newer schema. Every mutation is refused up front in this state so
+    /// edits cannot appear to succeed and then vanish on the next launch.
+    var isPersistenceBlocked: Bool { stateBlob.isWriteBlocked || hasUnsupportedPersistedState }
 
     init(
         defaults: UserDefaults = .standard,
@@ -130,6 +138,7 @@ final class StrengthWorkoutStore {
 
     /// Append the reviewed batch; stable draft IDs make retries idempotent.
     func addTextWorkout(_ draft: WorkoutTextDraft, library: [ExerciseLibraryItem]) throws {
+        guard !isPersistenceBlocked else { throw WorkoutTextError.invalid(Self.persistenceBlockedMessage) }
         let additions = try draft.planned(library: library)
         guard let date = Self.date(for: draft.date) else { throw WorkoutTextError.invalid("Choose a valid date.") }
         let known = Set(customActivities.map(\.itemID))
@@ -159,6 +168,7 @@ final class StrengthWorkoutStore {
 
     @discardableResult
     func saveUserExercise(_ draft: UserExerciseDraft, existingItemID: String? = nil) -> ExerciseLibraryItem? {
+        guard !isPersistenceBlocked else { return nil }
         let trimmedName = draft.trimmedName
         guard !trimmedName.isEmpty else { return nil }
 
@@ -187,7 +197,7 @@ final class StrengthWorkoutStore {
         } else {
             userExercises.append(template)
         }
-        save()
+        guard save() else { return nil }
         orphanCandidates
             .filter { !referencesUserExerciseImage($0) }
             .forEach { FoodImageStore.shared.delete(filename: $0) }
@@ -195,11 +205,11 @@ final class StrengthWorkoutStore {
     }
 
     func deleteUserExercise(itemID: String) {
-        guard UserExercise.isUserExercise(itemID) else { return }
+        guard !isPersistenceBlocked, UserExercise.isUserExercise(itemID) else { return }
         let orphanCandidates = userExercises.first(where: { $0.itemID == itemID })?.imagePaths ?? []
         userExercises.removeAll { $0.itemID == itemID }
         savedExerciseIDs.remove(itemID)
-        save()
+        guard save() else { return }
         orphanCandidates
             .filter { !referencesUserExerciseImage($0) }
             .forEach { FoodImageStore.shared.delete(filename: $0) }
@@ -231,10 +241,11 @@ final class StrengthWorkoutStore {
     }
 
     func removeExercise(_ exerciseID: UUID, on date: Date) {
+        guard !isPersistenceBlocked else { return }
         let removedPaths = exercises(for: date).first(where: { $0.id == exerciseID })?.imagePaths ?? []
-        updatePlan(for: date) { plan in
+        guard updatePlan(for: date, mutate: { plan in
             plan.exercises.removeAll { $0.id == exerciseID }
-        }
+        }) else { return }
         removedPaths
             .filter { !referencesUserExerciseImage($0) }
             .forEach { FoodImageStore.shared.delete(filename: $0) }
@@ -281,6 +292,7 @@ final class StrengthWorkoutStore {
     }
 
     func toggleSaved(_ itemID: String) {
+        guard !isPersistenceBlocked else { return }
         if savedExerciseIDs.contains(itemID) {
             savedExerciseIDs.remove(itemID)
         } else {
@@ -395,6 +407,7 @@ final class StrengthWorkoutStore {
         elapsedSeconds: Int,
         weightUnit: WeightUnit
     ) -> StrengthWorkoutSession? {
+        guard !isPersistenceBlocked else { return nil }
         let planned = exercises(for: date)
         guard !planned.isEmpty else { return nil }
 
@@ -408,7 +421,7 @@ final class StrengthWorkoutStore {
             exercises: logs
         )
         completedSessions.append(session)
-        save()
+        guard save() else { return nil }
         return session
     }
 
@@ -422,6 +435,7 @@ final class StrengthWorkoutStore {
         weightUnit: WeightUnit,
         calculatedAt: Date = .now
     ) -> StrengthWorkoutSession? {
+        guard !isPersistenceBlocked else { return nil }
         let planned = exercises(for: date)
         let logs = completedExerciseLogs(from: planned, weightUnit: weightUnit)
         guard planned.contains(where: {
@@ -452,7 +466,9 @@ final class StrengthWorkoutStore {
             $0.stableDiaryDateKey == key && $0.caloriesBurned != nil
         }
         completedSessions.append(session)
-        save()
+        // Health only hears about the burn once it is durably stored, so a
+        // refused save cannot leave a sample with no diary record behind it.
+        guard save() else { return nil }
         for duplicate in existingBurns.dropFirst() where duplicate.id != session.id {
             onWorkoutBurnDeleted?(duplicate.id)
         }
@@ -484,11 +500,12 @@ final class StrengthWorkoutStore {
     }
 
     func deleteSession(_ id: UUID) {
+        guard !isPersistenceBlocked else { return }
         let deletedBurnID = completedSessions.first {
             $0.id == id && $0.caloriesBurned != nil
         }?.id
         completedSessions.removeAll { $0.id == id }
-        save()
+        guard save() else { return }
         if let deletedBurnID { onWorkoutBurnDeleted?(deletedBurnID) }
     }
 
@@ -496,7 +513,7 @@ final class StrengthWorkoutStore {
     /// This merge never fires write callbacks, so imported samples are not
     /// echoed back to Apple Health.
     func importWorkoutBurnSessions(_ imported: [StrengthWorkoutSession]) {
-        guard !imported.isEmpty else { return }
+        guard !isPersistenceBlocked, !imported.isEmpty else { return }
         var changed = false
 
         for session in imported where session.caloriesBurned != nil {
@@ -555,22 +572,26 @@ final class StrengthWorkoutStore {
     }
 
     func updatePreferences(_ mutate: (inout StrengthWorkoutPreferences) -> Void) {
+        guard !isPersistenceBlocked else { return }
         mutate(&preferences)
         preferences.sanitize()
         save()
     }
 
+    /// Re-reads the persisted state (e.g. after a cloud restore). Memory is
+    /// only replaced by what was actually read: a missing key empties the
+    /// store, a decoded blob replaces it, and a corrupt or newer-schema blob
+    /// leaves the current in-memory diary untouched.
     func reloadFromDefaults() {
-        dayPlans = [:]
-        completedSessions = []
-        savedExerciseIDs = []
-        customActivities = []
-        userExercises = []
-        preferences = StrengthWorkoutPreferences()
         load()
     }
 
+    /// Explicit user action: wipes the diary. The persisted blob is removed
+    /// first so that, if the guard refuses (a corrupt blob still has no
+    /// backup), neither memory nor the exercise photos are touched.
     func clearAll() {
+        guard stateBlob.remove() else { return }
+        hasUnsupportedPersistedState = false
         dayPlans = [:]
         completedSessions = []
         savedExerciseIDs = []
@@ -580,10 +601,12 @@ final class StrengthWorkoutStore {
         }
         userExercises = []
         preferences = StrengthWorkoutPreferences()
-        stateBlob.remove()
     }
 
-    private func updatePlan(for date: Date, mutate: (inout StrengthWorkoutDayPlan) -> Void) {
+    /// Returns `false` (leaving memory untouched) when persistence is blocked.
+    @discardableResult
+    private func updatePlan(for date: Date, mutate: (inout StrengthWorkoutDayPlan) -> Void) -> Bool {
+        guard !isPersistenceBlocked else { return false }
         let key = Self.dateKey(for: date)
         var plan = dayPlans[key] ?? StrengthWorkoutDayPlan(dateKey: key)
         let previousTimerInputs = savedTimerBurnInputs(in: plan)
@@ -608,8 +631,9 @@ final class StrengthWorkoutStore {
         } else {
             invalidatedBurnIDs = []
         }
-        save()
+        guard save() else { return false }
         for id in invalidatedBurnIDs { onWorkoutBurnDeleted?(id) }
+        return true
     }
 
     private struct SavedTimerBurnInput: Equatable {
@@ -701,19 +725,28 @@ final class StrengthWorkoutStore {
     private func load() {
         let state: PersistedState
         switch stateBlob.loadValue(PersistedState.self) {
-        case .missing, .corrupt:
-            // Corrupt blobs are backed up by the guard and protected from
-            // being overwritten until that copy exists.
+        case .missing:
+            hasUnsupportedPersistedState = false
+            resetInMemoryState()
+            return
+        case .corrupt:
+            // Backed up by the guard (or write-blocked until it is). Keep
+            // whatever is in memory: it is either the fresh defaults on first
+            // load or the last good state during a reload.
             return
         case .decoded(let decoded, _):
             state = decoded
         }
         guard state.version == 1 else {
-            // Written by a build with a newer schema — preserve it rather than
-            // clobbering it with a downgraded empty state on the next save.
+            // Written by a build with a newer schema. Copy it aside for good
+            // measure, but the real protection is the persistent write block:
+            // this build must never save its own (older, here empty) state
+            // over data the user created in a newer one.
+            hasUnsupportedPersistedState = true
             stateBlob.quarantineCurrentBlob(reason: "unsupported workout state version \(state.version)")
             return
         }
+        hasUnsupportedPersistedState = false
         dayPlans = state.dayPlans
         completedSessions = state.completedSessions
         savedExerciseIDs = state.savedExerciseIDs
@@ -735,7 +768,23 @@ final class StrengthWorkoutStore {
         }
     }
 
-    private func save() {
+    private func resetInMemoryState() {
+        dayPlans = [:]
+        completedSessions = []
+        savedExerciseIDs = []
+        customActivities = []
+        userExercises = []
+        preferences = StrengthWorkoutPreferences()
+    }
+
+    static let persistenceBlockedMessage =
+        "Your saved workout history is being protected and can't be changed right now. Update Fud AI to the latest version or restart the app and try again."
+
+    /// Returns `false` when the guard refused the write (a newer-schema blob is
+    /// on disk, or a corrupt one still has no backup copy).
+    @discardableResult
+    private func save() -> Bool {
+        guard !hasUnsupportedPersistedState else { return false }
         let state = PersistedState(
             dayPlans: dayPlans,
             completedSessions: completedSessions,
@@ -744,7 +793,7 @@ final class StrengthWorkoutStore {
             customActivities: customActivities,
             userExercises: userExercises
         )
-        stateBlob.save(state)
+        return stateBlob.save(state)
     }
 
     private static func decimalText(_ value: String) -> String {

--- a/ios/calorietracker/Stores/WaterStore.swift
+++ b/ios/calorietracker/Stores/WaterStore.swift
@@ -64,13 +64,29 @@ struct WaterEntry: Codable, Identifiable, Equatable {
 final class WaterStore {
     private(set) var entries: [WaterEntry] = []
     var onEntriesChanged: (() -> Void)?
-    private let defaults: UserDefaults
+    private let entriesBlob: PersistedBlobGuard
 
-    init(defaults: UserDefaults = .standard) {
-        self.defaults = defaults
-        guard let data = defaults.data(forKey: WaterSettings.entriesKey),
-              let decoded = try? JSONDecoder().decode([WaterEntry].self, from: data) else { return }
-        entries = decoded
+    /// True while an unreadable blob is on disk without a backup copy.
+    var isPersistenceBlocked: Bool { entriesBlob.isWriteBlocked }
+
+    init(defaults: UserDefaults = .standard, corruptBackupDirectory: URL? = nil) {
+        self.entriesBlob = PersistedBlobGuard(
+            defaults: defaults,
+            key: WaterSettings.entriesKey,
+            backupDirectory: corruptBackupDirectory
+        )
+        load(isInitialLoad: true)
+    }
+
+    private func load(isInitialLoad: Bool) {
+        switch entriesBlob.loadList(WaterEntry.self) {
+        case .missing:
+            entries = []
+        case .decoded(let decoded, _):
+            entries = decoded
+        case .corrupt:
+            if isInitialLoad { entries = [] }
+        }
     }
 
     @discardableResult
@@ -83,6 +99,7 @@ final class WaterStore {
     @discardableResult
     func add(id: UUID, milliliters: Int, on date: Date) -> WaterEntry? {
         guard milliliters > 0 else { return nil }
+        guard !isPersistenceBlocked else { return nil }
         if let existing = entries.first(where: { $0.id == id }) { return existing }
         let entry = WaterEntry(id: id, date: date, milliliters: milliliters)
         entries.append(entry)
@@ -92,31 +109,27 @@ final class WaterStore {
     }
 
     func delete(id: UUID) {
+        guard !isPersistenceBlocked else { return }
         entries.removeAll { $0.id == id }
         save()
         onEntriesChanged?()
     }
 
     func reloadFromDefaults() {
-        guard let data = defaults.data(forKey: WaterSettings.entriesKey),
-              let decoded = try? JSONDecoder().decode([WaterEntry].self, from: data) else {
-            entries = []
-            onEntriesChanged?()
-            return
-        }
-        entries = decoded
+        load(isInitialLoad: false)
         onEntriesChanged?()
     }
 
     func replaceEntriesFromImport(_ imported: [WaterEntry]) {
+        guard !isPersistenceBlocked else { return }
         entries = imported
         save()
         onEntriesChanged?()
     }
 
     func clear() {
+        guard entriesBlob.remove() else { return }
         entries = []
-        defaults.removeObject(forKey: WaterSettings.entriesKey)
         onEntriesChanged?()
     }
 
@@ -132,7 +145,6 @@ final class WaterStore {
     }
 
     private func save() {
-        guard let data = try? JSONEncoder().encode(entries) else { return }
-        defaults.set(data, forKey: WaterSettings.entriesKey)
+        entriesBlob.save(entries)
     }
 }

--- a/ios/calorietracker/Stores/WeightStore.swift
+++ b/ios/calorietracker/Stores/WeightStore.swift
@@ -7,14 +7,25 @@ class WeightStore {
     var onEntryAdded: ((WeightEntry) -> Void)?
     var onEntryDeleted: ((UUID) -> Void)?
 
-    private let storageKey = "weightEntries"
+    static let storageKey = "weightEntries"
     private let observesExternalChanges: Bool
+    private let entriesBlob: PersistedBlobGuard
+
+    /// True while an unreadable weight blob is on disk without a backup copy;
+    /// mutations are refused so they cannot overwrite the user's history.
+    var isPersistenceBlocked: Bool { entriesBlob.isWriteBlocked }
+    var corruptBlobBackups: [PersistedBlobGuard.CorruptBackup] { entriesBlob.backups }
 
     static let externalChangeNotification = "ai.fud.weightEntriesDidChange"
 
-    init(observesExternalChanges: Bool = true) {
+    init(
+        observesExternalChanges: Bool = true,
+        defaults: UserDefaults = .standard,
+        corruptBackupDirectory: URL? = nil
+    ) {
         self.observesExternalChanges = observesExternalChanges
-        loadEntries()
+        self.entriesBlob = PersistedBlobGuard(defaults: defaults, key: Self.storageKey, backupDirectory: corruptBackupDirectory)
+        loadEntries(isInitialLoad: true)
         if observesExternalChanges {
             startObservingExternalChanges()
         }
@@ -54,6 +65,7 @@ class WeightStore {
     }
 
     func addEntry(_ entry: WeightEntry) {
+        guard !isPersistenceBlocked else { return }
         let previousLatest = entries.sorted { $0.date > $1.date }.first
         entries.append(entry)
         saveEntries()
@@ -76,6 +88,7 @@ class WeightStore {
     }
 
     func deleteEntry(_ entry: WeightEntry) {
+        guard !isPersistenceBlocked else { return }
         let id = entry.id
         entries.removeAll { $0.id == id }
         saveEntries()
@@ -96,10 +109,11 @@ class WeightStore {
     }
 
     func reloadFromDefaults() {
-        loadEntries()
+        loadEntries(isInitialLoad: false)
     }
 
     func replaceAllEntries(_ newEntries: [WeightEntry]) {
+        guard !isPersistenceBlocked else { return }
         entries = newEntries
         saveEntries()
     }
@@ -108,36 +122,52 @@ class WeightStore {
     /// scale history that predate Fud AI). Bypasses onEntryAdded so the
     /// imported externals don't echo back to HK as fresh writes — these
     /// samples already exist there. Saves + syncs profile once at the end.
+    /// Samples whose id is already in the store (a restore that raced a
+    /// live observer write, or the same batch delivered twice) are skipped so
+    /// the list never accumulates duplicate ids.
     func importExternalEntries(_ external: [WeightEntry]) {
-        guard !external.isEmpty else { return }
-        entries.append(contentsOf: external)
+        guard !isPersistenceBlocked else { return }
+        var seen = Set(entries.map(\.id))
+        let fresh = external.filter { seen.insert($0.id).inserted }
+        guard !fresh.isEmpty else { return }
+        entries.append(contentsOf: fresh)
         saveEntries()
         syncProfileWeightToLatest()
     }
 
+    /// Upserts by id; duplicate ids resolve newest-wins instead of trapping.
     func mergeWithCloudEntries(_ cloudEntries: [WeightEntry]) {
-        var merged = Dictionary(uniqueKeysWithValues: entries.map { ($0.id, $0) })
-        for cloudEntry in cloudEntries {
-            merged[cloudEntry.id] = cloudEntry
-        }
-        entries = Array(merged.values)
+        guard !isPersistenceBlocked else { return }
+        entries = Self.mergingByID(entries, with: cloudEntries)
         saveEntries()
     }
 
-    private func saveEntries() {
-        if let data = try? JSONEncoder().encode(entries) {
-            UserDefaults.standard.set(data, forKey: storageKey)
+    static func mergingByID(_ existing: [WeightEntry], with incoming: [WeightEntry]) -> [WeightEntry] {
+        var order: [UUID] = []
+        var byID: [UUID: WeightEntry] = [:]
+        for entry in existing + incoming {
+            if byID.updateValue(entry, forKey: entry.id) == nil {
+                order.append(entry.id)
+            }
         }
+        return order.compactMap { byID[$0] }
     }
 
-    private func loadEntries() {
-        guard let data = UserDefaults.standard.data(forKey: storageKey),
-              let decoded = try? JSONDecoder().decode([WeightEntry].self, from: data)
-        else {
+    private func saveEntries() {
+        entriesBlob.save(entries)
+    }
+
+    private func loadEntries(isInitialLoad: Bool) {
+        switch entriesBlob.loadList(WeightEntry.self) {
+        case .missing:
             entries = []
-            return
+        case .decoded(let decoded, _):
+            entries = decoded
+        case .corrupt:
+            // Backed up (or write-blocked until it is). Keep the in-memory
+            // copy on reloads instead of presenting an empty history.
+            if isInitialLoad { entries = [] }
         }
-        entries = decoded
     }
 
     private func startObservingExternalChanges() {
@@ -158,7 +188,7 @@ class WeightStore {
     }
 
     private func reloadFromExternalChange() {
-        loadEntries()
+        loadEntries(isInitialLoad: false)
         syncProfileWeightToLatest()
     }
 

--- a/ios/calorietrackerTests/DiaryPersistenceSafetyTests.swift
+++ b/ios/calorietrackerTests/DiaryPersistenceSafetyTests.swift
@@ -80,6 +80,128 @@ struct DiaryPersistenceSafetyTests {
         }
     }
 
+    @Test func blobReplacedExternallyWithGarbageIsBackedUpBeforeSave() throws {
+        try withDefaults { defaults, backupDir in
+            let blob = PersistedBlobGuard(defaults: defaults, key: "k", backupDirectory: backupDir)
+            #expect(blob.save([WaterEntry(milliliters: 100)]))
+            guard case .decoded = blob.loadList(WaterEntry.self) else {
+                Issue.record("expected .decoded")
+                return
+            }
+            // Another process (widget, restore) replaces the key behind the guard's back.
+            let garbage = Data("{not water".utf8)
+            defaults.set(garbage, forKey: "k")
+
+            #expect(blob.save([WaterEntry(milliliters: 250)]))
+            let backup = try #require(blob.backups.first)
+            #expect(try Data(contentsOf: backup.url) == garbage)
+        }
+    }
+
+    @Test func blobReplacedExternallyWithGarbageBlocksSaveWhenBackupFails() throws {
+        try withDefaults { defaults, _ in
+            let unwritable = URL(fileURLWithPath: "/dev/null/cannot-create")
+            let blob = PersistedBlobGuard(defaults: defaults, key: "k", backupDirectory: unwritable)
+            #expect(blob.save([WaterEntry(milliliters: 100)]))
+            guard case .decoded = blob.loadList(WaterEntry.self) else {
+                Issue.record("expected .decoded")
+                return
+            }
+            #expect(!blob.isWriteBlocked)
+            let garbage = Data("{not water".utf8)
+            defaults.set(garbage, forKey: "k")
+
+            #expect(!blob.save([WaterEntry(milliliters: 250)]))
+            #expect(!blob.remove())
+            #expect(blob.isWriteBlocked)
+            #expect(defaults.data(forKey: "k") == garbage)
+        }
+    }
+
+    @Test func blobReplacedExternallyWithValidDataDoesNotSpawnBackups() throws {
+        try withDefaults { defaults, backupDir in
+            let blob = PersistedBlobGuard(defaults: defaults, key: "k", backupDirectory: backupDir)
+            _ = blob.loadList(WaterEntry.self)
+            defaults.set(try JSONEncoder().encode([WaterEntry(milliliters: 100)]), forKey: "k")
+
+            #expect(blob.save([WaterEntry(milliliters: 250)]))
+            #expect(blob.backups.isEmpty)
+        }
+    }
+
+    // MARK: - FastingStore
+
+    @Test func persistedActiveSessionSurvivesOneUnreadableRow() throws {
+        try withDefaults { defaults, _ in
+            let active = FastingSession(startedAt: Date(timeIntervalSince1970: 1_800_000_000), goalMinutes: 960)
+            let activeJSON = try String(decoding: JSONEncoder().encode(active), as: UTF8.self)
+            defaults.set(Data("[{\"id\": 1}, \(activeJSON)]".utf8), forKey: FastingSettings.sessionsKey)
+
+            #expect(FastingStore.persistedActiveSession(defaults: defaults)?.id == active.id)
+        }
+    }
+
+    // MARK: - StrengthWorkoutStore
+
+    @Test func workoutMutationsAreRefusedWhileCorruptStateHasNoBackup() throws {
+        try withDefaults { defaults, _ in
+            let key = "workouts"
+            let garbage = Data("{broken".utf8)
+            defaults.set(garbage, forKey: key)
+            let unwritable = URL(fileURLWithPath: "/dev/null/cannot-create")
+            let store = StrengthWorkoutStore(defaults: defaults, storageKey: key, corruptBackupDirectory: unwritable)
+            let date = Date(timeIntervalSince1970: 1_800_000_000)
+
+            #expect(store.isPersistenceBlocked)
+            store.toggleExercise(makeExercise(), on: date)
+            store.toggleSaved("bench")
+            store.updatePreferences { $0.frequencyDays = 6 }
+            #expect(store.completeWorkout(on: date, startedAt: date, elapsedSeconds: 60, weightUnit: .kg) == nil)
+            store.clearAll()
+
+            #expect(store.dayPlans.isEmpty)
+            #expect(store.savedExerciseIDs.isEmpty)
+            #expect(store.preferences == StrengthWorkoutPreferences())
+            #expect(defaults.data(forKey: key) == garbage)
+        }
+    }
+
+    @Test func reloadingCorruptWorkoutStateKeepsTheInMemoryDiary() throws {
+        try withDefaults { defaults, backupDir in
+            let key = "workouts"
+            let store = StrengthWorkoutStore(defaults: defaults, storageKey: key, corruptBackupDirectory: backupDir)
+            let date = Date(timeIntervalSince1970: 1_800_000_000)
+            store.toggleExercise(makeExercise(), on: date)
+            #expect(store.workoutCount(for: date) == 1)
+
+            defaults.set(Data("garbage".utf8), forKey: key)
+            store.reloadFromDefaults()
+
+            #expect(store.workoutCount(for: date) == 1)
+            #expect(!store.isPersistenceBlocked)
+        }
+    }
+
+    @Test func newerWorkoutSchemaStaysWriteBlockedAfterBackup() throws {
+        try withDefaults { defaults, backupDir in
+            let key = "workouts"
+            var newerState = StrengthWorkoutStore.PersistedState()
+            newerState.version = 2
+            let newer = try JSONEncoder().encode(newerState)
+            defaults.set(newer, forKey: key)
+            let store = StrengthWorkoutStore(defaults: defaults, storageKey: key, corruptBackupDirectory: backupDir)
+            let date = Date(timeIntervalSince1970: 1_800_000_000)
+
+            // The backup exists, yet this build must still never overwrite the newer state.
+            #expect(store.isPersistenceBlocked)
+            store.toggleExercise(makeExercise(), on: date)
+            store.toggleSaved("bench")
+            #expect(store.dayPlans.isEmpty)
+            #expect(store.savedExerciseIDs.isEmpty)
+            #expect(defaults.data(forKey: key) == newer)
+        }
+    }
+
     // MARK: - FoodStore
 
     @Test func corruptFoodBlobIsPreservedAndAddIsRefusedUntilBackedUp() throws {
@@ -215,6 +337,21 @@ struct DiaryPersistenceSafetyTests {
     }
 
     // MARK: - Helpers
+
+    private func makeExercise() -> ExerciseLibraryItem {
+        ExerciseLibraryItem(
+            id: "bench",
+            name: "Bench Press",
+            rawLevel: "intermediate",
+            force: "push",
+            mechanic: "compound",
+            category: "strength",
+            rawEquipment: "barbell",
+            primaryMuscles: ["chest"],
+            secondaryMuscles: ["triceps"],
+            instructions: ["Control the repetition."]
+        )
+    }
 
     private func makeMeal() -> FoodEntry {
         FoodEntry(

--- a/ios/calorietrackerTests/DiaryPersistenceSafetyTests.swift
+++ b/ios/calorietrackerTests/DiaryPersistenceSafetyTests.swift
@@ -118,6 +118,33 @@ struct DiaryPersistenceSafetyTests {
         }
     }
 
+    @Test func firstWriteWithoutLoadBacksUpWhateverIsAlreadyStored() throws {
+        try withDefaults { defaults, backupDir in
+            let garbage = Data("{never decoded".utf8)
+            defaults.set(garbage, forKey: "k")
+            // No load: the guard has no decoder and has never seen the key.
+            let blob = PersistedBlobGuard(defaults: defaults, key: "k", backupDirectory: backupDir)
+
+            #expect(blob.save([WaterEntry(milliliters: 250)]))
+            let backup = try #require(blob.backups.first)
+            #expect(try Data(contentsOf: backup.url) == garbage)
+        }
+    }
+
+    @Test func firstWriteWithoutLoadIsRefusedWhenExistingBlobCannotBeBackedUp() throws {
+        try withDefaults { defaults, _ in
+            let garbage = Data("{never decoded".utf8)
+            defaults.set(garbage, forKey: "k")
+            let unwritable = URL(fileURLWithPath: "/dev/null/cannot-create")
+            let blob = PersistedBlobGuard(defaults: defaults, key: "k", backupDirectory: unwritable)
+
+            #expect(!blob.save([WaterEntry(milliliters: 250)]))
+            #expect(!blob.remove())
+            #expect(blob.isWriteBlocked)
+            #expect(defaults.data(forKey: "k") == garbage)
+        }
+    }
+
     @Test func blobReplacedExternallyWithValidDataDoesNotSpawnBackups() throws {
         try withDefaults { defaults, backupDir in
             let blob = PersistedBlobGuard(defaults: defaults, key: "k", backupDirectory: backupDir)
@@ -162,6 +189,38 @@ struct DiaryPersistenceSafetyTests {
             #expect(store.dayPlans.isEmpty)
             #expect(store.savedExerciseIDs.isEmpty)
             #expect(store.preferences == StrengthWorkoutPreferences())
+            #expect(defaults.data(forKey: key) == garbage)
+        }
+    }
+
+    @Test func workoutMutationsRollBackWhenBlobTurnsCorruptBehindTheStore() throws {
+        try withDefaults { defaults, _ in
+            let key = "workouts"
+            let unwritable = URL(fileURLWithPath: "/dev/null/cannot-create")
+            let store = StrengthWorkoutStore(defaults: defaults, storageKey: key, corruptBackupDirectory: unwritable)
+            let date = Date(timeIntervalSince1970: 1_800_000_000)
+            store.toggleExercise(makeExercise(), on: date)
+            store.toggleSaved("bench")
+            #expect(store.workoutCount(for: date) == 1)
+            #expect(!store.isPersistenceBlocked)
+
+            // Another writer replaces the blob after the store's last look.
+            // The up-front check still passes; only the write-time re-read
+            // discovers the corrupt bytes, and their backup fails.
+            let garbage = Data("{broken".utf8)
+            defaults.set(garbage, forKey: key)
+
+            store.toggleExercise(makeExercise(), on: date)
+            store.toggleSaved("bench")
+            store.updatePreferences { $0.frequencyDays = 6 }
+            #expect(store.completeWorkout(on: date, startedAt: date, elapsedSeconds: 60, weightUnit: .kg) == nil)
+
+            // Every refused edit was rolled back: memory still shows the last persisted state.
+            #expect(store.workoutCount(for: date) == 1)
+            #expect(store.savedExerciseIDs == ["bench"])
+            #expect(store.preferences == StrengthWorkoutPreferences())
+            #expect(store.completedSessions.isEmpty)
+            #expect(store.isPersistenceBlocked)
             #expect(defaults.data(forKey: key) == garbage)
         }
     }

--- a/ios/calorietrackerTests/DiaryPersistenceSafetyTests.swift
+++ b/ios/calorietrackerTests/DiaryPersistenceSafetyTests.swift
@@ -1,0 +1,238 @@
+import Foundation
+import Testing
+@testable import calorietracker
+
+/// Guards against the "decode failure silently wipes the diary" bug class and
+/// the duplicate-id trap in `Dictionary(uniqueKeysWithValues:)`.
+@MainActor
+struct DiaryPersistenceSafetyTests {
+    // MARK: - PersistedBlobGuard
+
+    @Test func missingKeyIsReportedAsMissingNotCorrupt() throws {
+        try withDefaults { defaults, backupDir in
+            let blob = PersistedBlobGuard(defaults: defaults, key: "k", backupDirectory: backupDir)
+            guard case .missing = blob.loadList(WaterEntry.self) else {
+                Issue.record("expected .missing")
+                return
+            }
+            #expect(!blob.isWriteBlocked)
+            #expect(blob.backups.isEmpty)
+        }
+    }
+
+    @Test func corruptBlobIsBackedUpAndNotTreatedAsEmpty() throws {
+        try withDefaults { defaults, backupDir in
+            let garbage = Data("{definitely not json".utf8)
+            defaults.set(garbage, forKey: "k")
+            let blob = PersistedBlobGuard(defaults: defaults, key: "k", backupDirectory: backupDir)
+
+            guard case .corrupt = blob.loadList(WaterEntry.self) else {
+                Issue.record("expected .corrupt")
+                return
+            }
+            let backup = try #require(blob.backups.first)
+            #expect(backup.url.lastPathComponent.hasPrefix("k.corrupt-"))
+            let preserved = try Data(contentsOf: backup.url)
+            #expect(preserved == garbage)
+            // Backup exists, so a save is no longer destructive and is allowed.
+            #expect(!blob.isWriteBlocked)
+            #expect(blob.save([WaterEntry(milliliters: 250)]))
+        }
+    }
+
+    @Test func writesAreRefusedWhileCorruptBlobHasNoBackup() throws {
+        try withDefaults { defaults, _ in
+            let garbage = Data("nope".utf8)
+            defaults.set(garbage, forKey: "k")
+            // A file path is not a directory: backup creation must fail.
+            let unwritable = URL(fileURLWithPath: "/dev/null/cannot-create")
+            let blob = PersistedBlobGuard(defaults: defaults, key: "k", backupDirectory: unwritable)
+
+            guard case .corrupt = blob.loadList(WaterEntry.self) else {
+                Issue.record("expected .corrupt")
+                return
+            }
+            #expect(blob.isWriteBlocked)
+            #expect(!blob.save([WaterEntry(milliliters: 250)]))
+            #expect(!blob.remove())
+            #expect(defaults.data(forKey: "k") == garbage)
+        }
+    }
+
+    @Test func oneBadRowIsDroppedInsteadOfTheWholeList() throws {
+        try withDefaults { defaults, backupDir in
+            let good = WaterEntry(id: UUID(), date: Date(timeIntervalSince1970: 1_800_000_000), milliliters: 300)
+            let goodJSON = try String(decoding: JSONEncoder().encode(good), as: UTF8.self)
+            let mixed = Data("[\(goodJSON), {\"id\": 42}, \(goodJSON)]".utf8)
+            defaults.set(mixed, forKey: "k")
+            let blob = PersistedBlobGuard(defaults: defaults, key: "k", backupDirectory: backupDir)
+
+            guard case .decoded(let entries, let dropped) = blob.loadList(WaterEntry.self) else {
+                Issue.record("expected partial decode")
+                return
+            }
+            #expect(entries == [good, good])
+            #expect(dropped == 1)
+            // The raw blob is preserved so the dropped row is still recoverable.
+            let backup = try #require(blob.backups.first)
+            let preserved = try Data(contentsOf: backup.url)
+            #expect(preserved == mixed)
+        }
+    }
+
+    // MARK: - FoodStore
+
+    @Test func corruptFoodBlobIsPreservedAndAddIsRefusedUntilBackedUp() throws {
+        try withDefaults { defaults, _ in
+            let garbage = Data("[{\"id\": \"broken\"".utf8)
+            defaults.set(garbage, forKey: FoodStore.storageKey)
+            let unwritable = URL(fileURLWithPath: "/dev/null/cannot-create")
+            let store = FoodStore(observesExternalChanges: false, defaults: defaults, corruptBackupDirectory: unwritable)
+
+            #expect(store.entries.isEmpty)
+            #expect(store.isPersistenceBlocked)
+            #expect(!store.addEntry(makeMeal()))
+            store.replaceAllEntries([])
+            #expect(defaults.data(forKey: FoodStore.storageKey) == garbage)
+        }
+    }
+
+    @Test func corruptFoodBlobIsBackedUpThenStoreBecomesWritable() throws {
+        try withDefaults { defaults, backupDir in
+            let garbage = Data("[{\"id\": \"broken\"".utf8)
+            defaults.set(garbage, forKey: FoodStore.storageKey)
+            let store = FoodStore(observesExternalChanges: false, defaults: defaults, corruptBackupDirectory: backupDir)
+
+            #expect(!store.isPersistenceBlocked)
+            let backup = try #require(store.corruptBlobBackups.first)
+            let preserved = try Data(contentsOf: backup.url)
+            #expect(preserved == garbage)
+            #expect(store.addEntry(makeMeal()))
+            #expect(store.entries.count == 1)
+        }
+    }
+
+    @Test func partiallyReadableFoodBlobKeepsGoodRows() throws {
+        try withDefaults { defaults, backupDir in
+            let meal = makeMeal()
+            let mealJSON = try String(decoding: JSONEncoder().encode(meal), as: UTF8.self)
+            defaults.set(Data("[\(mealJSON), {\"name\": \"no id\"}]".utf8), forKey: FoodStore.storageKey)
+            let store = FoodStore(observesExternalChanges: false, defaults: defaults, corruptBackupDirectory: backupDir)
+
+            #expect(store.entries.map(\.id) == [meal.id])
+            #expect(store.droppedEntriesOnLoad == 1)
+            #expect(store.corruptBlobBackups.count == 1)
+        }
+    }
+
+    @Test func reloadingACorruptBlobKeepsTheInMemoryDiary() throws {
+        try withDefaults { defaults, backupDir in
+            let store = FoodStore(observesExternalChanges: false, defaults: defaults, corruptBackupDirectory: backupDir)
+            #expect(store.addEntry(makeMeal()))
+            defaults.set(Data("garbage".utf8), forKey: FoodStore.storageKey)
+
+            store.reloadFromDefaults()
+            #expect(store.entries.count == 1)
+        }
+    }
+
+    @Test func mergingDuplicateFoodIDsDoesNotTrapAndNewestWins() throws {
+        try withDefaults { defaults, backupDir in
+            let id = UUID()
+            let older = FoodEntry(id: id, name: "Old", calories: 100, protein: 1, carbs: 1, fat: 1, source: .manual)
+            let newer = FoodEntry(id: id, name: "New", calories: 200, protein: 2, carbs: 2, fat: 2, source: .manual)
+            // Simulate a diary that already contains the same id twice.
+            defaults.set(try JSONEncoder().encode([older, older]), forKey: FoodStore.storageKey)
+            let store = FoodStore(observesExternalChanges: false, defaults: defaults, corruptBackupDirectory: backupDir)
+            #expect(store.entries.count == 2)
+
+            store.mergeWithCloudEntries([newer, makeMeal()])
+            #expect(store.entries.count == 2)
+            #expect(store.entries.first { $0.id == id }?.name == "New")
+        }
+    }
+
+    @Test func mergingByIDPreservesOrderAndLetsLaterDuplicatesWin() {
+        let a = FoodEntry(name: "A", calories: 1, protein: 0, carbs: 0, fat: 0, source: .manual)
+        let b = FoodEntry(name: "B", calories: 1, protein: 0, carbs: 0, fat: 0, source: .manual)
+        let bUpdated = FoodEntry(id: b.id, name: "B2", calories: 5, protein: 0, carbs: 0, fat: 0, source: .manual)
+        let merged = FoodStore.mergingByID([a, b, a], with: [bUpdated])
+        #expect(merged.map(\.id) == [a.id, b.id])
+        #expect(merged[1].name == "B2")
+    }
+
+    // MARK: - WeightStore
+
+    @Test func weightMergeAndImportToleratesDuplicateIDs() throws {
+        try withDefaults { defaults, backupDir in
+            let id = UUID()
+            let older = WeightEntry(id: id, date: Date(timeIntervalSince1970: 1), weightKg: 80)
+            let newer = WeightEntry(id: id, date: Date(timeIntervalSince1970: 2), weightKg: 79)
+            defaults.set(try JSONEncoder().encode([older, older]), forKey: WeightStore.storageKey)
+            let store = WeightStore(observesExternalChanges: false, defaults: defaults, corruptBackupDirectory: backupDir)
+
+            store.mergeWithCloudEntries([newer])
+            #expect(store.entries.count == 1)
+            #expect(store.entries.first?.weightKg == 79)
+
+            // HealthKit restore delivering an id we already hold must not duplicate it.
+            store.importExternalEntries([newer, WeightEntry(weightKg: 78), newer])
+            #expect(store.entries.count == 2)
+            #expect(store.entries.filter { $0.id == id }.count == 1)
+        }
+    }
+
+    @Test func corruptWeightBlobIsNotReplacedByANewEntry() throws {
+        try withDefaults { defaults, _ in
+            let garbage = Data("broken".utf8)
+            defaults.set(garbage, forKey: WeightStore.storageKey)
+            let unwritable = URL(fileURLWithPath: "/dev/null/cannot-create")
+            let store = WeightStore(observesExternalChanges: false, defaults: defaults, corruptBackupDirectory: unwritable)
+
+            #expect(store.isPersistenceBlocked)
+            store.addEntry(WeightEntry(weightKg: 70))
+            #expect(store.entries.isEmpty)
+            #expect(defaults.data(forKey: WeightStore.storageKey) == garbage)
+        }
+    }
+
+    // MARK: - DiaryImporter
+
+    @Test func replaceDateRangeImportSurvivesDuplicateExistingIDs() throws {
+        let day = Calendar.current.startOfDay(for: Date(timeIntervalSince1970: 1_800_000_000))
+        let id = UUID()
+        let existing = [
+            FoodEntry(id: id, name: "Dup 1", calories: 100, protein: 0, carbs: 0, fat: 0, timestamp: day, source: .manual),
+            FoodEntry(id: id, name: "Dup 2", calories: 120, protein: 0, carbs: 0, fat: 0, timestamp: day, source: .manual),
+        ]
+        let imported = FoodEntry(id: id, name: "Imported", calories: 150, protein: 0, carbs: 0, fat: 0, timestamp: day, source: .manual)
+        let preview = DiaryImportPreview(entries: [imported], startDate: day, endDate: day, waterEntries: [], includesWater: false)
+
+        let result = DiaryImporter.applying(preview, to: existing, mode: .replaceDateRange)
+        #expect(result.count == 1)
+        #expect(result.first?.id == id)
+        #expect(result.first?.name == "Imported")
+    }
+
+    // MARK: - Helpers
+
+    private func makeMeal() -> FoodEntry {
+        FoodEntry(
+            name: "Rice and beans", calories: 270, protein: 12, carbs: 52, fat: 2,
+            timestamp: Date(timeIntervalSince1970: 1_800_000_000),
+            source: .snapFood, mealType: .lunch
+        )
+    }
+
+    private func withDefaults(_ body: (UserDefaults, URL) throws -> Void) throws {
+        let suite = "DiaryPersistenceSafetyTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        let backupDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DiaryPersistenceSafetyTests-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            defaults.removePersistentDomain(forName: suite)
+            try? FileManager.default.removeItem(at: backupDir)
+        }
+        try body(defaults, backupDir)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Data-loss class fixes across both platforms, scoped to persistence / decode / HealthKit-restore safety.

### C3 — decode failure silently wiped the diary

**iOS** — new `PersistedBlobGuard` (`Services/PersistedBlobGuard.swift`) wraps every UserDefaults JSON blob:
- Distinguishes `.missing` / `.decoded(items, droppedElements:)` / `.corrupt`.
- Element-wise decode (`[LenientElement<T>]`) so one bad row is dropped, not the whole list.
- Corrupt or partially readable blobs are copied to `Application Support/CorruptDataBackups/<key>.corrupt-<ts>.json` before anything overwrites them. If that copy cannot be written, `save()`/`remove()` return `false` and stores refuse mutations (`isPersistenceBlocked`) — the unreadable bytes stay in place.
- Wired into `FoodStore` (entries + favorites), `WeightStore`, `WaterStore`, `FastingStore`, `StrengthWorkoutStore` (also quarantines unsupported `version`), and `UserProfile.load/save`.
- On *reload* of a corrupt blob (cloud restore / external change) the in-memory copy is kept rather than replaced with `[]`.
- `WeightStore` now accepts an injected `UserDefaults` so it is testable.

**Android**
- `Json { ignoreUnknownKeys; coerceInputValues }` so unknown enum values (e.g. a future `mealType`) fall back to the property default.
- `LenientJsonList.decode` → `PersistedListDecode.{Missing, Decoded(dropped), Corrupt}`; element-wise fallback.
- `PreferencesStore.update{Food,Weight,Water,Fasting,FavoriteFood,BodyFat,BodyMeasurement}Entries { current -> ... }` run decode + mutate + encode inside **one** `DataStore.edit`. An unreadable blob is preserved first — to `files/corrupt-backups/<key>.json.corrupt-<ts>`, or as an in-store `<key>.corrupt-<ts>` preference inside the same transaction if the file copy fails — so a write is never destructive.
- `FoodRepository` (add/update/delete/combine/replaceFromImport/favorites/`restoreFromHealthConnect`) and the weight/water/fasting/body-fat/body-measurement repositories no longer do `first() + entry` → `set(...)`.
- `setUserProfile`, `setWorkoutState`, `setOptionalNutrientGoals` back up an undecodable existing blob before replacing it.
- `foodEntriesCorrupt: Flow<Boolean>` exposed for a future banner.

### H7 — `Dictionary(uniqueKeysWithValues:)` trap on duplicate ids (iOS)
- `FoodStore.mergeWithCloudEntries` / `WeightStore.mergeWithCloudEntries` use an order-preserving newest-wins upsert (`mergingByID`).
- `DiaryImporter.applying(.replaceDateRange)` uses `uniquingKeysWith: { _, latest in latest }`.
- `WeightStore.importExternalEntries` (HealthKit backfill) skips ids already present, including duplicates inside the batch.
- Android `restoreFromHealthConnect` dedupes ids within the batch as well.

### M1 — Android DataStore corruption crash loop
- `fudaiDataStore` is now built via `PreferenceDataStoreFactory.create` with a `ReplaceFileCorruptionHandler` that copies the bad `fudai_prefs.preferences_pb` to `datastore/corrupt-backups/…corrupt-<ts>` and continues with empty preferences instead of throwing into every collector.
- `nutritionImportedKeys` and the ledger decode inside `importHealthNutrition` are wrapped in `runCatching` like their siblings.
- `FudAIApp.appScope` gets a `CoroutineExceptionHandler` so a failing startup task logs instead of crashing on every launch.

## Tests
- iOS: `calorietrackerTests/DiaryPersistenceSafetyTests.swift` — missing vs corrupt, backup file contents, write refusal when the backup cannot be written, one-bad-row drop, `FoodStore`/`WeightStore` refusing to overwrite a corrupt blob, reload keeping in-memory data, duplicate-id merges/imports not trapping, `DiaryImporter` with duplicate existing ids. (No Xcode in this environment; these were written against the existing Swift Testing conventions but not executed here — please run the `calorietracker` scheme's tests.)
- Android: `PersistedJsonGuardTest` — 11 tests covering missing/valid/corrupt/partial decode, enum coercion, and `CorruptBlobArchive` behaviour. `:app:testDebugUnitTest` passes locally.

## Review follow-ups (Greptile / CodeRabbit / Qodo)

- **`FudaiDataStore` fails closed**: if the corrupt `fudai_prefs.preferences_pb` cannot be copied aside, the corruption handler rethrows instead of returning `emptyPreferences()`, so DataStore leaves the original file in place rather than replacing the only copy of every preference. `CorruptBlobArchive.preserveFile` now picks a collision-free name and falls back to `files/corrupt-backups/` when the sibling copy fails.
- **`FastingRepository.endActive` / `update`** resolve the target, run the active/overlap checks and decide success *inside* the `updateFastingSessions` transaction against the live list (no more stale `first()` snapshot). `update` returns `false` when the session no longer exists.
- **`WeightRepository.importExternalWeights`** marks the transaction changed when `associateBy` collapses duplicate ids, so the cleanup is persisted even when every incoming value matches.
- **`PersistedBlobGuard`** remembers the bytes it last loaded/wrote and re-reads `UserDefaults` before every `save`/`remove`; a blob replaced externally since then is decode-checked with the key's type and quarantined (backed up, or the write is refused). Lenient list decoding is exposed as `decodeListLeniently` and reused by `FastingStore.persistedActiveSession`, so `FoodStore`'s fasting check can no longer disagree with `activeSession` over one bad row.
- **`StrengthWorkoutStore`**: every mutation checks `isPersistenceBlocked` *before* touching memory, exercise photos or Health callbacks; `save()` returns the guard's result and callbacks fire only after a durable write. `reloadFromDefaults` no longer clears memory before loading (a corrupt/newer blob leaves the in-memory diary intact). `clearAll` removes the blob first and aborts if refused. A newer `version` now sets a persistent write block that a successful backup does not lift.
- Tests: Android archive collision + fallback-directory cases; iOS external-change backup/refusal/no-spurious-backup, lenient `persistedActiveSession`, and workout-store block/reload/newer-schema cases (again not executed here — no Xcode).

## Notes / follow-ups
- Recovery UI (surfacing `corruptBlobBackups` / `foodEntriesCorrupt` to the user) is intentionally out of scope.
- `BodyFatStore`, `BodyMeasurementStore`, `ChatStore` on iOS still use the old `try?` pattern; they can adopt `PersistedBlobGuard` the same way.
- Did not expand into serializing HealthKit nutrition ops; the restore path already keys by id and the store-side merge now tolerates duplicates.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d6fb058-7472-4fa4-8acb-38b8fda4b712?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d6fb058-7472-4fa4-8acb-38b8fda4b712&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved protection against lost diary, weight, fasting, water, body measurement, and profile data during storage errors.
  - Corrupted or partially unreadable records are preserved for recovery, while valid records remain available.
  - Prevented crashes and duplicate-ID failures during diary imports and data synchronization.
  - Improved reliability when multiple updates occur at the same time.
  - Unknown meal types now fall back safely instead of invalidating records.
- **Reliability**
  - App startup is more resilient to unexpected background failures and damaged local data.
  - Destructive updates are blocked when corrupted data cannot be safely backed up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens persistence and restoration across iOS and Android against corrupt blobs, partially decodable lists, duplicate identifiers, concurrent updates, and DataStore corruption.
- Preserves unreadable data before replacement and blocks destructive writes when preservation fails.
- Moves Android list mutations into atomic DataStore edits.
- Replaces duplicate-ID traps with deterministic deduplication and merge behavior.
- Makes iOS workout mutations transactional in memory, rolling them back when persistence fails.
- Adds focused persistence, corruption, concurrency, and duplicate-ID tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the persistence and transaction fixes address the previously reported data-loss and stale-state failures without introducing a new actionable defect.

The corrupt DataStore backup now rethrows when preservation fails, fasting validation executes against transaction-local state, and workout mutations roll back when their durable write is refused. The three previous threads were manually resolved without explanatory replies, and the current code fully addresses their reported behavior.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| ios/calorietracker/Services/PersistedBlobGuard.swift | Revalidates externally changed or previously unobserved blobs before save/remove and fails closed when preservation is unavailable. |
| ios/calorietracker/Stores/StrengthWorkoutStore.swift | Wraps persisted mutations in snapshot-and-rollback commits and defers callbacks and cleanup until writes succeed. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/data/PreferencesStore.kt | Centralizes lenient decoding, corrupt-blob preservation, and atomic list updates within DataStore transactions. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FudaiDataStore.kt | Adds corruption recovery that preserves the damaged preferences file and rethrows when preservation fails. |
| android/app/src/main/java/com/apoorvdarshan/calorietracker/data/FastingRepository.kt | Performs fasting lookup, invariant checks, mutation, and success determination against transactional current state. |
| ios/calorietrackerTests/DiaryPersistenceSafetyTests.swift | Covers first-write preservation, failed-save rollback, corrupt reloads, unsupported schemas, lenient decoding, and duplicate IDs. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Read persisted blob] --> B{Decode result}
  B -->|Missing| C[Use empty initial state]
  B -->|Fully decoded| D[Use decoded state]
  B -->|Partially decoded| E[Preserve original bytes]
  B -->|Corrupt| E
  E --> F{Backup succeeded?}
  F -->|Yes| G[Allow guarded mutation]
  F -->|No| H[Block mutation and retain original]
  C --> G
  D --> G
  G --> I[Persist updated state atomically]
  I --> J[Run Health and cleanup side effects]
```

<sub>Reviews (3): Last reviewed commit: ["iOS tests: cover first-write guard inspe..."](https://github.com/apoorvdarshan/fud-ai/commit/dd831d650bd645cda92cf896fe10f3f2b6754668) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63535576)</sub>

<!-- /greptile_comment -->